### PR TITLE
Null out cache entry when we decide not to use it.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -167,6 +167,9 @@ public class StaticHandlerImpl implements StaticHandler {
           context.response().setStatusCode(NOT_MODIFIED.code()).end();
           return;
         }
+
+        // Toss entry so we don't use it for anything
+        entry = null;
       }
     }
 


### PR DESCRIPTION
This avoids issues where we use the properties in the cache entry, but not the data.  This can result in the content being truncated because the content used is actually longer than the entry says it is.