### PR TITLE
WIP: Bump handlebars refactor prefixes

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <version>1.3.0</version>
+      <version>4.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
@@ -41,8 +41,9 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
 
   /**
    * Default template path
+   * //TODO move this to appropriate place
    */
-  String DEFAULT_TEMPLATE_PATH = "tempates";
+  String DEFAULT_TEMPLATE_PATH = "templates";
 
   /**
    * Create a template engine using defaults

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
@@ -40,6 +40,11 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
   String DEFAULT_TEMPLATE_EXTENSION = "hbs";
 
   /**
+   * Default template path
+   */
+  String DEFAULT_TEMPLATE_PATH = "tempates";
+
+  /**
    * Create a template engine using defaults
    *
    * @return  the engine
@@ -55,6 +60,14 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
    * @return a reference to this for fluency
    */
   HandlebarsTemplateEngine setExtension(String extension);
+
+  /**
+   * Set the path for partials
+   *
+   * @param path the path
+   * @return a reference to this for fluency
+   */
+  HandlebarsTemplateEngine setPath(String path);
 
   /**
    * Set the max cache size for the engine

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
@@ -129,6 +129,16 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
     public String getSuffix() {
       return extension;
     }
+
+    @Override
+    public void setPrefix(String prefix) {
+      // does nothing since TemplateLoader handles the prefix
+    }
+
+    @Override
+    public void setSuffix(String suffix) {
+      extension = suffix;
+    }
   }
 
 

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
@@ -38,13 +38,21 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
   private final Loader loader = new Loader();
 
   public HandlebarsTemplateEngineImpl() {
-    super(HandlebarsTemplateEngine.DEFAULT_TEMPLATE_EXTENSION, HandlebarsTemplateEngine.DEFAULT_MAX_CACHE_SIZE);
+    super(HandlebarsTemplateEngine.DEFAULT_TEMPLATE_EXTENSION,
+            HandlebarsTemplateEngine.DEFAULT_TEMPLATE_PATH,
+            HandlebarsTemplateEngine.DEFAULT_MAX_CACHE_SIZE);
     handlebars = new Handlebars(loader);
   }
 
   @Override
   public HandlebarsTemplateEngine setExtension(String extension) {
     doSetExtension(extension);
+    return this;
+  }
+
+  @Override
+  public HandlebarsTemplateEngine setPath(String path) {
+    doSetPath(path);
     return this;
   }
 
@@ -122,7 +130,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
     @Override
     public String getPrefix() {
-      return null;
+      return path;
     }
 
     @Override
@@ -132,7 +140,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
     @Override
     public void setPrefix(String prefix) {
-      // does nothing since TemplateLoader handles the prefix
+      path = prefix;
     }
 
     @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
@@ -28,13 +28,15 @@ public abstract class CachingTemplateEngine<T> implements TemplateEngine {
 
   protected final ConcurrentLRUCache<String, T> cache;
   protected String extension;
+  protected String path;
 
-  protected CachingTemplateEngine(String ext, int maxCacheSize) {
+  protected CachingTemplateEngine(String path, String ext, int maxCacheSize) {
     Objects.requireNonNull(ext);
     if (maxCacheSize < 1) {
       throw new IllegalArgumentException("maxCacheSize must be >= 1");
     }
     doSetExtension(ext);
+    doSetPath(path);
     this.cache = new ConcurrentLRUCache<>(maxCacheSize);
   }
 
@@ -48,5 +50,11 @@ public abstract class CachingTemplateEngine<T> implements TemplateEngine {
   protected void doSetExtension(String ext) {
     this.extension = ext.charAt(0) == '.' ? ext : "." + ext;
   }
+
+  protected void doSetPath(String path) {
+    this.path = path;
+  }
+
+
 
 }


### PR DESCRIPTION
See "Bump handlebars to 2.2.3": #220 for more info

Began the refactoring the CachingTemplateEngine to allow prefix to be configured instead of relying on the TemplateHandlerImpl to specify the template directory/path.

This is a work in progress at the moment.
