### PR TITLE
Add BodyHandler constructor which allows custom upload directory

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/BodyHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/BodyHandler.java
@@ -57,6 +57,16 @@ public interface BodyHandler extends Handler<RoutingContext> {
   }
 
   /**
+   * Create a body handler and use the given upload directory.
+   *
+   * @param uploadDirectory  the uploads directory
+   * @return the body handler
+   */
+  static BodyHandler create(String uploadDirectory) {
+    return new BodyHandlerImpl(uploadDirectory);
+  }
+
+  /**
    * Set the maximum body size -1 means unlimited
    *
    * @param bodyLimit  the max size

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -44,6 +44,10 @@ public class BodyHandlerImpl implements BodyHandler {
     setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY);
   }
 
+  public BodyHandlerImpl(String uploadDirectory) {
+    setUploadsDirectory(uploadDirectory);
+  }
+
   @Override
   public void handle(RoutingContext context) {
     HttpServerRequest request = context.request();


### PR DESCRIPTION
Currently there is no way to avoid the creation of the default uploads directory ```file-uploads``` in the CWD which is created when invoking ```new BodyHandlerImpl()```.  Adding another constructor would solve this issue. 

Another option i can think of is using a static System property similiar to the way this is currently being implemented in ```FileResolver``` via ```vertx.cacheDirBase```.

Signed-off-by: Johannes Schüth <j.schueth@gentics.com>