### PR TITLE
added ticket to eventbus bridge messages

### DIFF
--- a/src/client/vertxbus.js
+++ b/src/client/vertxbus.js
@@ -53,8 +53,10 @@ var vertx = vertx || {};
     var state = vertx.EventBus.CONNECTING;
     var pingTimerID = null;
     var pingInterval = null;
+    var ticket = null;
     if (options) {
       pingInterval = options['vertxbus_ping_interval'];
+      ticket = options['ticket'];
     }
     if (!pingInterval) {
       pingInterval = 5000;
@@ -135,6 +137,9 @@ var vertx = vertx || {};
           type: 'register',
           address: address
         };
+        if ( ticket != null ) {
+            msg['ticket'] = ticket;
+        }
         sockJSConn.send(JSON.stringify(msg));
       } else {
         handlers[handlers.length] = handler;
@@ -156,6 +161,10 @@ var vertx = vertx || {};
             type: 'unregister',
             address: address
           };
+          if ( ticket != null ) {
+            msg['ticket'] = ticket;
+          }
+
           sockJSConn.send(JSON.stringify(msg));
           delete handlerMap[address];
         }
@@ -257,6 +266,9 @@ var vertx = vertx || {};
         address: address,
         body: message
       };
+      if ( ticket != null ) {
+        envelope['ticket'] = ticket;
+      }
 
       if (headers) {
         envelope.headers = headers;


### PR DESCRIPTION
For identifying or authorization of clients using the javascript eventbus bridge i added a __ticket__ to the json message. The ticket is set via the options map in the eventbus constructor and send to the server with every send/publish/register or unregister message. The ticket can used as session id, auth token, ....
To see it in action i setup a small project: https://github.com/sibay/ebb-ticket-showcase

Are there any tests for vertxbus.js?