### PR TITLE
Fixes #335: race condition when parsing multiple file uploads

### DIFF
--- a/vertx-web/src/main/asciidoc/enums.adoc
+++ b/vertx-web/src/main/asciidoc/enums.adoc
@@ -1,40 +1,5 @@
 = Enums
 
-[[Transport]]
-== Transport
-
-++++
- The available SockJS transports
-++++
-'''
-
-[cols=">25%,75%"]
-[frame="topbot"]
-|===
-^|Name | Description
-|[[WEBSOCKET]]`WEBSOCKET`|
-+++
-<a href="http://www.rfc-editor.org/rfc/rfc6455.txt">rfc 6455</a>
-+++
-|[[EVENT_SOURCE]]`EVENT_SOURCE`|
-+++
-<a href="http://dev.w3.org/html5/eventsource/">Event source</a>
-+++
-|[[HTML_FILE]]`HTML_FILE`|
-+++
-<a href="http://cometdaily.com/2007/11/18/ie-activexhtmlfile-transport-part-ii/">HtmlFile</a>.
-+++
-|[[JSON_P]]`JSON_P`|
-+++
-Slow and old fashioned <a hred="https://developer.mozilla.org/en/DOM/window.postMessage">JSONP polling</a>.
- This transport will show "busy indicator" (aka: "spinning wheel") when sending data.
-+++
-|[[XHR]]`XHR`|
-+++
-Long-polling using <a hred="https://secure.wikimedia.org/wikipedia/en/wiki/XMLHttpRequest#Cross-domain_requests">cross domain XHR</a>
-+++
-|===
-
 [[BridgeEventType]]
 == BridgeEventType
 
@@ -74,6 +39,41 @@ This event will occur when a client attempts to register a handler.
 |[[UNREGISTER]]`UNREGISTER`|
 +++
 This event will occur when a client attempts to unregister a handler.
++++
+|===
+
+[[Transport]]
+== Transport
+
+++++
+ The available SockJS transports
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[WEBSOCKET]]`WEBSOCKET`|
++++
+<a href="http://www.rfc-editor.org/rfc/rfc6455.txt">rfc 6455</a>
++++
+|[[EVENT_SOURCE]]`EVENT_SOURCE`|
++++
+<a href="http://dev.w3.org/html5/eventsource/">Event source</a>
++++
+|[[HTML_FILE]]`HTML_FILE`|
++++
+<a href="http://cometdaily.com/2007/11/18/ie-activexhtmlfile-transport-part-ii/">HtmlFile</a>.
++++
+|[[JSON_P]]`JSON_P`|
++++
+Slow and old fashioned <a hred="https://developer.mozilla.org/en/DOM/window.postMessage">JSONP polling</a>.
+ This transport will show "busy indicator" (aka: "spinning wheel") when sending data.
++++
+|[[XHR]]`XHR`|
++++
+Long-polling using <a hred="https://secure.wikimedia.org/wikipedia/en/wiki/XMLHttpRequest#Cross-domain_requests">cross domain XHR</a>
 +++
 |===
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -142,12 +142,18 @@ public class BodyHandlerImpl implements BodyHandler {
 
     void uploadEnded() {
       int count = uploadCount.decrementAndGet();
-      if (count == 0) {
+      // only if parsing is done and count is 0 then all files have been processed
+      if (ended && count == 0) {
         doEnd();
       }
     }
 
     void end() {
+      // this marks the end of body parsing, calling doEnd should
+      // only be possible from this moment onwards
+      ended = true;
+
+      // only if parsing is done and count is 0 then all files have been processed
       if (uploadCount.get() == 0) {
         doEnd();
       }
@@ -162,10 +168,10 @@ public class BodyHandlerImpl implements BodyHandler {
         }
       }
 
-      if (failed || ended) {
+      if (failed) {
         return;
       }
-      ended = true;
+
       HttpServerRequest req = context.request();
       if (mergeFormAttributes && req.isExpectMultipart()) {
         req.params().addAll(req.formAttributes());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
@@ -340,6 +340,40 @@ public class BodyHandlerTest extends WebTestBase {
     testFormMultipartFormData(false);
   }
 
+  @Test
+  public void testMultiFileUpload() throws Exception {
+
+    int uploads = 1000;
+
+    router.route().handler(rc -> {
+      assertEquals(uploads, rc.fileUploads().size());
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+      Buffer buffer = Buffer.buffer();
+
+      for (int i = 0; i < uploads; i++) {
+        String header =
+            "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"file" + i + "\"; filename=\"file" + i + "\"\r\n" +
+                "Content-Type: application/octet-stream\r\n" +
+                "Content-Transfer-Encoding: binary\r\n" +
+                "\r\n";
+        buffer.appendString(header);
+        buffer.appendBuffer(TestUtils.randomBuffer(4096*16));
+        buffer.appendString("\r\n");
+      }
+      buffer.appendString("--" + boundary + "\r\n");
+
+      req.headers().set("content-length", String.valueOf(buffer.length()));
+      req.headers().set("content-type", "multipart/form-data; boundary=" + boundary);
+      req.write(buffer);
+
+    }, 200, "OK", null);
+  }
+
   private void testFormMultipartFormData(boolean mergeAttributes) throws Exception {
     router.route().handler(rc -> {
       MultiMap attrs = rc.request().formAttributes();


### PR DESCRIPTION
Fixes #335 

Since this was a race condition, making a test to reproduce the issue was hard. The current test might seem a bit too much but it is what i can use on my laptop to reproduce the issue 100% of the times. It could be that on other machines it will not be 100%...

The problem was that a counter was being incremented and decremented every time a file was being offered from the upload body. This can be seem like a stack, say that you have 1000 files in the upload.

The counter would be going like:
```
cnt++
cnt++
cnt++
```
but with small bodies at the end of the single upload the counter gets decremented:
```
cnt--
```

We were checking if the cnt was 0 and assume we were complete, however, we could reach a point where cnt was 0 but the parsing was not finished (this bug).

The solution was to flag the end of parsing properly and only then trigger the end.