### PR TITLE
Add Vary header when using caching and compression

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -106,6 +106,11 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * directory.
    */
   boolean DEFAULT_ROOT_FILESYSTEM_ACCESS = false;
+  
+  /**
+   * Default of whether vary header should be sent.
+   */
+  boolean DEFAULT_SEND_VARY_HEADER = true;
 
   /**
    * Create a handler using defaults
@@ -272,5 +277,14 @@ public interface StaticHandler extends Handler<RoutingContext> {
    */
   @Fluent
   StaticHandler setEnableRangeSupport(boolean enableRangeSupport);
+  
+  /**
+   * Set whether vary header should be sent with response.
+   *
+   * @param varyHeader true to sent vary header
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  StaticHandler setSendVaryHeader(boolean varyHeader);
 
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -69,6 +69,7 @@ public class StaticHandlerImpl implements StaticHandler {
   private int maxCacheSize = DEFAULT_MAX_CACHE_SIZE;
   private boolean rangeSupport = DEFAULT_RANGE_SUPPORT;
   private boolean allowRootFileSystemAccess = DEFAULT_ROOT_FILESYSTEM_ACCESS;
+  private boolean sendVaryHeader = DEFAULT_SEND_VARY_HEADER;
 
   // These members are all related to auto tuning of synchronous vs asynchronous file system access
   private static int NUM_SERVES_TUNING_FS_ACCESS = 1000;
@@ -113,6 +114,11 @@ public class StaticHandlerImpl implements StaticHandler {
       // We *do not use* etags and expires (since they do the same thing - redundant)
       headers.set("cache-control", "public, max-age=" + maxAgeSeconds);
       headers.set("last-modified", dateTimeFormatter.format(props.lastModifiedTime()));
+      // We send the vary header (for intermediate caches)
+      // (assumes that most will turn on compression when using static handler)
+      if (sendVaryHeader && request.headers().contains("accept-encoding")) {
+        headers.set("vary", "accept-encoding");
+      }
     }
 
     // date header is mandatory
@@ -496,6 +502,12 @@ public class StaticHandlerImpl implements StaticHandler {
   @Override
   public StaticHandler setMaxAvgServeTimeNs(long maxAvgServeTimeNanoSeconds) {
     this.maxAvgServeTimeNanoSeconds = maxAvgServeTimeNanoSeconds;
+    return this;
+  }
+  
+  @Override
+  public StaticHandler setSendVaryHeader(boolean sendVaryHeader) {
+    this.sendVaryHeader = sendVaryHeader;
     return this;
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -230,6 +230,25 @@ public class StaticHandlerTest extends WebTestBase {
     }, res -> {
     }, 200, "OK", "<html><body>Other page</body></html>");
   }
+  
+  @Test
+  public void testSendVaryAcceptEncodingHeader() throws Exception {
+    testRequest(HttpMethod.GET, "/otherpage.html", req -> {
+      req.putHeader("accept-encoding", "gzip");
+    }, res -> {
+      String vary = res.headers().get("vary");
+      assertNotNull(vary);
+      assertEquals("accept-encoding", vary);
+    }, 200, "OK", "<html><body>Other page</body></html>");
+  }
+  
+  @Test
+  public void testNoSendingOfVaryAcceptEncodingHeader() throws Exception {
+    testRequest(HttpMethod.GET, "/otherpage.html", null, res -> {
+      String vary = res.headers().get("vary");
+      assertNull(vary);
+    }, 200, "OK", "<html><body>Other page</body></html>");
+  }
 
   @Test
   public void testSetMaxAge() throws Exception {


### PR DESCRIPTION
I couldn't find out if it's possible to get the server options within `StaticHandler`.

So currently, the `Vary` header is send when the request contains an `Accept-Encoding`-header, assuming that when someone uses `StaticHandler`, compression is most likely also wanted.
