### PR TITLE
Thread safe SessionImpl, Only persist sessions if contain data.

### DIFF
--- a/vertx-sockjs-service-proxy/src/test/resources/vertx-js/vertx-eventbus.js
+++ b/vertx-sockjs-service-proxy/src/test/resources/vertx-js/vertx-eventbus.js
@@ -103,10 +103,10 @@
       self.onopen && self.onopen();
     };
 
-    this.sockJSConn.onclose = function () {
+    this.sockJSConn.onclose = function (e) {
       self.state = EventBus.CLOSED;
       if (pingTimerID) clearInterval(pingTimerID);
-      self.onclose && self.onclose();
+      self.onclose && self.onclose(e);
     };
 
     this.sockJSConn.onmessage = function (e) {

--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-hazelcast</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Session.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Session.java
@@ -57,6 +57,15 @@ public class Session {
   }
 
   /**
+   * @return true if data has been written to this session
+   * @return 
+   */
+  public boolean hasContent() { 
+    boolean ret = this.delegate.hasContent();
+    return ret;
+  }
+
+  /**
    * Put some data in a session
    * @param key the key for the data
    * @param obj the data

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Session.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Session.groovy
@@ -47,6 +47,14 @@ public class Session {
     return ret;
   }
   /**
+   * @return true if data has been written to this session
+   * @return 
+   */
+  public boolean hasContent() {
+    def ret = this.delegate.hasContent();
+    return ret;
+  }
+  /**
    * Put some data in a session
    * @param key the key for the data
    * @param obj the data

--- a/vertx-web/src/main/java/io/vertx/ext/web/Session.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Session.java
@@ -44,10 +44,15 @@ public interface Session {
   String id();
 
   /**
+   * @return true if data has been written to this session
+   */
+  boolean hasContent();
+
+  /**
    * Put some data in a session
    *
-   * @param key  the key for the data
-   * @param obj  the data
+   * @param key the key for the data
+   * @param obj the data
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
@@ -56,16 +61,16 @@ public interface Session {
   /**
    * Get some data from the session
    *
-   * @param key  the key of the data
-   * @return  the data
+   * @param key the key of the data
+   * @return the data
    */
   <T> T get(String key);
 
   /**
    * Remove some data from the session
    *
-   * @param key  the key of the data
-   * @return  the data that was there or null if none there
+   * @param key the key of the data
+   * @return the data that was there or null if none there
    */
   <T> T remove(String key);
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -146,13 +146,15 @@ public class SessionHandlerImpl implements SessionHandler {
     context.addHeadersEndHandler(v -> {
       Session session = context.session();
       if (!session.isDestroyed()) {
-        // Store the session
-        session.setAccessed();
-        sessionStore.put(session, res -> {
-          if (res.failed()) {
-            log.error("Failed to store session", res.cause());
-          }
-        });
+        if (session.hasContent()) {
+          // Store the session
+          session.setAccessed();
+          sessionStore.put(session, res -> {
+            if (res.failed()) {
+              log.error("Failed to store session", res.cause());
+            }
+          });
+        }
       } else {
         sessionStore.delete(session.id(), res -> {
           if (res.failed()) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserSessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserSessionHandlerImpl.java
@@ -54,7 +54,11 @@ public class UserSessionHandlerImpl implements UserSessionHandler {
         }
         holder.context = routingContext;
       } else {
-        session.put(SESSION_USER_HOLDER_KEY, new UserHolder(routingContext));
+        routingContext.addHeadersEndHandler(v -> {
+          if (routingContext.user() != null) {
+            session.put(SESSION_USER_HOLDER_KEY, new UserHolder(routingContext));
+          }
+        });
       }
       if (user != null) {
         routingContext.setUser(user);

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -322,7 +322,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private Map<Integer, Handler<Void>> getHeadersEndHandlers() {
     if (headersEndHandlers == null) {
-      headersEndHandlers = new LinkedHashMap<>();
+      headersEndHandlers = new TreeMap<>(Collections.reverseOrder());
       response().headersEndHandler(v -> headersEndHandlers.values().forEach(handler -> handler.handle(null)));
     }
     return headersEndHandlers;

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -27,9 +27,10 @@ import io.vertx.ext.web.impl.Utils;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -55,9 +56,10 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
 
   private String id;
   private long timeout;
-  private Map<String, Object> data;
+  private final AtomicReference<Map<String, Object>> data = new AtomicReference<>();
   private long lastAccessed;
   private boolean destroyed;
+  private boolean hasContent;
 
   public SessionImpl() {
   }
@@ -74,6 +76,11 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   }
 
   @Override
+  public boolean hasContent() {
+    return hasContent;
+  }
+
+  @Override
   public long timeout() {
     return timeout;
   }
@@ -87,7 +94,11 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
 
   @Override
   public Session put(String key, Object obj) {
-    getData().put(key, obj);
+    if (obj == null)
+      getData().remove(key);
+    else
+      getData().put(key, obj);
+    hasContent = true;
     return this;
   }
 
@@ -95,6 +106,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @SuppressWarnings("unchecked")
   public <T> T remove(String key) {
     Object obj = getData().remove(key);
+    hasContent = true;
     return (T)obj;
   }
 
@@ -116,7 +128,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @Override
   public void destroy() {
     destroyed = true;
-    data = null;
+    data.set(null);
   }
 
   @Override
@@ -147,10 +159,16 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   }
 
   private Map<String, Object> getData() {
-    if (data == null) {
-      data = new HashMap<>();
+    while (true) {
+      Map<String, Object> map = data.get();
+      if (map != null)
+        return map;
+
+
+      Map<String, Object> newMap = new ConcurrentHashMap<>();
+      if (data.compareAndSet(null, newMap))
+        return newMap;
     }
-    return data;
   }
 
   private Buffer writeDataToBuffer() {
@@ -217,7 +235,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     try {
       int entries = buffer.getInt(pos);
       pos +=4;
-      data = new HashMap<>(entries);
+      Map<String, Object> data = new ConcurrentHashMap<>();
       for (int i = 0; i < entries; i++) {
         int keylen = buffer.getInt(pos);
         pos += 4;
@@ -304,8 +322,11 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
           default:
             throw new IllegalStateException("Invalid serialized type: " + type);
         }
-        data.put(key, val);
+        if (val != null)
+          data.put(key, val);
       }
+      hasContent = true;
+      this.data.set(data); // we assume this is not called concurrently
       return pos;
     } catch (Exception e) {
       throw new VertxException(e);

--- a/vertx-web/src/main/resources/vertx-web-js/session.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session.js
@@ -51,6 +51,20 @@ var Session = function(j_val) {
   };
 
   /**
+   @return true if data has been written to this session
+
+   @public
+
+   @return {boolean}
+   */
+  this.hasContent = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_session["hasContent()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    Put some data in a session
 
    @public

--- a/vertx-web/src/main/resources/vertx-web/session.rb
+++ b/vertx-web/src/main/resources/vertx-web/session.rb
@@ -29,6 +29,14 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling id()"
     end
+    #  @return true if data has been written to this session
+    # @return [true,false]
+    def has_content?
+      if !block_given?
+        return @j_del.java_method(:hasContent, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling has_content?()"
+    end
     #  Put some data in a session
     # @param [String] key the key for the data
     # @param [Object] obj the data

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -132,6 +132,9 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
     }, resp -> {
       String wwwAuth = resp.headers().get("WWW-Authenticate");
       assertNull(wwwAuth);
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+      sessionCookie.set(setCookie);
     }, 200, "OK", "Welcome to the protected resource!");
 
     // And try again a few times we should be logged in with user stored in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
@@ -184,6 +184,7 @@ public abstract class SessionHandlerTestBase extends WebTestBase {
         case 1:
           assertFalse(rid.get().equals(sess.id())); // New session
           assertNull(sess.get("foo"));
+          sess.put("baz", "bar");
           break;
       }
       requestCount.incrementAndGet();


### PR DESCRIPTION
This pull request should be merged with @pmlopes pull request https://github.com/vert-x3/vertx-web/pull/327 (all his changes except SessionHandlerImpl.java)

Several things
1. SessionImpl.java usage of HashMap<> replaced by ConcurrentHashMap<>
2. Session method boolean hasContent() which becomes true on first "put".
3. SessionHandlerImpl.java only stores the session if (session.hasContent())
4. UserHandler only creates UserHolder if (routingContext.user() != null)

See https://github.com/vert-x3/vertx-web/issues/322

Remaining todos: 
1. merge @pmlopes pull request https://github.com/vert-x3/vertx-web/pull/327
2. session.data().put(...) does not set the "hasContent" flag.
