### PR TITLE
fixes #299: Root paths check using Files.listRoots() instead of /

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -513,8 +513,12 @@ public class StaticHandlerImpl implements StaticHandler {
 
   private void setRoot(String webRoot) {
     Objects.requireNonNull(webRoot);
-    if (webRoot.startsWith("/") && !allowRootFileSystemAccess) {
-      throw new IllegalArgumentException("root cannot start with '/'");
+    if (!allowRootFileSystemAccess) {
+      for (File root : File.listRoots()) {
+        if (webRoot.startsWith(root.getAbsolutePath())) {
+          throw new IllegalArgumentException("root cannot start with '" + root.getAbsolutePath() + "'");
+        }
+      }
     }
     this.webRoot = webRoot;
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -556,6 +556,17 @@ public class StaticHandlerTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/" + file.getName(), 200, "OK", "");
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testAccessToRootPath() throws Exception {
+    router.clear();
+
+    File file = File.createTempFile("vertx", "tmp");
+    file.deleteOnExit();
+
+    // remap stat to the temp dir
+    stat = StaticHandler.create().setWebRoot(file.getParent());
+  }
+
   // TODO
   // 1.Test all the params including invalid values
   // 2. Make sure exists isn't being called too many times


### PR DESCRIPTION
fixes #299: Root paths check using Files.listRoots() instead of /