### PR TITLE
Serialization of the lastAccessed session property

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -129,6 +129,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     byte[] bytes = id.getBytes(UTF8);
     buff.appendInt(bytes.length).appendBytes(bytes);
     buff.appendLong(timeout);
+    buff.appendLong(lastAccessed);
     Buffer dataBuf = writeDataToBuffer();
     buff.appendBuffer(dataBuf);
   }
@@ -141,6 +142,8 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     pos += len;
     id = new String(bytes, UTF8);
     timeout = buffer.getLong(pos);
+    pos += 8;
+    lastAccessed = buffer.getLong(pos);
     pos += 8;
     pos = readDataFromBuffer(pos, buffer);
     return pos;

--- a/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
@@ -137,6 +137,8 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
   public void testSessionSerializationNullPrincipal() {
     long timeout = 123;
     SessionImpl session = (SessionImpl)store.createSession(timeout);
+    session.setAccessed();
+    long lastAccessed = session.lastAccessed();    
     stuffSession(session);
     checkSession(session);
     Buffer buffer = Buffer.buffer();
@@ -145,6 +147,7 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
     session2.readFromBuffer(0, buffer);
     checkSession(session2);
     assertEquals(timeout, session2.timeout());
+    assertEquals(lastAccessed, session2.lastAccessed());
     assertEquals(session.id(), session2.id());
   }
 


### PR DESCRIPTION
In a clustered environment, the lastAccessed property of the session is not being serialized. The session times out even if the user touches the session.