### PR TITLE
restore the old vertxbus.js to comply with the old API, new users sho…

### DIFF
--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -87,7 +87,7 @@
             <configuration>
               <artifacts>
                 <artifact>
-                  <file>${basedir}/src/client/vertxbus.js</file>
+                  <file>${basedir}/src/client/vertx3bus.js</file>
                   <classifier>client</classifier>
                   <type>js</type>
                 </artifact>

--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -87,7 +87,7 @@
             <configuration>
               <artifacts>
                 <artifact>
-                  <file>${basedir}/src/client/vertx3bus.js</file>
+                  <file>${basedir}/src/client/vertx-eventbus.js</file>
                   <classifier>client</classifier>
                   <type>js</type>
                 </artifact>

--- a/vertx-web/src/client/vertx-eventbus.js
+++ b/vertx-web/src/client/vertx-eventbus.js
@@ -18,7 +18,7 @@
     // CommonJS loader
     var SockJS = require('sockjs-client');
     if(!SockJS) {
-      throw new Error('vertx3bus.js requires sockjs-client, see http://sockjs.org');
+      throw new Error('vertx-eventbus.js requires sockjs-client, see http://sockjs.org');
     }
     factory(SockJS);
   } else if (typeof define === 'function' && define.amd) {
@@ -27,7 +27,7 @@
   } else {
     // plain old include
     if (typeof this.SockJS === 'undefined') {
-      throw new Error('vertx3bus.js requires sockjs-client, see http://sockjs.org');
+      throw new Error('vertx-eventbus.js requires sockjs-client, see http://sockjs.org');
     }
 
     EventBus = factory(this.SockJS);

--- a/vertx-web/src/client/vertx3bus.js
+++ b/vertx-web/src/client/vertx3bus.js
@@ -1,0 +1,296 @@
+/*
+ *   Copyright (c) 2011-2015 The original author or authors
+ *   ------------------------------------------------------
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+!function (factory) {
+  if (typeof require === 'function' && typeof module !== 'undefined') {
+    // CommonJS loader
+    var SockJS = require('sockjs-client');
+    if(!SockJS) {
+      throw new Error('vertx3bus.js requires sockjs-client, see http://sockjs.org');
+    }
+    factory(SockJS);
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD loader
+    define('vertx3bus', ['sockjs'], factory);
+  } else {
+    // plain old include
+    if (typeof this.SockJS === 'undefined') {
+      throw new Error('vertx3bus.js requires sockjs-client, see http://sockjs.org');
+    }
+
+    EventBus = factory(this.SockJS);
+  }
+}(function (SockJS) {
+
+  function makeUUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (a, b) {
+      return b = Math.random() * 16, (a == 'y' ? b & 3 | 8 : b | 0).toString(16);
+    });
+  }
+
+  function mergeHeaders(defaultHeaders, headers) {
+    if (defaultHeaders) {
+      if(!headers) {
+        return defaultHeaders;
+      }
+
+      for (var headerName in defaultHeaders) {
+        if (defaultHeaders.hasOwnProperty(headerName)) {
+          // user can overwrite the default headers
+          if (typeof headers[headerName] === 'undefined') {
+            headers[headerName] = defaultHeaders[headerName];
+          }
+        }
+      }
+    }
+
+    // headers are required to be a object
+    return headers || {};
+  }
+
+  /**
+   * EventBus
+   *
+   * @param url
+   * @param options
+   * @constructor
+   */
+  var EventBus = function (url, options) {
+    var self = this;
+
+    options = options || {};
+
+    var pingInterval = options.vertxbus_ping_interval || 5000;
+    var pingTimerID;
+
+    // attributes
+    this.sockJSConn = new SockJS(url, null, options);
+    this.state = EventBus.CONNECTING;
+    this.handlers = {};
+    this.replyHandlers = {};
+    this.defaultHeaders = null;
+
+    // default event handlers
+    this.onerror = console.error;
+
+    var sendPing = function () {
+      self.sockJSConn.send(JSON.stringify({type: 'ping'}));
+    };
+
+    this.sockJSConn.onopen = function () {
+      // Send the first ping then send a ping every pingInterval milliseconds
+      sendPing();
+      pingTimerID = setInterval(sendPing, pingInterval);
+      self.state = EventBus.OPEN;
+      self.onopen && self.onopen();
+    };
+
+    this.sockJSConn.onclose = function () {
+      self.state = EventBus.CLOSED;
+      if (pingTimerID) clearInterval(pingTimerID);
+      self.onclose && self.onclose();
+    };
+
+    this.sockJSConn.onmessage = function (e) {
+      var json = JSON.parse(e.data);
+
+      // define a reply function on the message itself
+      if (json.replyAddress) {
+        Object.defineProperty(json, 'reply', {
+          value: function (message, headers, callback) {
+            self.send(json.replyAddress, message, headers, callback);
+          }
+        });
+      }
+
+      if (self.handlers[json.address]) {
+        // iterate all registered handlers
+        var handlers = self.handlers[json.address];
+        for (var i = 0; i < handlers.length; i++) {
+          if (json.type === 'err') {
+            handlers[i]({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
+          } else {
+            handlers[i](null, json);
+          }
+        }
+      } else if (self.replyHandlers[json.address]) {
+        // Might be a reply message
+        var handler = self.replyHandlers[json.address];
+        delete self.replyHandlers[json.address];
+        if (json.type === 'err') {
+          handler({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
+        } else {
+          handler(null, json);
+        }
+      } else {
+        if (json.type === 'err') {
+          self.onerror(json);
+        } else {
+          console.warn('No handler found for message: ', json);
+        }
+      }
+    }
+  };
+
+  /**
+   * Send a message
+   *
+   * @param {String} address
+   * @param {Object} message
+   * @param {Object} [headers]
+   * @param {Function} [callback]
+   */
+  EventBus.prototype.send = function (address, message, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    if (typeof headers === 'function') {
+      callback = headers;
+      headers = {};
+    }
+
+    var envelope = {
+      type: 'send',
+      address: address,
+      headers: mergeHeaders(this.defaultHeaders, headers),
+      body: message
+    };
+
+    if (callback) {
+      var replyAddress = makeUUID();
+      envelope.replyAddress = replyAddress;
+      this.replyHandlers[replyAddress] = callback;
+    }
+
+    this.sockJSConn.send(JSON.stringify(envelope));
+  };
+
+  /**
+   * Publish a message
+   *
+   * @param {String} address
+   * @param {Object} message
+   * @param {Object} [headers]
+   */
+  EventBus.prototype.publish = function (address, message, headers) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    this.sockJSConn.send(JSON.stringify({
+      type: 'publish',
+      address: address,
+      headers: mergeHeaders(this.defaultHeaders, headers),
+      body: message
+    }));
+  };
+
+  /**
+   * Register a new handler
+   *
+   * @param {String} address
+   * @param {Object} [headers]
+   * @param {Function} callback
+   */
+  EventBus.prototype.registerHandler = function (address, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    if (typeof headers === 'function') {
+      callback = headers;
+      headers = {};
+    }
+
+    // ensure it is an array
+    if (!this.handlers[address]) {
+      this.handlers[address] = [];
+      // First handler for this address so we should register the connection
+      this.sockJSConn.send(JSON.stringify({
+        type: 'register',
+        address: address,
+        headers: mergeHeaders(this.defaultHeaders, headers)
+      }));
+    }
+
+    this.handlers[address].push(callback);
+  };
+
+  /**
+   * Unregister a handler
+   *
+   * @param {String} address
+   * @param {Object} [headers]
+   * @param {Function} callback
+   */
+  EventBus.prototype.unregisterHandler = function (address, headers, callback) {
+    // are we ready?
+    if (this.state != EventBus.OPEN) {
+      throw new Error('INVALID_STATE_ERR');
+    }
+
+    var handlers = this.handlers[address];
+
+    if (handlers) {
+
+      if (typeof headers === 'function') {
+        callback = headers;
+        headers = {};
+      }
+
+      var idx = handlers.indexOf(callback);
+      if (idx != -1) {
+        handlers.splice(idx, 1);
+        if (handlers.length === 0) {
+          // No more local handlers so we should unregister the connection
+          this.sockJSConn.send(JSON.stringify({
+            type: 'unregister',
+            address: address,
+            headers: mergeHeaders(this.defaultHeaders, headers)
+          }));
+
+          delete this.handlers[address];
+        }
+      }
+    }
+  };
+
+  /**
+   * Closes the connection to the EvenBus Bridge.
+   */
+  EventBus.prototype.close = function () {
+    this.state = vertx.EventBus.CLOSING;
+    this.sockJSConn.close();
+  };
+
+  EventBus.CONNECTING = 0;
+  EventBus.OPEN = 1;
+  EventBus.CLOSING = 2;
+  EventBus.CLOSED = 3;
+
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = EventBus;
+    } else {
+      exports.EventBus = EventBus;
+    }
+  } else {
+    return EventBus;
+  }
+});

--- a/vertx-web/src/client/vertxbus.js
+++ b/vertx-web/src/client/vertxbus.js
@@ -1,296 +1,222 @@
 /*
- *   Copyright (c) 2011-2015 The original author or authors
- *   ------------------------------------------------------
- *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
- *   and Apache License v2.0 which accompanies this distribution.
+ * Copyright 2014 Red Hat, Inc.
  *
- *       The Eclipse Public License is available at
- *       http://www.eclipse.org/legal/epl-v10.html
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
  *
- *       The Apache License v2.0 is available at
- *       http://www.opensource.org/licenses/apache2.0.php
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
  *
- *   You may elect to redistribute this code under either of these licenses.
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
  */
-!function (factory) {
-  if (typeof require === 'function' && typeof module !== 'undefined') {
-    // CommonJS loader
-    var SockJS = require('sockjs-client');
-    if(!SockJS) {
-      throw new Error('vertxbus.js requires sockjs-client, see http://sockjs.org');
-    }
-    factory(SockJS);
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD loader
-    define('vertxbus', ['sockjs'], factory);
+
+/** @deprecated */
+var vertx = vertx || {};
+
+!function(factory) {
+  if (typeof define === "function" && define.amd) {
+    // Expose as an AMD module with SockJS dependency.
+    // "vertxbus" and "sockjs" names are used because
+    // AMD module names are derived from file names.
+    define("vertxbus", ["sockjs"], factory);
   } else {
-    // plain old include
-    if (typeof this.SockJS === 'undefined') {
-      throw new Error('vertxbus.js requires sockjs-client, see http://sockjs.org');
+    // No AMD-compliant loader
+    factory(SockJS);
+  }
+}(function(SockJS) {
+
+  /** @deprecated */
+  vertx.EventBus = function(url, options) {
+
+    var that = this;
+    var sockJSConn = new SockJS(url, undefined, options);
+    var handlerMap = {};
+    var replyHandlers = {};
+    var state = vertx.EventBus.CONNECTING;
+    var pingTimerID = null;
+    var pingInterval = null;
+    if (options) {
+      pingInterval = options['vertxbus_ping_interval'];
+    }
+    if (!pingInterval) {
+      pingInterval = 5000;
     }
 
-    EventBus = factory(this.SockJS);
-  }
-}(function (SockJS) {
+    /** @deprecated */
+    that.onopen = null;
+    /** @deprecated */
+    that.onclose = null;
 
-  function makeUUID() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (a, b) {
-      return b = Math.random() * 16, (a == 'y' ? b & 3 | 8 : b | 0).toString(16);
-    });
-  }
+    /** @deprecated */
+    that.send = function(address, message, replyHandler) {
+      sendOrPub("send", address, message, replyHandler)
+    }
 
-  function mergeHeaders(defaultHeaders, headers) {
-    if (defaultHeaders) {
-      if(!headers) {
-        return defaultHeaders;
+    /** @deprecated */
+    that.publish = function(address, message) {
+      sendOrPub("publish", address, message, null)
+    }
+
+    /** @deprecated */
+    that.registerHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (!handlers) {
+        handlers = [handler];
+        handlerMap[address] = handlers;
+        // First handler for this address so we should register the connection
+        var msg = { type : "register",
+          address: address };
+        sockJSConn.send(JSON.stringify(msg));
+      } else {
+        handlers[handlers.length] = handler;
       }
+    }
 
-      for (var headerName in defaultHeaders) {
-        if (defaultHeaders.hasOwnProperty(headerName)) {
-          // user can overwrite the default headers
-          if (typeof headers[headerName] === 'undefined') {
-            headers[headerName] = defaultHeaders[headerName];
-          }
+    /** @deprecated */
+    that.unregisterHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (handlers) {
+        var idx = handlers.indexOf(handler);
+        if (idx != -1) handlers.splice(idx, 1);
+        if (handlers.length == 0) {
+          // No more local handlers so we should unregister the connection
+
+          var msg = { type : "unregister",
+            address: address};
+          sockJSConn.send(JSON.stringify(msg));
+          delete handlerMap[address];
         }
       }
     }
 
-    // headers are required to be a object
-    return headers || {};
-  }
+    /** @deprecated */
+    that.close = function() {
+      checkOpen();
+      state = vertx.EventBus.CLOSING;
+      sockJSConn.close();
+    }
 
-  /**
-   * EventBus
-   *
-   * @param url
-   * @param options
-   * @constructor
-   */
-  var EventBus = function (url, options) {
-    var self = this;
+    /** @deprecated */
+    that.readyState = function() {
+      return state;
+    }
 
-    options = options || {};
-
-    var pingInterval = options.vertxbus_ping_interval || 5000;
-    var pingTimerID;
-
-    // attributes
-    this.sockJSConn = new SockJS(url, null, options);
-    this.state = EventBus.CONNECTING;
-    this.handlers = {};
-    this.replyHandlers = {};
-    this.defaultHeaders = null;
-
-    // default event handlers
-    this.onerror = console.error;
-
-    var sendPing = function () {
-      self.sockJSConn.send(JSON.stringify({type: 'ping'}));
-    };
-
-    this.sockJSConn.onopen = function () {
+    sockJSConn.onopen = function() {
       // Send the first ping then send a ping every pingInterval milliseconds
       sendPing();
       pingTimerID = setInterval(sendPing, pingInterval);
-      self.state = EventBus.OPEN;
-      self.onopen && self.onopen();
-    };
-
-    this.sockJSConn.onclose = function () {
-      self.state = EventBus.CLOSED;
-      if (pingTimerID) clearInterval(pingTimerID);
-      self.onclose && self.onclose();
-    };
-
-    this.sockJSConn.onmessage = function (e) {
-      var json = JSON.parse(e.data);
-
-      // define a reply function on the message itself
-      if (json.replyAddress) {
-        Object.defineProperty(json, 'reply', {
-          value: function (message, headers, callback) {
-            self.send(json.replyAddress, message, headers, callback);
-          }
-        });
+      state = vertx.EventBus.OPEN;
+      if (that.onopen) {
+        that.onopen();
       }
+    };
 
-      if (self.handlers[json.address]) {
-        // iterate all registered handlers
-        var handlers = self.handlers[json.address];
-        for (var i = 0; i < handlers.length; i++) {
-          if (json.type === 'err') {
-            handlers[i]({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
-          } else {
-            handlers[i](null, json);
-          }
-        }
-      } else if (self.replyHandlers[json.address]) {
-        // Might be a reply message
-        var handler = self.replyHandlers[json.address];
-        delete self.replyHandlers[json.address];
-        if (json.type === 'err') {
-          handler({failureCode: json.failureCode, failureType: json.failureType, message: json.message});
-        } else {
-          handler(null, json);
+    sockJSConn.onclose = function() {
+      state = vertx.EventBus.CLOSED;
+      if (pingTimerID) clearInterval(pingTimerID);
+      if (that.onclose) {
+        that.onclose();
+      }
+    };
+
+    sockJSConn.onmessage = function(e) {
+      var msg = e.data;
+      var json = JSON.parse(msg);
+      var type = json.type;
+      if (type === 'err') {
+        console.error("Error received on connection: " + json.body);
+        return;
+      }
+      var body = json.body;
+      var replyAddress = json.replyAddress;
+      var address = json.address;
+      var replyHandler;
+      if (replyAddress) {
+        replyHandler = function(reply, replyHandler) {
+          // Send back reply
+          that.send(replyAddress, reply, replyHandler);
+        };
+      }
+      var handlers = handlerMap[address];
+      if (handlers) {
+        // We make a copy since the handler might get unregistered from within the
+        // handler itself, which would screw up our iteration
+        var copy = handlers.slice(0);
+        for (var i  = 0; i < copy.length; i++) {
+          copy[i](body, replyHandler);
         }
       } else {
-        if (json.type === 'err') {
-          self.onerror(json);
-        } else {
-          console.warn('No handler found for message: ', json);
+        // Might be a reply message
+        var handler = replyHandlers[address];
+        if (handler) {
+          delete replyHandlers[address];
+          handler(body, replyHandler);
         }
       }
     }
-  };
 
-  /**
-   * Send a message
-   *
-   * @param {String} address
-   * @param {Object} message
-   * @param {Object} [headers]
-   * @param {Function} [callback]
-   */
-  EventBus.prototype.send = function (address, message, headers, callback) {
-    // are we ready?
-    if (this.state != EventBus.OPEN) {
-      throw new Error('INVALID_STATE_ERR');
+    function sendPing() {
+      var msg = {
+        type: "ping"
+      }
+      sockJSConn.send(JSON.stringify(msg));
     }
 
-    if (typeof headers === 'function') {
-      callback = headers;
-      headers = {};
-    }
-
-    var envelope = {
-      type: 'send',
-      address: address,
-      headers: mergeHeaders(this.defaultHeaders, headers),
-      body: message
-    };
-
-    if (callback) {
-      var replyAddress = makeUUID();
-      envelope.replyAddress = replyAddress;
-      this.replyHandlers[replyAddress] = callback;
-    }
-
-    this.sockJSConn.send(JSON.stringify(envelope));
-  };
-
-  /**
-   * Publish a message
-   *
-   * @param {String} address
-   * @param {Object} message
-   * @param {Object} [headers]
-   */
-  EventBus.prototype.publish = function (address, message, headers) {
-    // are we ready?
-    if (this.state != EventBus.OPEN) {
-      throw new Error('INVALID_STATE_ERR');
-    }
-
-    this.sockJSConn.send(JSON.stringify({
-      type: 'publish',
-      address: address,
-      headers: mergeHeaders(this.defaultHeaders, headers),
-      body: message
-    }));
-  };
-
-  /**
-   * Register a new handler
-   *
-   * @param {String} address
-   * @param {Object} [headers]
-   * @param {Function} callback
-   */
-  EventBus.prototype.registerHandler = function (address, headers, callback) {
-    // are we ready?
-    if (this.state != EventBus.OPEN) {
-      throw new Error('INVALID_STATE_ERR');
-    }
-
-    if (typeof headers === 'function') {
-      callback = headers;
-      headers = {};
-    }
-
-    // ensure it is an array
-    if (!this.handlers[address]) {
-      this.handlers[address] = [];
-      // First handler for this address so we should register the connection
-      this.sockJSConn.send(JSON.stringify({
-        type: 'register',
+    function sendOrPub(sendOrPub, address, message, replyHandler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("replyHandler", 'function', replyHandler, true);
+      checkOpen();
+      var envelope = { type : sendOrPub,
         address: address,
-        headers: mergeHeaders(this.defaultHeaders, headers)
-      }));
-    }
-
-    this.handlers[address].push(callback);
-  };
-
-  /**
-   * Unregister a handler
-   *
-   * @param {String} address
-   * @param {Object} [headers]
-   * @param {Function} callback
-   */
-  EventBus.prototype.unregisterHandler = function (address, headers, callback) {
-    // are we ready?
-    if (this.state != EventBus.OPEN) {
-      throw new Error('INVALID_STATE_ERR');
-    }
-
-    var handlers = this.handlers[address];
-
-    if (handlers) {
-
-      if (typeof headers === 'function') {
-        callback = headers;
-        headers = {};
+        body: message };
+      if (replyHandler) {
+        var replyAddress = makeUUID();
+        envelope.replyAddress = replyAddress;
+        replyHandlers[replyAddress] = replyHandler;
       }
+      var str = JSON.stringify(envelope);
+      sockJSConn.send(str);
+    }
 
-      var idx = handlers.indexOf(callback);
-      if (idx != -1) {
-        handlers.splice(idx, 1);
-        if (handlers.length === 0) {
-          // No more local handlers so we should unregister the connection
-          this.sockJSConn.send(JSON.stringify({
-            type: 'unregister',
-            address: address,
-            headers: mergeHeaders(this.defaultHeaders, headers)
-          }));
-
-          delete this.handlers[address];
-        }
+    function checkOpen() {
+      if (state != vertx.EventBus.OPEN) {
+        throw new Error('INVALID_STATE_ERR');
       }
     }
-  };
 
-  /**
-   * Closes the connection to the EvenBus Bridge.
-   */
-  EventBus.prototype.close = function () {
-    this.state = vertx.EventBus.CLOSING;
-    this.sockJSConn.close();
-  };
-
-  EventBus.CONNECTING = 0;
-  EventBus.OPEN = 1;
-  EventBus.CLOSING = 2;
-  EventBus.CLOSED = 3;
-
-  if (typeof exports !== 'undefined') {
-    if (typeof module !== 'undefined' && module.exports) {
-      exports = module.exports = EventBus;
-    } else {
-      exports.EventBus = EventBus;
+    function checkSpecified(paramName, paramType, param, optional) {
+      if (!optional && !param) {
+        throw new Error("Parameter " + paramName + " must be specified");
+      }
+      if (param && typeof param != paramType) {
+        throw new Error("Parameter " + paramName + " must be of type " + paramType);
+      }
     }
-  } else {
-    return EventBus;
+
+    function isFunction(obj) {
+      return !!(obj && obj.constructor && obj.call && obj.apply);
+    }
+
+    function makeUUID(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+      .replace(/[xy]/g,function(a,b){return b=Math.random()*16,(a=="y"?b&3|8:b|0).toString(16)})}
+
   }
+
+  vertx.EventBus.CONNECTING = 0;
+  vertx.EventBus.OPEN = 1;
+  vertx.EventBus.CLOSING = 2;
+  vertx.EventBus.CLOSED = 3;
+
+  return vertx.EventBus;
+
 });

--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2207,7 +2207,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertxbus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2236,12 +2236,12 @@ router.route("/eventbus/*").handler(sockJSHandler)
 
 ----
 
-In client side JavaScript you use the 'vertxbus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertxbus.js'></script>
+<script src='vertx3bus.js'></script>
 
 <script>
 

--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2207,7 +2207,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx-eventbus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2236,16 +2236,16 @@ router.route("/eventbus/*").handler(sockJSHandler)
 
 ----
 
-In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertx3bus.js'></script>
+<script src='vertx-eventbus.js'></script>
 
 <script>
 
-var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+var eb = new EventBus('http://localhost:8080/eventbus');
 
 eb.onopen = function() {
 
@@ -2264,7 +2264,7 @@ eb.onopen = function() {
 
 The first thing the example does is to create a instance of the event bus
 
- var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ var eb = new EventBus('http://localhost:8080/eventbus');
 
 The parameter to the constructor is the URI where to connect to the event bus. Since we create our bridge with
 the prefix `eventbus` we will connect there.

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1993,7 +1993,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertxbus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2018,12 +2018,12 @@ sockJSHandler.bridge(options);
 router.route("/eventbus/*").handler(sockJSHandler);
 ----
 
-In client side JavaScript you use the 'vertxbus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertxbus.js'></script>
+<script src='vertx3bus.js'></script>
 
 <script>
 

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1993,7 +1993,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx-eventbus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2018,16 +2018,16 @@ sockJSHandler.bridge(options);
 router.route("/eventbus/*").handler(sockJSHandler);
 ----
 
-In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertx3bus.js'></script>
+<script src='vertx-eventbus.js'></script>
 
 <script>
 
-var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+var eb = new EventBus('http://localhost:8080/eventbus');
 
 eb.onopen = function() {
 
@@ -2046,7 +2046,7 @@ eb.onopen = function() {
 
 The first thing the example does is to create a instance of the event bus
 
- var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ var eb = new EventBus('http://localhost:8080/eventbus');
 
 The parameter to the constructor is the URI where to connect to the event bus. Since we create our bridge with
 the prefix `eventbus` we will connect there.

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2203,7 +2203,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx-eventbus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2233,16 +2233,16 @@ router.route("/eventbus/*").handler(sockJSHandler.handle);
 
 ----
 
-In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertx3bus.js'></script>
+<script src='vertx-eventbus.js'></script>
 
 <script>
 
-var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+var eb = new EventBus('http://localhost:8080/eventbus');
 
 eb.onopen = function() {
 
@@ -2261,7 +2261,7 @@ eb.onopen = function() {
 
 The first thing the example does is to create a instance of the event bus
 
- var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ var eb = new EventBus('http://localhost:8080/eventbus');
 
 The parameter to the constructor is the URI where to connect to the event bus. Since we create our bridge with
 the prefix `eventbus` we will connect there.

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2203,7 +2203,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertxbus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2233,12 +2233,12 @@ router.route("/eventbus/*").handler(sockJSHandler.handle);
 
 ----
 
-In client side JavaScript you use the 'vertxbus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertxbus.js'></script>
+<script src='vertx3bus.js'></script>
 
 <script>
 

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -2203,7 +2203,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx-eventbus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2233,16 +2233,16 @@ router.route("/eventbus/*").handler(&sockJSHandler.method(:handle))
 
 ----
 
-In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertx3bus.js'></script>
+<script src='vertx-eventbus.js'></script>
 
 <script>
 
-var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+var eb = new EventBus('http://localhost:8080/eventbus');
 
 eb.onopen = function() {
 
@@ -2261,7 +2261,7 @@ eb.onopen = function() {
 
 The first thing the example does is to create a instance of the event bus
 
- var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ var eb = new EventBus('http://localhost:8080/eventbus');
 
 The parameter to the constructor is the URI where to connect to the event bus. Since we create our bridge with
 the prefix `eventbus` we will connect there.

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -2203,7 +2203,7 @@ client side JavaScript running in browsers.
 We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
 be connected to the same server as long as the servers are connected.
 
-This is done by providing a simple client side JavaScript library called `vertxbus.js` which provides an API
+This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
 very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
 and register handlers to receive messages.
 
@@ -2233,12 +2233,12 @@ router.route("/eventbus/*").handler(&sockJSHandler.method(:handle))
 
 ----
 
-In client side JavaScript you use the 'vertxbus.js` library to create connections to the event bus and to send
+In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
 and receive messages:
 
 ----
 <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
-<script src='vertxbus.js'></script>
+<script src='vertx3bus.js'></script>
 
 <script>
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -336,7 +336,7 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
     String replyAddress = message.getString("replyAddress");
     // Sanity check reply address is not too big, to avoid DoS
     if (replyAddress != null && replyAddress.length() > 36) {
-      // vertx3bus.js ids are always 36 chars
+      // vertx-eventbus.js ids are always 36 chars
       log.error("Will not send message, reply address is > 36 chars");
       replyError(sock, "invalid_reply_address");
       return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -336,7 +336,7 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
     String replyAddress = message.getString("replyAddress");
     // Sanity check reply address is not too big, to avoid DoS
     if (replyAddress != null && replyAddress.length() > 36) {
-      // vertxbus.js ids are always 36 chars
+      // vertx3bus.js ids are always 36 chars
       log.error("Will not send message, reply address is > 36 chars");
       replyError(sock, "invalid_reply_address");
       return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1478,7 +1478,7 @@
  *
  * <script>
  *
- * var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ * var eb = new EventBus('http://localhost:8080/eventbus');
  *
  * eb.onopen = function() {
  *
@@ -1497,7 +1497,7 @@
  *
  * The first thing the example does is to create a instance of the event bus
  *
- *  var eb = new vertx.EventBus('http://localhost:8080/eventbus');
+ *  var eb = new EventBus('http://localhost:8080/eventbus');
  *
  * The parameter to the constructor is the URI where to connect to the event bus. Since we create our bridge with
  * the prefix `eventbus` we will connect there.

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1450,7 +1450,7 @@
  * We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
  * be connected to the same server as long as the servers are connected.
  *
- * This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
+ * This is done by providing a simple client side JavaScript library called `vertx-eventbus.js` which provides an API
  * very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
  * and register handlers to receive messages.
  *
@@ -1469,12 +1469,12 @@
  * {@link examples.Examples#example45}
  * ----
  *
- * In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
+ * In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send
  * and receive messages:
  *
  * ----
  * <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
- * <script src='vertx3bus.js'></script>
+ * <script src='vertx-eventbus.js'></script>
  *
  * <script>
  *

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1450,7 +1450,7 @@
  * We can therefore create a huge distributed bus encompassing many browsers and servers. The browsers don't have to
  * be connected to the same server as long as the servers are connected.
  *
- * This is done by providing a simple client side JavaScript library called `vertxbus.js` which provides an API
+ * This is done by providing a simple client side JavaScript library called `vertx3bus.js` which provides an API
  * very similar to the server-side Vert.x event-bus API, which allows you to send and publish messages to the event bus
  * and register handlers to receive messages.
  *
@@ -1469,12 +1469,12 @@
  * {@link examples.Examples#example45}
  * ----
  *
- * In client side JavaScript you use the 'vertxbus.js` library to create connections to the event bus and to send
+ * In client side JavaScript you use the 'vertx3bus.js` library to create connections to the event bus and to send
  * and receive messages:
  *
  * ----
  * <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
- * <script src='vertxbus.js'></script>
+ * <script src='vertx3bus.js'></script>
  *
  * <script>
  *


### PR DESCRIPTION
…uld use vertx3bus.js

@cescoffier the old API is restored and marked as deprecated, since the underlying protocol did not change both scripts can be used interchangeably but the old one has some limitations such as not full error handling and no consistent error handing across functions and reply support. 