### PR TITLE
Bump handlebars to 4.0.4

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <version>1.3.0</version>
+      <version>4.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
@@ -129,6 +129,16 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
     public String getSuffix() {
       return extension;
     }
+
+    @Override
+    public void setPrefix(String prefix) {
+      // does nothing since TemplateLoader handles the prefix
+    }
+
+    @Override
+    public void setSuffix(String suffix) {
+      extension = suffix;
+    }
   }
 
 


### PR DESCRIPTION
See "Bump handlebars to 2.2.3": https://github.com/vert-x3/vertx-web/issues/220 for more info

Bumping the version and providing stub implementation for new methods in Loader interface.