### PR TITLE
Add flag for session get retry

### DIFF
--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/SessionHandler.java
@@ -116,6 +116,16 @@ public class SessionHandler implements Handler<RoutingContext> {
     return this;
   }
 
+  /**
+   * Set whether the handler should retry once to get session after a first return is null.
+   * @param sessionGetRetry true to set SessionHandler retry once get session
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SessionHandler setSessionGetRetry(boolean sessionGetRetry) { 
+    this.delegate.setSessionGetRetry(sessionGetRetry);
+    return this;
+  }
+
 
   public static SessionHandler newInstance(io.vertx.ext.web.handler.SessionHandler arg) {
     return arg != null ? new SessionHandler(arg) : null;

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/SessionHandler.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/SessionHandler.groovy
@@ -100,4 +100,13 @@ public class SessionHandler implements Handler<RoutingContext> {
     this.delegate.setSessionCookieName(sessionCookieName);
     return this;
   }
+  /**
+   * Set whether the handler should retry once to get session after a first return is null.
+   * @param sessionGetRetry true to set SessionHandler retry once get session
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SessionHandler setSessionGetRetry(boolean sessionGetRetry) {
+    this.delegate.setSessionGetRetry(sessionGetRetry);
+    return this;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -55,6 +55,11 @@ public interface SessionHandler extends Handler<RoutingContext> {
   boolean DEFAULT_NAG_HTTPS = true;
 
   /**
+   * Default of whether the handler should retry once to get session if a first return is null.
+   */
+  boolean DEFAULT_SESSION_GET_RETRY = true;
+
+  /**
    * Default of whether the cookie has the HttpOnly flag set
    * More info: https://www.owasp.org/index.php/HttpOnly
    */
@@ -73,7 +78,7 @@ public interface SessionHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static SessionHandler create(SessionStore sessionStore) {
-    return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_TIMEOUT, DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG, sessionStore);
+    return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_TIMEOUT, DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG, DEFAULT_SESSION_GET_RETRY, sessionStore);
   }
 
   /**
@@ -123,4 +128,12 @@ public interface SessionHandler extends Handler<RoutingContext> {
   @Fluent
   SessionHandler setSessionCookieName(String sessionCookieName);
 
+  /**
+   * Set whether the handler should retry once to get session after a first return is null.
+   *
+   * @param sessionGetRetry  true to set SessionHandler retry once get session
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  SessionHandler setSessionGetRetry(boolean sessionGetRetry);
 }

--- a/vertx-web/src/main/resources/vertx-web-js/session_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session_handler.js
@@ -122,6 +122,21 @@ var SessionHandler = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Set whether the handler should retry once to get session after a first return is null.
+
+   @public
+   @param sessionGetRetry {boolean} true to set SessionHandler retry once get session 
+   @return {SessionHandler} a reference to this, so the API can be used fluently
+   */
+  this.setSessionGetRetry = function(sessionGetRetry) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] ==='boolean') {
+      j_sessionHandler["setSessionGetRetry(boolean)"](sessionGetRetry);
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/session_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/session_handler.rb
@@ -92,5 +92,15 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling set_session_cookie_name(sessionCookieName)"
     end
+    #  Set whether the handler should retry once to get session after a first return is null.
+    # @param [true,false] sessionGetRetry true to set SessionHandler retry once get session
+    # @return [self]
+    def set_session_get_retry(sessionGetRetry=nil)
+      if (sessionGetRetry.class == TrueClass || sessionGetRetry.class == FalseClass) && !block_given?
+        @j_del.java_method(:setSessionGetRetry, [Java::boolean.java_class]).call(sessionGetRetry)
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling set_session_get_retry(sessionGetRetry)"
+    end
   end
 end


### PR DESCRIPTION
Add a flag so we can control the retry of session get. This is useful if the session store is local or via standalone server, e.g. Redis. The *retry* is not necessary in those session store.