### PR TITLE
add path params in a separate map + a simple test

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -396,4 +396,20 @@ public interface RoutingContext {
     final List<Locale> acceptableLocales = acceptableLocales();
     return acceptableLocales.size() > 0 ? acceptableLocales.get(0) : null;
   }
+
+  /**
+   * Returns a map of named parameters as defined in path declaration with their actual values
+   *
+   * @return the map of named parameters
+   */
+  Map<String, String> pathParams();
+
+  /**
+   * Gets the value of a single path parameter
+   *
+   * @param name the name of parameter as defined in path declaration
+   * @return the actual value of the parameter or null if it doesn't exist
+   */
+  @Nullable
+  String pathParam(String name);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -281,6 +281,7 @@ public class RouteImpl implements Route {
             }
           }
           request.params().addAll(params);
+          context.pathParams().putAll(params);
         }
       } else {
         return false;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -254,8 +254,11 @@ public class RouteImpl implements Route {
             try {
               for (int i = 0; i < groups.size(); i++) {
                 final String k = groups.get(i);
+                final String value = URLDecoder.decode(URLDecoder.decode(m.group("p" + i), "UTF-8"), "UTF-8");
                 if (!request.params().contains(k)) {
-                  params.put(k, URLDecoder.decode(m.group("p" + i), "UTF-8"));
+                  params.put(k, value);
+                } else {
+                  context.pathParams().put(k, value);
                 }
               }
             } catch (UnsupportedEncodingException e) {
@@ -270,8 +273,11 @@ public class RouteImpl implements Route {
                 String group = m.group(i + 1);
                 if(group != null) {
                   final String k = "param" + i;
+                  final String value = URLDecoder.decode(group, "UTF-8");
                   if (!request.params().contains(k)) {
-                    params.put(k, URLDecoder.decode(group, "UTF-8"));
+                    params.put(k, value);
+                  } else {
+                    context.pathParams().put(k, value);
                   }
                 }
               }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.impl;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -205,6 +206,16 @@ public class RoutingContextDecorator implements RoutingContext {
   @Override
   public List<Locale> acceptableLocales() {
     return decoratedContext.acceptableLocales();
+  }
+
+  @Override
+  public Map<String, String> pathParams() {
+    return decoratedContext.pathParams();
+  }
+
+  @Override
+  public @Nullable String pathParam(String name) {
+    return decoratedContext.pathParam(name);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.impl;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -41,6 +42,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private final RouterImpl router;
   private Map<String, Object> data;
+  private Map<String, String> pathParams;
   private AtomicInteger handlerSeq = new AtomicInteger();
   private Map<Integer, Handler<Void>> headersEndHandlers;
   private Map<Integer, Handler<Void>> bodyEndHandlers;
@@ -318,6 +320,23 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     }
 
     return Collections.emptyList();
+  }
+
+  @Override
+  public Map<String, String> pathParams() {
+    return getPathParams();
+  }
+
+  @Override
+  public @Nullable String pathParam(String name) {
+    return getPathParams().get(name);
+  }
+
+  private Map<String, String> getPathParams() {
+    if (pathParams == null) {
+      pathParams = new HashMap<>();
+    }
+    return pathParams;
   }
 
   private Map<Integer, Handler<Void>> getHeadersEndHandlers() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.impl;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -249,6 +250,16 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   @Override
   public List<Locale> acceptableLocales() {
     return inner.acceptableLocales();
+  }
+
+  @Override
+  public Map<String, String> pathParams() {
+    return inner.pathParams();
+  }
+
+  @Override
+  public @Nullable String pathParam(String name) {
+    return inner.pathParam(name);
   }
 
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -770,6 +770,15 @@ public class RouterTest extends WebTestBase {
     testPattern("/blah/tim/quux/julien/eep/nick", "timjuliennick");
   }
 
+  @Test
+  public void testPathParamsAreFulfilled() throws Exception {
+    router.route("/blah/:abc/quux/:def/eep/:ghi").handler(rc -> {
+      Map<String, String> params = rc.pathParams();
+      rc.response().setStatusMessage(params.get("abc") + params.get("def") + params.get("ghi")).end();
+    });
+    testPattern("/blah/tim/quux/julien/eep/nick", "timjuliennick");
+  }
+
   private void testPattern(String pathRoot, String expected) throws Exception {
     testRequest(HttpMethod.GET, pathRoot, 200, expected);
     testRequest(HttpMethod.GET, pathRoot + "/", 404, "Not Found");

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -800,6 +800,21 @@ public class RouterTest extends WebTestBase {
             pathParamValue + "|" + queryParamValue1 + sep + queryParamValue2);
   }
 
+  @Test
+  public void testPathParamsWithReroute() throws Exception {
+    String paramName = "param";
+    String firstParamValue = "fpv";
+    String secondParamValue = "secondParamValue";
+    router.route("/first/:" + paramName + "/route").handler(rc -> {
+      assertEquals(firstParamValue, rc.pathParam(paramName));
+      rc.reroute(HttpMethod.GET, "/second/" + secondParamValue + "/route");
+    });
+    router.route("/second/:" + paramName + "/route").handler(rc -> {
+       rc.response().setStatusMessage(rc.pathParam(paramName)).end();
+    });
+    testRequest(HttpMethod.GET, "/first/" + firstParamValue + "/route", 200, secondParamValue);
+  }
+
   private void testPattern(String pathRoot, String expected) throws Exception {
     testRequest(HttpMethod.GET, pathRoot, 200, expected);
     testRequest(HttpMethod.GET, pathRoot + "/", 404, "Not Found");


### PR DESCRIPTION
A very basic implementation for now, let me know what you guys think about it.

It's aimed at being backwards compatible, meaning path parameters are still available as request parameters, but if you want to fetch actual routing parameters, you'll fetch them from the routing context, which makes sense since it's a matter of vertx-web, not vertx-core.

Please review and let me know if something's wrong, thanks.

(bound to : #304 ) 