### PR TITLE
adding missing dependency type javascript for maven artefacts

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2315,6 +2315,7 @@ You can retrieve the client library using a dependency manager:
   <artifactId>vertx-web</artifactId>
   <version>3.3.0-SNAPSHOT</version>
   <classifier>client</classifier>
+  <type>js</type>
 </dependency>
 ----
 

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -2097,6 +2097,7 @@ You can retrieve the client library using a dependency manager:
   <artifactId>vertx-web</artifactId>
   <version>3.3.0-SNAPSHOT</version>
   <classifier>client</classifier>
+  <type>js</type>
 </dependency>
 ----
 

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2312,6 +2312,7 @@ You can retrieve the client library using a dependency manager:
   <artifactId>vertx-web</artifactId>
   <version>3.3.0-SNAPSHOT</version>
   <classifier>client</classifier>
+  <type>js</type>
 </dependency>
 ----
 

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -2312,6 +2312,7 @@ You can retrieve the client library using a dependency manager:
   <artifactId>vertx-web</artifactId>
   <version>3.3.0-SNAPSHOT</version>
   <classifier>client</classifier>
+  <type>js</type>
 </dependency>
 ----
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1548,6 +1548,7 @@
  *   <artifactId>${maven.artifactId}</artifactId>
  *   <version>${maven.version}</version>
  *   <classifier>client</classifier>
+ *   <type>js</type>
  * </dependency>
  * ----
  *


### PR DESCRIPTION
For maven artefacts, the type matches the file name extension in the repository. For the referenced JavaScript resource the extension is `js` and should be named in the docs accordingly. 

Link to maven repo: http://central.maven.org/maven2/io/vertx/vertx-web/3.2.1/

