### PR TITLE
Disable template caching for development

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateEngineImpl.java
@@ -63,7 +63,7 @@ public class FreeMarkerTemplateEngineImpl extends CachingTemplateEngine<Template
   @Override
   public void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
     try {
-      Template template = cache.get(templateFileName);
+      Template template = isCachingEnabled() ? cache.get(templateFileName) : null;
       if (template == null) {
         // real compile
         synchronized (this) {
@@ -71,7 +71,9 @@ public class FreeMarkerTemplateEngineImpl extends CachingTemplateEngine<Template
           // Compile
           template = config.getTemplate(adjustLocation(templateFileName));
         }
-        cache.put(templateFileName, template);
+        if (isCachingEnabled()) {
+          cache.put(templateFileName, template);
+        }
       }
 
       Map<String, RoutingContext> variables = new HashMap<>(1);

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerTemplateTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.templ;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 import org.junit.Test;
 
 /**
@@ -36,6 +37,12 @@ public class FreeMarkerTemplateTest extends WebTestBase {
   public void testTemplateHandlerOnFileSystem() throws Exception {
     TemplateEngine engine = FreeMarkerTemplateEngine.create();
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-freemarker-template3.ftl", "Hello badger and fox\nRequest path is /test-freemarker-template3.ftl");
+  }
+
+  @Test
+  public void testTemplateHandlerOnClasspathDisableCaching() throws Exception {
+    System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+    testTemplateHandlerOnClasspath();
   }
 
   @Test

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
@@ -57,12 +57,14 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
   @Override
   public void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
     try {
-      Template template = cache.get(templateFileName);
+      Template template = isCachingEnabled() ? cache.get(templateFileName) : null;
       if (template == null) {
         synchronized (this) {
           loader.setVertx(context.vertx());
           template = handlebars.compile(templateFileName);
-          cache.put(templateFileName, template);
+          if (isCachingEnabled()) {
+            cache.put(templateFileName, template);
+          }
         }
       }
       handler.handle(Future.succeededFuture(Buffer.buffer(template.apply(context.data()))));

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.templ;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.TemplateHandler;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 import org.junit.Test;
 
 /**
@@ -36,6 +37,12 @@ public class HandlebarsTemplateTest extends WebTestBase {
   public void testTemplateOnFileSystem() throws Exception {
     TemplateEngine engine = HandlebarsTemplateEngine.create();
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-handlebars-template3.hbs", "Goodbye badger and fox");
+  }
+
+  @Test
+  public void testTemplateOnClasspathDisableCaching() throws Exception {
+    System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+    testTemplateOnClasspath();
   }
 
   @Test

--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
@@ -63,7 +63,7 @@ public class JadeTemplateEngineImpl extends CachingTemplateEngine<JadeTemplate> 
   @Override
   public void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
     try {
-      JadeTemplate template = cache.get(templateFileName);
+      JadeTemplate template = isCachingEnabled() ? cache.get(templateFileName) : null;
 
       if (template == null) {
         synchronized (this) {
@@ -71,7 +71,9 @@ public class JadeTemplateEngineImpl extends CachingTemplateEngine<JadeTemplate> 
           // Compile
           template = config.getTemplate(templateFileName);
         }
-        cache.put(templateFileName, template);
+        if (isCachingEnabled()) {
+          cache.put(templateFileName, template);
+        }
       }
       Map<String, Object> variables = new HashMap<>(1);
       variables.put("context", context);

--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
@@ -39,12 +39,16 @@ import java.util.Map;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class JadeTemplateEngineImpl extends CachingTemplateEngine<JadeTemplate> implements JadeTemplateEngine {
+  /* JadeConfiguration performs internal caching. Use this instead of calling isCachingEnabled() in constructor.
+   * Todo: Remove CachingTemplateEngine as parent class as jade4j's JadeConfiguration performs internal caching. */
+  private static final boolean ENABLE_CACHING = !Boolean.getBoolean(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME);
 
   private final JadeConfiguration config = new JadeConfiguration();
   private final JadeTemplateLoader loader = new JadeTemplateLoader();
 
   public JadeTemplateEngineImpl() {
     super(DEFAULT_TEMPLATE_EXTENSION, DEFAULT_MAX_CACHE_SIZE);
+    config.setCaching(ENABLE_CACHING);
     config.setTemplateLoader(loader);
   }
 

--- a/vertx-template-engines/vertx-web-templ-jade/src/test/java/io/vertx/ext/web/templ/JadeTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/test/java/io/vertx/ext/web/templ/JadeTemplateTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.templ;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 import org.junit.Test;
 
 /**
@@ -36,6 +37,12 @@ public class JadeTemplateTest extends WebTestBase {
   public void testTemplateHandlerOnFileSystem() throws Exception {
     TemplateEngine engine = JadeTemplateEngine.create();
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-jade-template3.jade", "<!DOCTYPE html><html><head><title>badger/test-jade-template3.jade</title></head><body></body></html>");
+  }
+
+  @Test
+  public void testTemplateHandlerOnClasspathDisableCaching() throws Exception {
+    System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+    testTemplateHandlerOnClasspath();
   }
 
   @Test

--- a/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/impl/MVELTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/impl/MVELTemplateEngineImpl.java
@@ -54,7 +54,7 @@ public class MVELTemplateEngineImpl extends CachingTemplateEngine<CompiledTempla
   @Override
   public void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
     try {
-      CompiledTemplate template = cache.get(templateFileName);
+      CompiledTemplate template = isCachingEnabled() ? cache.get(templateFileName) : null;
       if (template == null) {
         // real compile
         String loc = adjustLocation(templateFileName);
@@ -63,7 +63,9 @@ public class MVELTemplateEngineImpl extends CachingTemplateEngine<CompiledTempla
           throw new IllegalArgumentException("Cannot find template " + loc);
         }
         template = TemplateCompiler.compileTemplate(templateText);
-        cache.put(templateFileName, template);
+        if (isCachingEnabled()) {
+          cache.put(templateFileName, template);
+        }
       }
       Map<String, RoutingContext> variables = new HashMap<>(1);
       variables.put("context", context);

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/MVELTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/MVELTemplateTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.templ;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 import org.junit.Test;
 
 /**
@@ -36,6 +37,12 @@ public class MVELTemplateTest extends WebTestBase {
   public void testTemplateHandlerOnFileSystem() throws Exception {
     TemplateEngine engine = MVELTemplateEngine.create();
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-mvel-template3.templ", "Hello badger and fox\nRequest path is /test-mvel-template3.templ");
+  }
+
+  @Test
+  public void testTemplateHandlerOnClasspathDisableCaching() throws Exception {
+    System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+    testTemplateHandlerOnClasspath();
   }
 
   @Test

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -36,11 +36,19 @@ import io.vertx.ext.web.templ.PebbleTemplateEngine;
  */
 public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTemplate> implements PebbleTemplateEngine {
 
+  /* PebbleEngine performs internal caching. Use this instead of calling isCachingEnabled() in constructor.
+   * Todo: Remove CachingTemplateEngine as parent class as pebble's PebbleEngine performs internal caching. */
+  private static final boolean ENABLE_CACHING = !Boolean.getBoolean(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME);
+
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
     super(DEFAULT_TEMPLATE_EXTENSION, DEFAULT_MAX_CACHE_SIZE);
-    pebbleEngine = new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).build();
+    PebbleEngine.Builder builder = new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx));
+    if (!ENABLE_CACHING) {
+      builder.templateCache(null);
+    }
+    pebbleEngine = builder.build();
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -58,12 +58,14 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   @Override
   public void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler) {
     try {
-      PebbleTemplate template = cache.get(templateFileName);
+      PebbleTemplate template = isCachingEnabled() ? cache.get(templateFileName) : null;
       if (template == null) {
         // real compile
         final String loc = adjustLocation(templateFileName);
         template = pebbleEngine.getTemplate(loc);
-        cache.put(templateFileName, template);
+        if (isCachingEnabled()) {
+          cache.put(templateFileName, template);
+        }
       }
       final Map<String, Object> variables = new HashMap<>(1);
       variables.put("context", context);

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.TemplateHandler;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 
 /**
  * @author Dan Kristensen
@@ -39,6 +40,12 @@ public class PebbleTemplateTest extends WebTestBase {
 		final TemplateEngine engine = PebbleTemplateEngine.create(vertx);
 		testTemplateHandler(engine, "src/test/filesystemtemplates", "test-pebble-template3.peb",
 		        "Hello badger and foxRequest path is /test-pebble-template3.peb");
+	}
+
+	@Test
+	public void testTemplateHandlerOnClasspathDisableCaching() throws Exception {
+		System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+		testTemplateHandlerOnClasspath();
 	}
 
 	@Test

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/impl/ThymeleafTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/impl/ThymeleafTemplateEngineImpl.java
@@ -46,15 +46,23 @@ import java.util.Set;
  * @author <a href="http://matty.io">Matty Southall</a>
  */
 public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
+    private static final boolean ENABLE_CACHING = !Boolean.getBoolean(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME);
+
     private final TemplateEngine templateEngine = new TemplateEngine();
     private ResourceTemplateResolver templateResolver;
 
     public ThymeleafTemplateEngineImpl() {
         ResourceTemplateResolver templateResolver = new ResourceTemplateResolver();
+        templateResolver.setCacheable(ENABLE_CACHING);
         templateResolver.setTemplateMode(ThymeleafTemplateEngine.DEFAULT_TEMPLATE_MODE);
 
         this.templateResolver = templateResolver;
         this.templateEngine.setTemplateResolver(templateResolver);
+    }
+
+    @Override
+    public boolean isCachingEnabled() {
+        return ENABLE_CACHING;
     }
 
     @Override

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/java/io/vertx/ext/web/templ/ThymeleafTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/java/io/vertx/ext/web/templ/ThymeleafTemplateTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.templ;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 import org.junit.Test;
 
 /**
@@ -37,6 +38,12 @@ public class ThymeleafTemplateTest extends WebTestBase {
   public void testTemplateHandlerOnFileSystem() throws Exception {
     TemplateEngine engine = ThymeleafTemplateEngine.create();
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-thymeleaf-template3.html");
+  }
+
+  @Test
+  public void testTemplateHandlerOnClasspathDisableCaching() throws Exception {
+    System.setProperty(CachingTemplateEngine.DISABLE_TEMPL_CACHING_PROP_NAME, "true");
+    testTemplateHandlerOnClasspath();
   }
 
   private void testTemplateHandler(TemplateEngine engine, String directoryName, String templateName) throws Exception {

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/templ/TemplateEngine.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/templ/TemplateEngine.java
@@ -74,6 +74,16 @@ public class TemplateEngine {
     return handler;
   }
 
+  /**
+   * Returns true if the template engine caches template files. If false, then template files are freshly loaded each
+   * time they are used.
+   * @return True if template files are cached; otherwise, false.
+   */
+  public boolean isCachingEnabled() { 
+    boolean ret = delegate.isCachingEnabled();
+    return ret;
+  }
+
 
   public static TemplateEngine newInstance(io.vertx.ext.web.templ.TemplateEngine arg) {
     return arg != null ? new TemplateEngine(arg) : null;

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/templ/TemplateEngine.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/templ/TemplateEngine.groovy
@@ -53,4 +53,13 @@ public class TemplateEngine {
       }
     } : null);
   }
+  /**
+   * Returns true if the template engine caches template files. If false, then template files are freshly loaded each
+   * time they are used.
+   * @return True if template files are cached; otherwise, false.
+   */
+  public boolean isCachingEnabled() {
+    def ret = delegate.isCachingEnabled();
+    return ret;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/TemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/TemplateEngine.java
@@ -39,4 +39,14 @@ public interface TemplateEngine {
    * @param handler  the handler that will be called with a result containing the buffer or a failure.
    */
   void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler);
+
+  /**
+   * Returns true if the template engine caches template files. If false, then template files are freshly loaded each
+   * time they are used.
+   *
+   * @return True if template files are cached; otherwise, false.
+   */
+  default boolean isCachingEnabled() {
+    return false;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
@@ -26,6 +26,10 @@ import java.util.Objects;
  */
 public abstract class CachingTemplateEngine<T> implements TemplateEngine {
 
+  public static final String DISABLE_TEMPL_CACHING_PROP_NAME = "vertx.web.disableTemplCaching";
+
+  private static final boolean ENABLE_CACHING = !Boolean.getBoolean(DISABLE_TEMPL_CACHING_PROP_NAME);
+
   protected final ConcurrentLRUCache<String, T> cache;
   protected String extension;
 
@@ -36,6 +40,11 @@ public abstract class CachingTemplateEngine<T> implements TemplateEngine {
     }
     doSetExtension(ext);
     this.cache = new ConcurrentLRUCache<>(maxCacheSize);
+  }
+
+  @Override
+  public boolean isCachingEnabled() {
+      return ENABLE_CACHING;
   }
 
   protected String adjustLocation(String location) {

--- a/vertx-web/src/main/resources/vertx-web-js/template_engine.js
+++ b/vertx-web/src/main/resources/vertx-web-js/template_engine.js
@@ -56,6 +56,21 @@ var TemplateEngine = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Returns true if the template engine caches template files. If false, then template files are freshly loaded each
+   time they are used.
+
+   @public
+
+   @return {boolean} True if template files are cached; otherwise, false.
+   */
+  this.isCachingEnabled = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_templateEngine["isCachingEnabled()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/template_engine.rb
+++ b/vertx-web/src/main/resources/vertx-web/template_engine.rb
@@ -28,5 +28,14 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling render(context,templateFileName)"
     end
+    #  Returns true if the template engine caches template files. If false, then template files are freshly loaded each
+    #  time they are used.
+    # @return [true,false] True if template files are cached; otherwise, false.
+    def caching_enabled?
+      if !block_given?
+        return @j_del.java_method(:isCachingEnabled, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling caching_enabled?()"
+    end
   end
 end


### PR DESCRIPTION
Attempts to resolve #417 .

My approach is to detect a system property (`-Dvertx.web.disableTemplCaching=true`) to disable template caching via the CLI. This plays well during development. I avoided putting in `setCachingEnabled(boolean)` on the TemplateEngines as I couldn't think of a use case when we would want to toggle template caching throughout the lifetime of the server. However, if that is desired, then the basic logic is pretty much there to implement that.

Similar to how the Thymeleaf library implements internal caching of templates, the Jade and Pebble libraries perform internal caching. I left the Jade and Pebble TemplateEngine implementations as derived classes of CachingTemplateEngine to avoid breaking backward compatibility, but in the future, these can look more like the Thymeleaf TemplateEngine implementation.
