### PR TITLE
Fix #431: Fix route resolving

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -59,9 +59,7 @@ public class Utils extends io.vertx.core.impl.Utils {
       for (int i = 0; i < path.length(); i++) {
         char c = path.charAt(i);
 
-        if (c == '+') {
-          result.append(' ');
-        } else if (c == '/') {
+        if (c == '/') {
           if (i == 0 || result.charAt(result.length() - 1) != '/')
             result.append(c);
         } else if (urldecode && c == '%') {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1349,6 +1349,14 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testGetWithPlusPath() throws Exception {
+    router.get("/some+path/").handler(rc -> {
+      rc.response().setStatusMessage("foo").end();
+    });
+    testRequest(HttpMethod.GET, "/some+path/", 200, "foo");
+  }
+
+  @Test
   public void testGetWithPathBegin() throws Exception {
     router.get("/somepath/*").handler(rc -> {
       rc.response().setStatusMessage("foo").end();

--- a/vertx-web/src/test/java/io/vertx/ext/web/UtilsTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/UtilsTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web;
 import io.vertx.ext.web.impl.Utils;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -39,8 +40,12 @@ public class UtilsTest {
   }
 
   @Test
-  public void testPathWithSpaces1() throws Exception {
-    assertEquals("/foo blah/eek", Utils.normalisePath("/foo+blah/eek"));
+  public void testPathSubDelims() throws Exception {
+    List<String> subDelims = Arrays.asList("!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "=");
+    for(String character : subDelims) {
+      String path = "/foo" + character + "blah/eek";
+      assertEquals(path, Utils.normalisePath(path));
+    }
   }
 
   @Test


### PR DESCRIPTION
Previously path normalisation did also affect the '+' characters. Those characters must not be normalised since those are allowed by RFC3986 for url fragments.

I have signed the CLA and ran all tests in vert.x web.

Signed-off-by: Johannes Schüth <j.schueth@gentics.com>