### PR TITLE
Fix: vert-x3/vertx-bus-bower#6

### DIFF
--- a/vertx-web/src/client/vertx-eventbus.js
+++ b/vertx-web/src/client/vertx-eventbus.js
@@ -103,10 +103,10 @@
       self.onopen && self.onopen();
     };
 
-    this.sockJSConn.onclose = function () {
+    this.sockJSConn.onclose = function (e) {
       self.state = EventBus.CLOSED;
       if (pingTimerID) clearInterval(pingTimerID);
-      self.onclose && self.onclose();
+      self.onclose && self.onclose(e);
     };
 
     this.sockJSConn.onmessage = function (e) {


### PR DESCRIPTION
Fixes: vert-x3/vertx-bus-bower#6

Even though we pass the event for cases when fall back modes are used it is not guaranteed that the event is of type: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent but a wrap provided by sockJS