### PR TITLE
pebble: expose context.data() to templates

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -29,11 +29,12 @@ import com.mitchellbosecke.pebble.loader.FileLoader;
 import com.mitchellbosecke.pebble.loader.Loader;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.templ.PebbleTemplateEngine;
@@ -42,6 +43,8 @@ import io.vertx.ext.web.templ.PebbleTemplateEngine;
  * @author Dan Kristensen
  */
 public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTemplate> implements PebbleTemplateEngine {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PebbleTemplateEngineImpl.class);
 
 	private final PebbleEngine pebbleEngine;
 	private final FileLoader fileLoader;
@@ -90,8 +93,14 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
 				template = pebbleEngine.getTemplate(templateText);
 				cache.put(templateFileName, template);
 			}
-			final Map<String, Object> variables = new HashMap<>(1);
+			final Map<String, Object> variables = new HashMap<>(context.data());
+
+			if (variables.containsKey("context")) {
+			  LOGGER.warn("Template variable <context> reserved for RoutingContext");
+			}
+
 			variables.put("context", context);
+
 			final StringWriter stringWriter = new StringWriter();
 			template.evaluate(stringWriter, variables);
 			handler.handle(Future.succeededFuture(Buffer.buffer(stringWriter.toString())));

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-context-variables.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-context-variables.peb
@@ -1,0 +1,2 @@
+Hello {{ foo }} and {{ bar }}
+Request path is {{context.request().path()}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
@@ -16,11 +16,10 @@
 
 package io.vertx.ext.web.templ;
 
-import org.junit.Test;
-
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.TemplateHandler;
+import org.junit.Test;
 
 /**
  * @author Dan Kristensen
@@ -31,14 +30,40 @@ public class PebbleTemplateTest extends WebTestBase {
 	public void testTemplateHandlerOnClasspath() throws Exception {
 		final TemplateEngine engine = PebbleTemplateEngine.create();
 		testTemplateHandler(engine, "somedir", "test-pebble-template2.peb",
-		        "Hello badger and foxRequest path is /test-pebble-template2.peb");
+				"Hello badger and foxRequest path is /test-pebble-template2.peb");
 	}
 
 	@Test
 	public void testTemplateHandlerOnFileSystem() throws Exception {
 		final TemplateEngine engine = PebbleTemplateEngine.create();
 		testTemplateHandler(engine, "src/test/filesystemtemplates", "test-pebble-template3.peb",
-		        "Hello badger and foxRequest path is /test-pebble-template3.peb");
+				"Hello badger and foxRequest path is /test-pebble-template3.peb");
+	}
+
+
+	@Test
+	public void testTemplateContextVariables() throws Exception {
+		final TemplateEngine engine = PebbleTemplateEngine.create();
+		testTemplateHandler(engine, "src/test/filesystemtemplates", "test-pebble-context-variables.peb",
+				"Hello badger and foxRequest path is /test-pebble-context-variables.peb");
+	}
+
+	@Test
+	public void testTemplateContextVariables_contextOverride() throws Exception {
+		final TemplateEngine engine = PebbleTemplateEngine.create();
+
+		router.route().handler(context -> {
+			context.put("foo", "badger");
+			context.put("bar", "fox");
+			context.put("context", "NOT GONNA BE USED!");
+
+			context.next();
+		});
+		router.route().handler(TemplateHandler.create(engine, "src/test/filesystemtemplates", "text/plain"));
+
+		String expected = "Hello badger and foxRequest path is /test-pebble-context-variables.peb";
+
+		testRequest(HttpMethod.GET, "/test-pebble-context-variables.peb", 200, "OK", expected);
 	}
 
 	@Test


### PR DESCRIPTION
In addition to exposing the routing context in pebble templates, expose `context.data()`, too.

This makes up for much cleaner templates.

To keep backwards compatibility the `context` variable is reserved for the `routingContext`. If you pass it as part of `context.data()` it will not be accessible and a warning will be logged.