### PR TITLE
Fixes #322: do not store sessions and issue cookies on error

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -322,7 +322,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private Map<Integer, Handler<Void>> getHeadersEndHandlers() {
     if (headersEndHandlers == null) {
-      headersEndHandlers = new LinkedHashMap<>();
+      // order is important we we should traverse backwards
+      headersEndHandlers = new TreeMap<>(Collections.reverseOrder());
       response().headersEndHandler(v -> headersEndHandlers.values().forEach(handler -> handler.handle(null)));
     }
     return headersEndHandlers;
@@ -330,7 +331,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private Map<Integer, Handler<Void>> getBodyEndHandlers() {
     if (bodyEndHandlers == null) {
-      bodyEndHandlers = new LinkedHashMap<>();
+      // order is important we we should traverse backwards
+      bodyEndHandlers = new TreeMap<>(Collections.reverseOrder());
       response().bodyEndHandler(v -> bodyEndHandlers.values().forEach(handler -> handler.handle(null)));
     }
     return bodyEndHandlers;

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1126,6 +1126,66 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testHeadersEndHandlerCalledBackwards() throws Exception {
+
+    final AtomicInteger cnt = new AtomicInteger(0);
+
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addHeadersEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addHeadersEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addHeadersEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.GET, "/", 200, "OK");
+  }
+
+  @Test
+  public void testHeadersEndHandlerCalledBackwards2() throws Exception {
+
+    final AtomicInteger cnt = new AtomicInteger(0);
+
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addBodyEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addBodyEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      final int val = cnt.incrementAndGet();
+      rc.addBodyEndHandler(v -> {
+        assertEquals(val, cnt.getAndDecrement());
+      });
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.GET, "/", 200, "OK");
+  }
+
+  @Test
   public void testHeadersEndHandlerRemoveHandler() throws Exception {
     router.route().handler(rc -> {
       rc.addHeadersEndHandler(v -> {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -121,17 +121,20 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
       assertNotNull(wwwAuth);
       assertEquals("Basic realm=\"" + BasicAuthHandler.DEFAULT_REALM + "\"", wwwAuth);
       String setCookie = resp.headers().get("set-cookie");
-      assertNotNull(setCookie);
-      sessionCookie.set(setCookie);
+      // auth failed you should not get a session cookie!!!
+      assertNull(setCookie);
     }, 401, "Unauthorized", null);
 
     // Now try again with credentials
     testRequest(HttpMethod.GET, "/protected/somepage", req -> {
       req.putHeader("Authorization", "Basic dGltOnNhdXNhZ2Vz");
-      req.putHeader("cookie", sessionCookie.get());
     }, resp -> {
       String wwwAuth = resp.headers().get("WWW-Authenticate");
       assertNull(wwwAuth);
+      // auth is success, we should get a cookie!!!
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+      sessionCookie.set(setCookie);
     }, 200, "OK", "Welcome to the protected resource!");
 
     // And try again a few times we should be logged in with user stored in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
@@ -303,6 +303,20 @@ public abstract class SessionHandlerTestBase extends WebTestBase {
     testRequest(HttpMethod.GET, "/", 200, "OK");
   }
 
+  @Test
+  public void testSessionCookieAttack() throws Exception {
+    router.route().handler(CookieHandler.create());
+    router.route().handler(SessionHandler.create(store));
+    // faking that there was some auth error
+    router.route().handler(rc -> {
+      rc.fail(401);
+    });
+
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      assertNull(resp.headers().get("set-cookie"));
+    }, 401, "Unauthorized", null);
+  }
+
   private final DateFormat dateTimeFormatter = Utils.createRFC1123DateTimeFormatter();
 
   protected long doTestSessionRetryTimeout() throws Exception {


### PR DESCRIPTION
Fixes #322 

Several things here:

* Session handler will only issue saves iif the response status is 2xx or 3xx
* Calling end handlers is called in a reverse order of registry. This is the correct way since it works as a stack, initially we add handlers and we clean up running backwards. e.g.: cookie handler -> session handler, and the we clean up by first calling the session handler and then the cookie handler.
* Fixed the basic auth test which stated that on a auth error 401 you would receive a valid session cookie. That is invalid behavior.