### PR TITLE
Fixes #293: Allow usage of underscore and dash in path variables

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1666,4 +1666,14 @@ public class RouterTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/foo", 200, "OK");
   }
+
+  @Test
+  public void testUnderscoreOnRoutePath() throws Exception {
+    router.route("/:account_id").handler(rc -> {
+      assertEquals("foo", rc.request().params().get("account_id"));
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.GET, "/foo", 200, "OK");
+  }
 }


### PR DESCRIPTION
By replacing the set with a list we can track the index of the variable on the path and allow the usage of characters that are not allowed on regex named groups such as:

* underscore
* dash