### PR TITLE
Documentation fix for vertx-eventbus.js example

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2254,8 +2254,8 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
-    console.log('received a message: ' + JSON.stringify(message);
+  eb.registerHandler('some-address', function(error, message) {
+    console.log('received a message: ' + JSON.stringify(message));
   });
 
   // send a message

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -2036,8 +2036,8 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
-    console.log('received a message: ' + JSON.stringify(message);
+  eb.registerHandler('some-address', function(error, message) {
+    console.log('received a message: ' + JSON.stringify(message));
   });
 
   // send a message

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2251,8 +2251,8 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
-    console.log('received a message: ' + JSON.stringify(message);
+  eb.registerHandler('some-address', function(error, message) {
+    console.log('received a message: ' + JSON.stringify(message));
   });
 
   // send a message

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -2251,8 +2251,8 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
-    console.log('received a message: ' + JSON.stringify(message);
+  eb.registerHandler('some-address', function(error, message) {
+    console.log('received a message: ' + JSON.stringify(message));
   });
 
   // send a message

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1487,8 +1487,8 @@
  * eb.onopen = function() {
  *
  *   // set a handler to receive a message
- *   eb.registerHandler('some-address', function(message) {
- *     console.log('received a message: ' + JSON.stringify(message);
+ *   eb.registerHandler('some-address', function(error, message) {
+ *     console.log('received a message: ' + JSON.stringify(message));
  *   });
  *
  *   // send a message


### PR DESCRIPTION
Small documentation fix. The vertx-eventbus.js example was not executable.