### PR TITLE
Experimenting with webpush

### DIFF
--- a/vertx-web/src/main/asciidoc/enums.adoc
+++ b/vertx-web/src/main/asciidoc/enums.adoc
@@ -42,41 +42,6 @@ This event will occur when a client attempts to unregister a handler.
 +++
 |===
 
-[[Transport]]
-== Transport
-
-++++
- The available SockJS transports
-++++
-'''
-
-[cols=">25%,75%"]
-[frame="topbot"]
-|===
-^|Name | Description
-|[[WEBSOCKET]]`WEBSOCKET`|
-+++
-<a href="http://www.rfc-editor.org/rfc/rfc6455.txt">rfc 6455</a>
-+++
-|[[EVENT_SOURCE]]`EVENT_SOURCE`|
-+++
-<a href="http://dev.w3.org/html5/eventsource/">Event source</a>
-+++
-|[[HTML_FILE]]`HTML_FILE`|
-+++
-<a href="http://cometdaily.com/2007/11/18/ie-activexhtmlfile-transport-part-ii/">HtmlFile</a>.
-+++
-|[[JSON_P]]`JSON_P`|
-+++
-Slow and old fashioned <a hred="https://developer.mozilla.org/en/DOM/window.postMessage">JSONP polling</a>.
- This transport will show "busy indicator" (aka: "spinning wheel") when sending data.
-+++
-|[[XHR]]`XHR`|
-+++
-Long-polling using <a hred="https://secure.wikimedia.org/wikipedia/en/wiki/XMLHttpRequest#Cross-domain_requests">cross domain XHR</a>
-+++
-|===
-
 [[LoggerFormat]]
 == LoggerFormat
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/RoutingContext.java
@@ -27,6 +27,7 @@ import io.vertx.rxjava.ext.auth.User;
 import io.vertx.rxjava.core.buffer.Buffer;
 import io.vertx.rxjava.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpMethod;
+import java.util.Map;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.Handler;
 
@@ -509,6 +510,25 @@ public class RoutingContext {
    */
   public Locale preferredLocale() { 
     Locale ret = Locale.newInstance(delegate.preferredLocale());
+    return ret;
+  }
+
+  /**
+   * Returns a map of named parameters as defined in path declaration with their actual values
+   * @return the map of named parameters
+   */
+  public Map<String,String> pathParams() { 
+    Map<String,String> ret = delegate.pathParams();
+    return ret;
+  }
+
+  /**
+   * Gets the value of a single path parameter
+   * @param name the name of parameter as defined in path declaration
+   * @return the actual value of the parameter or null if it doesn't exist
+   */
+  public String pathParam(String name) { 
+    String ret = delegate.pathParam(name);
     return ret;
   }
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/StaticHandler.java
@@ -18,6 +18,7 @@ package io.vertx.rxjava.ext.web.handler;
 
 import java.util.Map;
 import rx.Observable;
+import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava.ext.web.RoutingContext;
 import io.vertx.core.Handler;
 
@@ -210,6 +211,16 @@ public class StaticHandler implements Handler<RoutingContext> {
    */
   public StaticHandler setEnableRangeSupport(boolean enableRangeSupport) { 
     delegate.setEnableRangeSupport(enableRangeSupport);
+    return this;
+  }
+
+  /**
+   * Set HTTP2 push mapping be used for accelerate content delivery.
+   * @param http2PushMapping dependency mapping
+   * @return a reference to this, so the API can be used fluently
+   */
+  public StaticHandler setHTTP2PushMapping(JsonObject http2PushMapping) { 
+    delegate.setHTTP2PushMapping(http2PushMapping);
     return this;
   }
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/sstore/SessionStore.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/sstore/SessionStore.java
@@ -96,15 +96,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.delete(id, new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.delete(id, resultHandler);
   }
 
   /**
@@ -124,15 +116,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.put((io.vertx.ext.web.Session)session.getDelegate(), new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.put((io.vertx.ext.web.Session)session.getDelegate(), resultHandler);
   }
 
   /**
@@ -151,15 +135,7 @@ public class SessionStore {
    * @param resultHandler will be called with a result true/false, or a failure
    */
   public void clear(Handler<AsyncResult<Boolean>> resultHandler) { 
-    delegate.clear(new Handler<AsyncResult<java.lang.Boolean>>() {
-      public void handle(AsyncResult<java.lang.Boolean> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.clear(resultHandler);
   }
 
   /**
@@ -177,15 +153,7 @@ public class SessionStore {
    * @param resultHandler will be called with the number, or a failure
    */
   public void size(Handler<AsyncResult<Integer>> resultHandler) { 
-    delegate.size(new Handler<AsyncResult<java.lang.Integer>>() {
-      public void handle(AsyncResult<java.lang.Integer> ar) {
-        if (ar.succeeded()) {
-          resultHandler.handle(io.vertx.core.Future.succeededFuture(ar.result()));
-        } else {
-          resultHandler.handle(io.vertx.core.Future.failedFuture(ar.cause()));
-        }
-      }
-    });
+    delegate.size(resultHandler);
   }
 
   /**

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/RoutingContext.groovy
@@ -27,6 +27,7 @@ import io.vertx.groovy.ext.auth.User
 import io.vertx.groovy.core.buffer.Buffer
 import io.vertx.groovy.core.http.HttpServerResponse
 import io.vertx.core.http.HttpMethod
+import java.util.Map
 import io.vertx.core.json.JsonObject
 import io.vertx.core.Handler
 /**
@@ -453,6 +454,23 @@ public class RoutingContext {
    */
   public Locale preferredLocale() {
     def ret = InternalHelper.safeCreate(delegate.preferredLocale(), io.vertx.groovy.ext.web.Locale.class);
+    return ret;
+  }
+  /**
+   * Returns a map of named parameters as defined in path declaration with their actual values
+   * @return the map of named parameters
+   */
+  public Map<String, String> pathParams() {
+    def ret = delegate.pathParams();
+    return ret;
+  }
+  /**
+   * Gets the value of a single path parameter
+   * @param name the name of parameter as defined in path declaration
+   * @return the actual value of the parameter or null if it doesn't exist
+   */
+  public String pathParam(String name) {
+    def ret = delegate.pathParam(name);
     return ret;
   }
   private HttpServerRequest cached_0;

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/StaticHandler.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/StaticHandler.groovy
@@ -18,6 +18,7 @@ package io.vertx.groovy.ext.web.handler;
 import groovy.transform.CompileStatic
 import io.vertx.lang.groovy.InternalHelper
 import io.vertx.core.json.JsonObject
+import io.vertx.core.json.JsonObject
 import io.vertx.groovy.ext.web.RoutingContext
 import io.vertx.core.Handler
 /**
@@ -185,6 +186,15 @@ public class StaticHandler implements Handler<RoutingContext> {
    */
   public StaticHandler setEnableRangeSupport(boolean enableRangeSupport) {
     delegate.setEnableRangeSupport(enableRangeSupport);
+    return this;
+  }
+  /**
+   * Set HTTP2 push mapping be used for accelerate content delivery.
+   * @param http2PushMapping dependency mapping
+   * @return a reference to this, so the API can be used fluently
+   */
+  public StaticHandler setHTTP2PushMapping(Map<String, Object> http2PushMapping) {
+    delegate.setHTTP2PushMapping(http2PushMapping != null ? new io.vertx.core.json.JsonObject(http2PushMapping) : null);
     return this;
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.StaticHandlerImpl;
 
@@ -272,5 +273,14 @@ public interface StaticHandler extends Handler<RoutingContext> {
    */
   @Fluent
   StaticHandler setEnableRangeSupport(boolean enableRangeSupport);
+
+  /**
+   * Set HTTP2 push mapping be used for accelerate content delivery.
+   *
+   * @param http2PushMapping dependency mapping
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  StaticHandler setHTTP2PushMapping(JsonObject http2PushMapping);
 
 }

--- a/vertx-web/src/main/resources/vertx-web-js/routing_context.js
+++ b/vertx-web/src/main/resources/vertx-web-js/routing_context.js
@@ -639,6 +639,34 @@ var RoutingContext = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Returns a map of named parameters as defined in path declaration with their actual values
+
+   @public
+
+   @return {Array.<string>} the map of named parameters
+   */
+  this.pathParams = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnMap(j_routingContext["pathParams()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Gets the value of a single path parameter
+
+   @public
+   @param name {string} the name of parameter as defined in path declaration 
+   @return {string} the actual value of the parameter or null if it doesn't exist
+   */
+  this.pathParam = function(name) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'string') {
+      return j_routingContext["pathParam(java.lang.String)"](name);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web-js/static_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/static_handler.js
@@ -269,6 +269,21 @@ var StaticHandler = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Set HTTP2 push mapping be used for accelerate content delivery.
+
+   @public
+   @param http2PushMapping {Object} dependency mapping 
+   @return {StaticHandler} a reference to this, so the API can be used fluently
+   */
+  this.setHTTP2PushMapping = function(http2PushMapping) {
+    var __args = arguments;
+    if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+      j_staticHandler["setHTTP2PushMapping(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(http2PushMapping));
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/routing_context.rb
+++ b/vertx-web/src/main/resources/vertx-web/routing_context.rb
@@ -435,5 +435,22 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling preferred_locale()"
     end
+    #  Returns a map of named parameters as defined in path declaration with their actual values
+    # @return [Hash{String => String}] the map of named parameters
+    def path_params
+      if !block_given?
+        return Java::IoVertxLangRuby::Helper.adaptingMap(@j_del.java_method(:pathParams, []).call(), Proc.new { |val| ::Vertx::Util::Utils.from_object(val) }, Proc.new { |val| ::Vertx::Util::Utils.to_string(val) })
+      end
+      raise ArgumentError, "Invalid arguments when calling path_params()"
+    end
+    #  Gets the value of a single path parameter
+    # @param [String] name the name of parameter as defined in path declaration
+    # @return [String] the actual value of the parameter or null if it doesn't exist
+    def path_param(name=nil)
+      if name.class == String && !block_given?
+        return @j_del.java_method(:pathParam, [Java::java.lang.String.java_class]).call(name)
+      end
+      raise ArgumentError, "Invalid arguments when calling path_param(name)"
+    end
   end
 end

--- a/vertx-web/src/main/resources/vertx-web/static_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/static_handler.rb
@@ -183,5 +183,15 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling set_enable_range_support(enableRangeSupport)"
     end
+    #  Set HTTP2 push mapping be used for accelerate content delivery.
+    # @param [Hash{String => Object}] http2PushMapping dependency mapping
+    # @return [self]
+    def set_http2_push_mapping(http2PushMapping=nil)
+      if http2PushMapping.class == Hash && !block_given?
+        @j_del.java_method(:setHTTP2PushMapping, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(http2PushMapping))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling set_http2_push_mapping(http2PushMapping)"
+    end
   end
 end


### PR DESCRIPTION
This is some experimental webpush support on static handler.

The idea is that there is no magic behind the current code and it is backwards compatible, if and only if HTTP2 request is present then webpush will be performed.

An example app would be:

``` java
public class App extends AbstractVerticle {

  @Override
  public void start() {

    Router router = Router.router(vertx);
    router.route().handler(StaticHandler.create()
        .setHTTP2PushMapping(
          new JsonObject().put("index.html", 
            new JsonArray().add("script1.js").add("script2.js").add("script3.js"))));

    vertx.createHttpServer(new HttpServerOptions()
        .setSsl(true)
        .setUseAlpn(true)
        .setSslEngine(SSLEngine.JDK)
        .setPemKeyCertOptions(new PemKeyCertOptions()
            .setKeyPath("tls/server-key.pem")
            .setCertPath("tls/server-cert.pem")))
        .requestHandler(router::accept)
        .listen(8443);
  }
}
```

When a resource like:

``` html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>H2 push test</title>
    <script src="script1.js"></script>
    <script src="script2.js"></script>
    <script src="script3.js"></script>
</head>
<body>

</body>
</html>
```

Finally the 3 script content should be something like:

``` js
console.log('hello');
```

Is served then the 3 configured scripts are pushed if and only if the client does not contain the resource already and its validity is acceptable.

You will see in the developer tools that the request to the following 3 scripts are always served from the browser cache.
