### PR TITLE
Percent sign is decoded twice

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -254,7 +254,7 @@ public class RouteImpl implements Route {
             try {
               for (int i = 0; i < groups.size(); i++) {
                 final String k = groups.get(i);
-                final String value = URLDecoder.decode(URLDecoder.decode(m.group("p" + i), "UTF-8"), "UTF-8");
+                final String value = URLDecoder.decode(m.group("p" + i), "UTF-8");
                 if (!request.params().contains(k)) {
                   params.put(k, value);
                 } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -772,6 +772,15 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testPercentEncoding() throws Exception {
+    router.route("/blah/:percenttext").handler(rc -> {
+      MultiMap params = rc.request().params();
+      rc.response().setStatusMessage(params.get("percenttext")).end();
+    });
+    testPattern("/blah/abc%25xyz", "abc%xyz");
+  }
+
+  @Test
   public void testPathParamsAreFulfilled() throws Exception {
     router.route("/blah/:abc/quux/:def/eep/:ghi").handler(rc -> {
       Map<String, String> params = rc.pathParams();


### PR DESCRIPTION
This is only a small fix to prevent parsing the path twice using `URLDecoder.decode`. This is introduced by #363 , and I don't think decoding twice is intended.