### PR TITLE
Missing argument in callback method example

### DIFF
--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -2036,7 +2036,7 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
+  eb.registerHandler('some-address', function(err, message) {
     console.log('received a message: ' + JSON.stringify(message);
   });
 


### PR DESCRIPTION
Based on my own test and the example here https://github.com/vert-x3/vertx-examples/blob/master/web-examples/src/main/java/io/vertx/example/web/vertxbus/amd/webroot/index.html#L30 it seems that the callback function needs two arguments.