### PR TITLE
Gradle dependency documentation fix

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -82,7 +82,10 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-web:3.2.0-SNAPSHOT
+dependencies {
+  compile 'io.vertx:vertx-web:3.2.0-SNAPSHOT'
+  // (...)
+}
 ----
 
 

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -82,7 +82,10 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-web:3.2.0-SNAPSHOT
+dependencies {
+  compile 'io.vertx:vertx-web:3.2.0-SNAPSHOT'
+  // (...)
+}
 ----
 
 

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -82,7 +82,10 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-web:3.2.0-SNAPSHOT
+dependencies {
+  compile 'io.vertx:vertx-web:3.2.0-SNAPSHOT'
+  // (...)
+}
 ----
 
 

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -82,7 +82,10 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-web:3.2.0-SNAPSHOT
+dependencies {
+  compile 'io.vertx:vertx-web:3.2.0-SNAPSHOT'
+  // (...)
+}
 ----
 
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -81,7 +81,9 @@
  *
  * [source,groovy,subs="+attributes"]
  * ----
- * compile ${maven.groupId}:${maven.artifactId}:${maven.version}
+ * dependencies {
+ *   compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * }
  * ----
  *
  *
@@ -1272,7 +1274,7 @@
  * To use Thymeleaf, you need to add the following _dependency_ to your project:
  * `${maven.groupId}:vertx-web-templ-thymeleaf:${maven.version}`. Create an instance of the Thymeleaf template engine
  * using: `io.vertx.ext.web.templ.ThymeleafTemplateEngine#create()`.
- * 
+ *
  * When using the Thymeleaf template engine, it will by default look for
  * templates with the `.html` extension if no extension is specified in the file name.
  *


### PR DESCRIPTION
The compile scope call lacked string delimiters.
I also added a surrounding dependencies section for clarity.
