### PR TITLE
EventbusBridge sends headers in messages to eventbus js client

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -324,18 +324,18 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
     if (message.replyAddress() != null) {
       envelope.put("replyAddress", message.replyAddress());
     }
-		if ( message.headers() != null && !message.headers().isEmpty()) {
-			JsonObject headersCopy = new JsonObject();
-			for (String name : message.headers().names()) {
-				List<String> values = message.headers().getAll(name);
-				if ( values.size() == 1) {
-					headersCopy.put(name, values.get(0));
-				} else {
-					headersCopy.put(name, values);
-				}
-			}
-			envelope.put("headers", headersCopy);
-		}
+    if ( message.headers() != null && !message.headers().isEmpty()) {
+      JsonObject headersCopy = new JsonObject();
+      for (String name : message.headers().names()) {
+      List<String> values = message.headers().getAll(name);
+        if ( values.size() == 1) {
+          headersCopy.put(name, values.get(0));
+        } else {
+          headersCopy.put(name, values);
+        }
+      }
+      envelope.put("headers", headersCopy);
+    }
     checkCallHook(() -> new BridgeEventImpl(BridgeEventType.RECEIVE, envelope, sock),
       () -> sock.write(buffer(envelope.encode())),
       () -> log.debug("outbound message rejected by bridge event handler"));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -324,18 +324,18 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
     if (message.replyAddress() != null) {
       envelope.put("replyAddress", message.replyAddress());
     }
-	if ( message.headers() != null && !message.headers().isEmpty()) {
-		JsonObject headersCopy = new JsonObject();
-		for (String name : message.headers().names()) {
-			List<String> values = message.headers().getAll(name);
-			if ( values.size() == 1) {
-				headersCopy.put(name, values.get(0));
-			} else {
-				headersCopy.put(name, values);
+		if ( message.headers() != null && !message.headers().isEmpty()) {
+			JsonObject headersCopy = new JsonObject();
+			for (String name : message.headers().names()) {
+				List<String> values = message.headers().getAll(name);
+				if ( values.size() == 1) {
+					headersCopy.put(name, values.get(0));
+				} else {
+					headersCopy.put(name, values);
+				}
 			}
+			envelope.put("headers", headersCopy);
 		}
-		envelope.put("headers", headersCopy);
-	}
     checkCallHook(() -> new BridgeEventImpl(BridgeEventType.RECEIVE, envelope, sock),
       () -> sock.write(buffer(envelope.encode())),
       () -> log.debug("outbound message rejected by bridge event handler"));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -324,6 +324,18 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
     if (message.replyAddress() != null) {
       envelope.put("replyAddress", message.replyAddress());
     }
+	if ( message.headers() != null && !message.headers().isEmpty()) {
+		JsonObject headersCopy = new JsonObject();
+		for (String name : message.headers().names()) {
+			List<String> values = message.headers().getAll(name);
+			if ( values.size() == 1) {
+				headersCopy.put(name, values.get(0));
+			} else {
+				headersCopy.put(name, values);
+			}
+		}
+		envelope.put("headers", headersCopy);
+	}
     checkCallHook(() -> new BridgeEventImpl(BridgeEventType.RECEIVE, envelope, sock),
       () -> sock.write(buffer(envelope.encode())),
       () -> log.debug("outbound message rejected by bridge event handler"));

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -29,7 +29,6 @@ import io.vertx.ext.web.handler.sockjs.*;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.test.core.TestUtils;
-import java.util.Map;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -714,11 +713,11 @@ public class EventbusBridgeTest extends WebTestBase {
         JsonObject received = new JsonObject(str);
         Object rec = received.getValue("body");
         assertEquals("barfoo", rec);
-				JsonObject headers = received.getJsonObject("headers");
-				assertNotNull(headers);
-				assertEquals("headbar", headers.getString("headfoo"));
-				assertTrue(headers.getJsonArray("multi").contains("m1"));
-				assertTrue(headers.getJsonArray("multi").contains("m2"));
+        JsonObject headers = received.getJsonObject("headers");
+        assertNotNull(headers);
+        assertEquals("headbar", headers.getString("headfoo"));
+        assertTrue(headers.getJsonArray("multi").contains("m1"));
+        assertTrue(headers.getJsonArray("multi").contains("m2"));
         ws.closeHandler(v -> latch.countDown());
         ws.close();
       });

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -714,11 +714,11 @@ public class EventbusBridgeTest extends WebTestBase {
         JsonObject received = new JsonObject(str);
         Object rec = received.getValue("body");
         assertEquals("barfoo", rec);
-		JsonObject headers = received.getJsonObject("headers");
-		assertNotNull(headers);
-		assertEquals("headbar", headers.getString("headfoo"));
-		assertTrue(headers.getJsonArray("multi").contains("m1"));
-		assertTrue(headers.getJsonArray("multi").contains("m2"));
+				JsonObject headers = received.getJsonObject("headers");
+				assertNotNull(headers);
+				assertEquals("headbar", headers.getString("headfoo"));
+				assertTrue(headers.getJsonArray("multi").contains("m1"));
+				assertTrue(headers.getJsonArray("multi").contains("m2"));
         ws.closeHandler(v -> latch.countDown());
         ws.close();
       });


### PR DESCRIPTION
Headers set in the DeliveryOptions of a message are now send  over the EventbusBridge to the eventbus javascript client. The other way (headers from javascript client to eventbus) already exists.

Perhaps the code in the EventbusBridgeImpl which copies the headers MultiMap into the Json envelope could go into the Json code of vertx-core (in a more general way).