### PR TITLE
Do not crash and leave requests pending when invalid characters are i…

### DIFF
--- a/src/main/generated/io/vertx/rxjava/ext/web/Route.java
+++ b/src/main/generated/io/vertx/rxjava/ext/web/Route.java
@@ -154,7 +154,7 @@ public class Route {
    * concurrently but always in the order they were called. The default value of ordered is true. If you do not want this
    * behaviour and don't mind if your blocking handlers are executed in parallel you can set ordered to false.
    * @param requestHandler the blocking request handler
-   * @param ordered 
+   * @param ordered if true handlers are executed in sequence, otherwise are run in parallel
    * @return a reference to this, so the API can be used fluently
    */
   public Route blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered) { 

--- a/src/main/groovy/io/vertx/groovy/ext/web/Route.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/web/Route.groovy
@@ -136,7 +136,7 @@ public class Route {
    * concurrently but always in the order they were called. The default value of ordered is true. If you do not want this
    * behaviour and don't mind if your blocking handlers are executed in parallel you can set ordered to false.
    * @param requestHandler the blocking request handler
-   * @param ordered 
+   * @param ordered if true handlers are executed in sequence, otherwise are run in parallel
    * @return a reference to this, so the API can be used fluently
    */
   public Route blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered) {

--- a/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
@@ -239,7 +239,7 @@ public class RoutingContext {
     return ret;
   }
   /**
-   * @return Get the entire HTTP request body as a {@link io.vertx.core.json.JsonObject}. The context must have first been routed to a
+   * @return Get the entire HTTP request body as a {@link io.vertx.groovy.core.json.JsonObject}. The context must have first been routed to a
    * {@link io.vertx.groovy.ext.web.handler.BodyHandler} for this to be populated.
    * @return 
    */

--- a/src/main/groovy/io/vertx/groovy/ext/web/handler/sockjs/BridgeEvent.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/web/handler/sockjs/BridgeEvent.groovy
@@ -73,7 +73,7 @@ public class BridgeEvent extends Future<Boolean> {
     cached_2 = ret;
     return ret;
   }
-  private io.vertx.ext.web.handler.sockjs.BridgeEventType cached_0;
+  private BridgeEventType cached_0;
   private Map<String, Object> cached_1;
   private SockJSSocket cached_2;
 }

--- a/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.impl;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -106,7 +107,14 @@ public abstract class RoutingContextImplBase implements RoutingContext {
       }
     }
     if (!response().ended()) {
-      response().setStatusCode(code);
+      try {
+        response().setStatusCode(code);
+      } catch (IllegalArgumentException e) {
+        // means that there are invalid chars in the status message
+        response()
+            .setStatusMessage(HttpResponseStatus.valueOf(code).reasonPhrase())
+            .setStatusCode(code);
+      }
       response().end(response().getStatusMessage());
     }
   }

--- a/src/main/java/io/vertx/ext/web/package-info.java
+++ b/src/main/java/io/vertx/ext/web/package-info.java
@@ -592,6 +592,11 @@
  * {@link examples.Examples#example26}
  * ----
  *
+ * For the eventuality that an error occurs when running the error handler related usage of not allowed characters in
+ * status message header, then the original status message will be changed to the default message from the error code.
+ * This is a tradeoff to keep the semantics of the HTTP protocol working instead of abruptly creash and close the socket
+ * without properly completing the protocol.
+ *
  * == Request body handling
  *
  * The {@link io.vertx.ext.web.handler.BodyHandler} allows you to retrieve request bodies, limit body sizes and handle

--- a/src/main/resources/vertx-web-js/route.js
+++ b/src/main/resources/vertx-web-js/route.js
@@ -171,7 +171,7 @@ var Route = function(j_val) {
 
    @public
    @param requestHandler {function} the blocking request handler 
-   @param ordered {boolean} 
+   @param ordered {boolean} if true handlers are executed in sequence, otherwise are run in parallel 
    @return {Route} a reference to this, so the API can be used fluently
    */
   this.blockingHandler = function() {

--- a/src/main/resources/vertx-web/route.rb
+++ b/src/main/resources/vertx-web/route.rb
@@ -107,7 +107,7 @@ module VertxWeb
     #  concurrently but always in the order they were called. The default value of ordered is true. If you do not want this
     #  behaviour and don't mind if your blocking handlers are executed in parallel you can set ordered to false.
     # @param [Proc] requestHandler the blocking request handler
-    # @param [true,false] ordered 
+    # @param [true,false] ordered if true handlers are executed in sequence, otherwise are run in parallel
     # @return [self]
     def blocking_handler(requestHandler=nil,ordered=nil)
       if block_given? && requestHandler == nil && ordered == nil

--- a/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -527,6 +527,26 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testFailureUsingInvalidCharsInStatus() throws Exception {
+    String path = "/blah";
+    router.route(path).handler(rc -> {
+      rc.response().setStatusMessage("Hello\nWorld!").end();
+    });
+    testRequest(HttpMethod.GET, path, 500, "Internal Server Error");
+  }
+
+  @Test
+  public void testFailureinHandlingFailureWithInvalidStatusMessage() throws Exception {
+    String path = "/blah";
+    router.route(path).handler(rc -> {
+      throw new RuntimeException("ouch!");
+    }).failureHandler(frc -> {
+      frc.response().setStatusMessage("Hello\nWorld").end();
+    });
+    testRequest(HttpMethod.GET, path, 500, "Internal Server Error");
+  }
+
+  @Test
   public void testSetExceptionHandler() throws Exception {
     String path = "/blah";
     router.route(path).handler(rc -> {


### PR DESCRIPTION
…n the response status message.

This solves #181 

However is a user sets a bad status response no escape will be done since the HTTP spec does not specify any escape mechanism and both servers and clients must agree on that. For this reason a user is required to implement the required escape sequence.