### PR TITLE
Nikku 366 template single route

### DIFF
--- a/vertx-web/src/main/asciidoc/enums.adoc
+++ b/vertx-web/src/main/asciidoc/enums.adoc
@@ -42,41 +42,6 @@ This event will occur when a client attempts to unregister a handler.
 +++
 |===
 
-[[Transport]]
-== Transport
-
-++++
- The available SockJS transports
-++++
-'''
-
-[cols=">25%,75%"]
-[frame="topbot"]
-|===
-^|Name | Description
-|[[WEBSOCKET]]`WEBSOCKET`|
-+++
-<a href="http://www.rfc-editor.org/rfc/rfc6455.txt">rfc 6455</a>
-+++
-|[[EVENT_SOURCE]]`EVENT_SOURCE`|
-+++
-<a href="http://dev.w3.org/html5/eventsource/">Event source</a>
-+++
-|[[HTML_FILE]]`HTML_FILE`|
-+++
-<a href="http://cometdaily.com/2007/11/18/ie-activexhtmlfile-transport-part-ii/">HtmlFile</a>.
-+++
-|[[JSON_P]]`JSON_P`|
-+++
-Slow and old fashioned <a hred="https://developer.mozilla.org/en/DOM/window.postMessage">JSONP polling</a>.
- This transport will show "busy indicator" (aka: "spinning wheel") when sending data.
-+++
-|[[XHR]]`XHR`|
-+++
-Long-polling using <a hred="https://secure.wikimedia.org/wikipedia/en/wiki/XMLHttpRequest#Cross-domain_requests">cross domain XHR</a>
-+++
-|===
-
 [[LoggerFormat]]
 == LoggerFormat
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/RoutingContext.java
@@ -27,6 +27,7 @@ import io.vertx.rxjava.ext.auth.User;
 import io.vertx.rxjava.core.buffer.Buffer;
 import io.vertx.rxjava.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpMethod;
+import java.util.Map;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.Handler;
 
@@ -509,6 +510,25 @@ public class RoutingContext {
    */
   public Locale preferredLocale() { 
     Locale ret = Locale.newInstance(delegate.preferredLocale());
+    return ret;
+  }
+
+  /**
+   * Returns a map of named parameters as defined in path declaration with their actual values
+   * @return the map of named parameters
+   */
+  public Map<String,String> pathParams() { 
+    Map<String,String> ret = delegate.pathParams();
+    return ret;
+  }
+
+  /**
+   * Gets the value of a single path parameter
+   * @param name the name of parameter as defined in path declaration
+   * @return the actual value of the parameter or null if it doesn't exist
+   */
+  public String pathParam(String name) { 
+    String ret = delegate.pathParam(name);
     return ret;
   }
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/sstore/SessionStore.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/sstore/SessionStore.java
@@ -96,15 +96,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.delete(id, new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.delete(id, resultHandler);
   }
 
   /**
@@ -124,15 +116,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.put((io.vertx.ext.web.Session)session.getDelegate(), new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.put((io.vertx.ext.web.Session)session.getDelegate(), resultHandler);
   }
 
   /**
@@ -151,15 +135,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void clear(Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.clear(new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.clear(resultHandler);
   }
 
   /**
@@ -177,15 +153,7 @@ public class SessionStore {
    * @param resultHandler will be called with the number, or a failure
    */
   public void size(Handler<AsyncResult<Integer>> resultHandler) { 
-    delegate.size(new Handler<AsyncResult<java.lang.Integer>>() {
-      public void handle(AsyncResult<java.lang.Integer> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.size(resultHandler);
   }
 
   /**

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
@@ -27,6 +27,7 @@ import io.vertx.groovy.ext.auth.User
 import io.vertx.groovy.core.buffer.Buffer
 import io.vertx.groovy.core.http.HttpServerResponse
 import io.vertx.core.http.HttpMethod
+import java.util.Map
 import io.vertx.core.json.JsonObject
 import io.vertx.core.Handler
 /**
@@ -453,6 +454,23 @@ public class RoutingContext {
    */
   public Locale preferredLocale() {
     def ret = InternalHelper.safeCreate(delegate.preferredLocale(), io.vertx.groovy.ext.web.Locale.class);
+    return ret;
+  }
+  /**
+   * Returns a map of named parameters as defined in path declaration with their actual values
+   * @return the map of named parameters
+   */
+  public Map<String, String> pathParams() {
+    def ret = delegate.pathParams();
+    return ret;
+  }
+  /**
+   * Gets the value of a single path parameter
+   * @param name the name of parameter as defined in path declaration
+   * @return the actual value of the parameter or null if it doesn't exist
+   */
+  public String pathParam(String name) {
+    def ret = delegate.pathParam(name);
     return ret;
   }
   private HttpServerRequest cached_0;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -213,7 +213,10 @@ public class Utils extends io.vertx.core.impl.Utils {
     }
     String routePath = context.currentRoute().getPath();
     if (routePath != null) {
-      prefixLen += routePath.length() - 1;
+      // if resource is directory, strip until slash
+      if (routePath.charAt(routePath.length() - 1) == '/') {
+        prefixLen += routePath.length() - 1;
+      }
     }
     return prefixLen != 0 ? path.substring(prefixLen) : path;
   }

--- a/vertx-web/src/main/resources/vertx-web-js/routing_context.js
+++ b/vertx-web/src/main/resources/vertx-web-js/routing_context.js
@@ -639,6 +639,34 @@ var RoutingContext = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Returns a map of named parameters as defined in path declaration with their actual values
+
+   @public
+
+   @return {Array.<string>} the map of named parameters
+   */
+  this.pathParams = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnMap(j_routingContext["pathParams()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Gets the value of a single path parameter
+
+   @public
+   @param name {string} the name of parameter as defined in path declaration 
+   @return {string} the actual value of the parameter or null if it doesn't exist
+   */
+  this.pathParam = function(name) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'string') {
+      return j_routingContext["pathParam(java.lang.String)"](name);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/routing_context.rb
+++ b/vertx-web/src/main/resources/vertx-web/routing_context.rb
@@ -435,5 +435,22 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling preferred_locale()"
     end
+    #  Returns a map of named parameters as defined in path declaration with their actual values
+    # @return [Hash{String => String}] the map of named parameters
+    def path_params
+      if !block_given?
+        return Java::IoVertxLangRuby::Helper.adaptingMap(@j_del.java_method(:pathParams, []).call(), Proc.new { |val| ::Vertx::Util::Utils.from_object(val) }, Proc.new { |val| ::Vertx::Util::Utils.to_string(val) })
+      end
+      raise ArgumentError, "Invalid arguments when calling path_params()"
+    end
+    #  Gets the value of a single path parameter
+    # @param [String] name the name of parameter as defined in path declaration
+    # @return [String] the actual value of the parameter or null if it doesn't exist
+    def path_param(name=nil)
+      if name.class == String && !block_given?
+        return @j_del.java_method(:pathParam, [Java::java.lang.String.java_class]).call(name)
+      end
+      raise ArgumentError, "Invalid arguments when calling path_param(name)"
+    end
   end
 end

--- a/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
@@ -74,14 +74,14 @@ public class TemplateTest extends WebTestBase {
   @Test
   public void testTemplateHandlerSingleRoute() throws Exception {
     TemplateEngine engine = new TestEngine(false);
-    router.route("/test-template")
+    router.route("/test-template.html")
              .handler(context -> {
                context.put("foo", "badger");
                context.put("bar", "fox");
                context.next();
              });
     
-    router.route("/test-template").handler(TemplateHandler.create(engine, "somedir", "text/html"));
+    router.route("/test-template.html").handler(TemplateHandler.create(engine, "somedir", "text/html"));
 
     // we assume test-template is going to be
     // mapped to {somedir}/test-template.html and
@@ -94,7 +94,7 @@ public class TemplateTest extends WebTestBase {
         "</body>\n" +
         "</html>";
 
-    testRequest(HttpMethod.GET, "/test-template", 200, "OK", expected);
+    testRequest(HttpMethod.GET, "/test-template.html", 200, "OK", expected);
   }
 
   @Test


### PR DESCRIPTION
Fixes #367 

However this is probably not correct. The idea behind the template handler is to match request paths to template files, when dealing with single templates there is no need for the handler and a using the engine directly is enough e.g.:

``` java
    router.route("/test-template.html")
             .handler(context -> {
               context.put("foo", "badger");
               context.put("bar", "fox");

               engine.render(context, "test-template.html", res -> {
                 if (res.failed()) {
                   context.fail(res.cause());
                 } else {
                   context.response()
                           .putHeader("Content-Type", "text/html")
                           .end(res.result());
                 }
               });
             });
```
