### PR TITLE
Content Length change

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
@@ -84,10 +84,7 @@ public class LoggerHandlerImpl implements LoggerHandler {
         contentLength = Long.parseLong(obj.toString());
       }
     } else {
-      Object obj = request.response().headers().get("content-length");
-      if (obj != null) {
-        contentLength = Long.parseLong(obj.toString());
-      }
+      contentLength  = request.response().bytesWritten();
     }
     String versionFormatted = "-";
     switch (version){


### PR DESCRIPTION
Now that bytesWritten() is available on HttpServerResponse, use that instead of content-length header to get size of response.

Signed-off-by: Dave Sinclair <stampy88@yahoo.com>