### PR TITLE
Fix documentation

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -267,6 +267,8 @@ public interface RoutingContext {
    * {@link #fail(int)}  then this will return that status code.  It can be used by failure handlers to render a response,
    * e.g. create a failure response page.
    *
+   * When the status code has not been set yet (it is undefined) its value will be -1.
+   *
    * @return  the status code used when signalling failure
    */
   @CacheReturn


### PR DESCRIPTION
Fixes #305 

When asking the set status code (when no set operation has been performed yet) it returns -1 (undefined).