### PR TITLE
Multiple methods matching + route composition

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -75,7 +75,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -84,7 +84,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile 'io.vertx:vertx-web:3.3.3'
+  compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT'
 }
 ----
 
@@ -272,6 +272,20 @@ By default, any blocking handlers executed on the same context (e.g. the same ve
 means the next one won't be executed until the previous one has completed. If you don't care about orderering and
 don't mind your blocking handlers executing in parallel you can set the blocking handler specifying `ordered` as
 false using `link:../../groovydoc/io/vertx/groovy/ext/web/Route.html#blockingHandler(io.vertx.core.Handler,%20boolean)[blockingHandler]`.
+
+Note, if you need to process multipart form data from a blocking handler, you MUST use a non-blocking handler
+      FIRST in order to call `setExpectMultipart(true)`. Here is an example:
+
+[source,groovy]
+----
+router.post("/some/endpoint").handler({ ctx ->
+  ctx.request().setExpectMultipart(true)
+  ctx.next()
+}).blockingHandler({ ctx ->
+  // ... Do some blocking operation
+})
+
+----
 
 == Routing by exact path
 
@@ -1926,7 +1940,7 @@ router.getWithRegex(".+\\.hbs").handler(handler)
 === MVEL template engine
 
 To use MVEL, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-mvel:3.3.3`. Create an instance of the MVEL template engine using:
+`io.vertx:vertx-web-templ-mvel:3.4.0-SNAPSHOT`. Create an instance of the MVEL template engine using:
 `io.vertx.ext.web.templ.MVELTemplateEngine#create()`
 
 When using the MVEL template engine, it will by default look for
@@ -1952,7 +1966,7 @@ MVEL templates.
 === Jade template engine
 
 To use the Jade template engine, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-jade:3.3.3`. Create an instance of the Jade template engine using:
+`io.vertx:vertx-web-templ-jade:3.4.0-SNAPSHOT`. Create an instance of the Jade template engine using:
 `io.vertx.ext.web.templ.JadeTemplateEngine#create()`.
 
 When using the Jade template engine, it will by default look for
@@ -1978,7 +1992,7 @@ Jade templates.
 === Handlebars template engine
 
 To use Handlebars, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-handlebars:3.3.3`. Create an instance of the Handlebars template engine
+`io.vertx:vertx-web-templ-handlebars:3.4.0-SNAPSHOT`. Create an instance of the Handlebars template engine
 using: `io.vertx.ext.web.templ.HandlebarsTemplateEngine#create()`.
 
 When using the Handlebars template engine, it will by default look for
@@ -2017,7 +2031,7 @@ handlebars templates.
 === Thymeleaf template engine
 
 To use Thymeleaf, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-thymeleaf:3.3.3`. Create an instance of the Thymeleaf template engine
+`io.vertx:vertx-web-templ-thymeleaf:3.4.0-SNAPSHOT`. Create an instance of the Thymeleaf template engine
 using: `io.vertx.ext.web.templ.ThymeleafTemplateEngine#create()`.
 
 When using the Thymeleaf template engine, it will by default look for
@@ -2045,7 +2059,7 @@ Thymeleaf templates.
 === Apache FreeMarker template engine
 
 To use Apache FreeMarker, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-freemarker:3.3.3`. Create an instance of the Apache FreeMarker template engine
+`io.vertx:vertx-web-templ-freemarker:3.4.0-SNAPSHOT`. Create an instance of the Apache FreeMarker template engine
 using: `io.vertx.ext.web.templ.FreeMarkerTemplateEngine#create()`.
 
 When using the Apache FreeMarker template engine, it will by default look for
@@ -2333,7 +2347,7 @@ You can retrieve the client library using a dependency manager:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
   <classifier>client</classifier>
   <type>js</type>
 </dependency>
@@ -2343,7 +2357,7 @@ You can retrieve the client library using a dependency manager:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-web:3.3.3:client'
+compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT:client'
 ----
 
 The library is also available on https://www.npmjs.com/package/vertx3-eventbus-client[NPM] and on

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -75,7 +75,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -84,7 +84,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile 'io.vertx:vertx-web:3.3.3'
+  compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT'
 }
 ----
 
@@ -259,6 +259,19 @@ By default, any blocking handlers executed on the same context (e.g. the same ve
 means the next one won't be executed until the previous one has completed. If you don't care about orderering and
 don't mind your blocking handlers executing in parallel you can set the blocking handler specifying `ordered` as
 false using `link:../../apidocs/io/vertx/ext/web/Route.html#blockingHandler-io.vertx.core.Handler-boolean-[blockingHandler]`.
+
+Note, if you need to process multipart form data from a blocking handler, you MUST use a non-blocking handler
+      FIRST in order to call `setExpectMultipart(true)`. Here is an example:
+
+[source,java]
+----
+router.post("/some/endpoint").handler(ctx -> {
+  ctx.request().setExpectMultipart(true);
+  ctx.next();
+}).blockingHandler(ctx -> {
+  // ... Do some blocking operation
+});
+----
 
 == Routing by exact path
 
@@ -1732,7 +1745,7 @@ router.getWithRegex(".+\\.hbs").handler(handler);
 === MVEL template engine
 
 To use MVEL, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-mvel:3.3.3`. Create an instance of the MVEL template engine using:
+`io.vertx:vertx-web-templ-mvel:3.4.0-SNAPSHOT`. Create an instance of the MVEL template engine using:
 `io.vertx.ext.web.templ.MVELTemplateEngine#create()`
 
 When using the MVEL template engine, it will by default look for
@@ -1758,7 +1771,7 @@ MVEL templates.
 === Jade template engine
 
 To use the Jade template engine, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-jade:3.3.3`. Create an instance of the Jade template engine using:
+`io.vertx:vertx-web-templ-jade:3.4.0-SNAPSHOT`. Create an instance of the Jade template engine using:
 `io.vertx.ext.web.templ.JadeTemplateEngine#create()`.
 
 When using the Jade template engine, it will by default look for
@@ -1784,7 +1797,7 @@ Jade templates.
 === Handlebars template engine
 
 To use Handlebars, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-handlebars:3.3.3`. Create an instance of the Handlebars template engine
+`io.vertx:vertx-web-templ-handlebars:3.4.0-SNAPSHOT`. Create an instance of the Handlebars template engine
 using: `io.vertx.ext.web.templ.HandlebarsTemplateEngine#create()`.
 
 When using the Handlebars template engine, it will by default look for
@@ -1819,7 +1832,7 @@ handlebars templates.
 === Thymeleaf template engine
 
 To use Thymeleaf, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-thymeleaf:3.3.3`. Create an instance of the Thymeleaf template engine
+`io.vertx:vertx-web-templ-thymeleaf:3.4.0-SNAPSHOT`. Create an instance of the Thymeleaf template engine
 using: `io.vertx.ext.web.templ.ThymeleafTemplateEngine#create()`.
 
 When using the Thymeleaf template engine, it will by default look for
@@ -1847,7 +1860,7 @@ Thymeleaf templates.
 === Apache FreeMarker template engine
 
 To use Apache FreeMarker, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-freemarker:3.3.3`. Create an instance of the Apache FreeMarker template engine
+`io.vertx:vertx-web-templ-freemarker:3.4.0-SNAPSHOT`. Create an instance of the Apache FreeMarker template engine
 using: `io.vertx.ext.web.templ.FreeMarkerTemplateEngine#create()`.
 
 When using the Apache FreeMarker template engine, it will by default look for
@@ -2115,7 +2128,7 @@ You can retrieve the client library using a dependency manager:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
   <classifier>client</classifier>
   <type>js</type>
 </dependency>
@@ -2125,7 +2138,7 @@ You can retrieve the client library using a dependency manager:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-web:3.3.3:client'
+compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT:client'
 ----
 
 The library is also available on https://www.npmjs.com/package/vertx3-eventbus-client[NPM] and on

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -75,7 +75,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -84,7 +84,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile 'io.vertx:vertx-web:3.3.3'
+  compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT'
 }
 ----
 
@@ -272,6 +272,20 @@ By default, any blocking handlers executed on the same context (e.g. the same ve
 means the next one won't be executed until the previous one has completed. If you don't care about orderering and
 don't mind your blocking handlers executing in parallel you can set the blocking handler specifying `ordered` as
 false using `link:../../jsdoc/module-vertx-web-js_route-Route.html#blockingHandler[blockingHandler]`.
+
+Note, if you need to process multipart form data from a blocking handler, you MUST use a non-blocking handler
+      FIRST in order to call `setExpectMultipart(true)`. Here is an example:
+
+[source,js]
+----
+router.post("/some/endpoint").handler(function (ctx) {
+  ctx.request().setExpectMultipart(true);
+  ctx.next();
+}).blockingHandler(function (ctx) {
+  // ... Do some blocking operation
+});
+
+----
 
 == Routing by exact path
 
@@ -1922,7 +1936,7 @@ router.getWithRegex(".+\\.hbs").handler(handler.handle);
 === MVEL template engine
 
 To use MVEL, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-mvel:3.3.3`. Create an instance of the MVEL template engine using:
+`io.vertx:vertx-web-templ-mvel:3.4.0-SNAPSHOT`. Create an instance of the MVEL template engine using:
 `io.vertx.ext.web.templ.MVELTemplateEngine#create()`
 
 When using the MVEL template engine, it will by default look for
@@ -1948,7 +1962,7 @@ MVEL templates.
 === Jade template engine
 
 To use the Jade template engine, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-jade:3.3.3`. Create an instance of the Jade template engine using:
+`io.vertx:vertx-web-templ-jade:3.4.0-SNAPSHOT`. Create an instance of the Jade template engine using:
 `io.vertx.ext.web.templ.JadeTemplateEngine#create()`.
 
 When using the Jade template engine, it will by default look for
@@ -1974,7 +1988,7 @@ Jade templates.
 === Handlebars template engine
 
 To use Handlebars, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-handlebars:3.3.3`. Create an instance of the Handlebars template engine
+`io.vertx:vertx-web-templ-handlebars:3.4.0-SNAPSHOT`. Create an instance of the Handlebars template engine
 using: `io.vertx.ext.web.templ.HandlebarsTemplateEngine#create()`.
 
 When using the Handlebars template engine, it will by default look for
@@ -2013,7 +2027,7 @@ handlebars templates.
 === Thymeleaf template engine
 
 To use Thymeleaf, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-thymeleaf:3.3.3`. Create an instance of the Thymeleaf template engine
+`io.vertx:vertx-web-templ-thymeleaf:3.4.0-SNAPSHOT`. Create an instance of the Thymeleaf template engine
 using: `io.vertx.ext.web.templ.ThymeleafTemplateEngine#create()`.
 
 When using the Thymeleaf template engine, it will by default look for
@@ -2041,7 +2055,7 @@ Thymeleaf templates.
 === Apache FreeMarker template engine
 
 To use Apache FreeMarker, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-freemarker:3.3.3`. Create an instance of the Apache FreeMarker template engine
+`io.vertx:vertx-web-templ-freemarker:3.4.0-SNAPSHOT`. Create an instance of the Apache FreeMarker template engine
 using: `io.vertx.ext.web.templ.FreeMarkerTemplateEngine#create()`.
 
 When using the Apache FreeMarker template engine, it will by default look for
@@ -2330,7 +2344,7 @@ You can retrieve the client library using a dependency manager:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
   <classifier>client</classifier>
   <type>js</type>
 </dependency>
@@ -2340,7 +2354,7 @@ You can retrieve the client library using a dependency manager:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-web:3.3.3:client'
+compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT:client'
 ----
 
 The library is also available on https://www.npmjs.com/package/vertx3-eventbus-client[NPM] and on

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -75,7 +75,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -84,7 +84,7 @@ To use vert.x web, add the following dependency to the _dependencies_ section of
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile 'io.vertx:vertx-web:3.3.3'
+  compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT'
 }
 ----
 
@@ -272,6 +272,20 @@ By default, any blocking handlers executed on the same context (e.g. the same ve
 means the next one won't be executed until the previous one has completed. If you don't care about orderering and
 don't mind your blocking handlers executing in parallel you can set the blocking handler specifying `ordered` as
 false using `link:../../yardoc/VertxWeb/Route.html#blocking_handler-instance_method[blockingHandler]`.
+
+Note, if you need to process multipart form data from a blocking handler, you MUST use a non-blocking handler
+      FIRST in order to call `setExpectMultipart(true)`. Here is an example:
+
+[source,ruby]
+----
+router.post("/some/endpoint").handler() { |ctx|
+  ctx.request().set_expect_multipart(true)
+  ctx.next()
+}.blocking_handler() { |ctx|
+  # ... Do some blocking operation
+}
+
+----
 
 == Routing by exact path
 
@@ -1922,7 +1936,7 @@ router.get_with_regex(".+\\.hbs").handler(&handler.method(:handle))
 === MVEL template engine
 
 To use MVEL, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-mvel:3.3.3`. Create an instance of the MVEL template engine using:
+`io.vertx:vertx-web-templ-mvel:3.4.0-SNAPSHOT`. Create an instance of the MVEL template engine using:
 `io.vertx.ext.web.templ.MVELTemplateEngine#create()`
 
 When using the MVEL template engine, it will by default look for
@@ -1948,7 +1962,7 @@ MVEL templates.
 === Jade template engine
 
 To use the Jade template engine, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-jade:3.3.3`. Create an instance of the Jade template engine using:
+`io.vertx:vertx-web-templ-jade:3.4.0-SNAPSHOT`. Create an instance of the Jade template engine using:
 `io.vertx.ext.web.templ.JadeTemplateEngine#create()`.
 
 When using the Jade template engine, it will by default look for
@@ -1974,7 +1988,7 @@ Jade templates.
 === Handlebars template engine
 
 To use Handlebars, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-handlebars:3.3.3`. Create an instance of the Handlebars template engine
+`io.vertx:vertx-web-templ-handlebars:3.4.0-SNAPSHOT`. Create an instance of the Handlebars template engine
 using: `io.vertx.ext.web.templ.HandlebarsTemplateEngine#create()`.
 
 When using the Handlebars template engine, it will by default look for
@@ -2013,7 +2027,7 @@ handlebars templates.
 === Thymeleaf template engine
 
 To use Thymeleaf, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-thymeleaf:3.3.3`. Create an instance of the Thymeleaf template engine
+`io.vertx:vertx-web-templ-thymeleaf:3.4.0-SNAPSHOT`. Create an instance of the Thymeleaf template engine
 using: `io.vertx.ext.web.templ.ThymeleafTemplateEngine#create()`.
 
 When using the Thymeleaf template engine, it will by default look for
@@ -2041,7 +2055,7 @@ Thymeleaf templates.
 === Apache FreeMarker template engine
 
 To use Apache FreeMarker, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-freemarker:3.3.3`. Create an instance of the Apache FreeMarker template engine
+`io.vertx:vertx-web-templ-freemarker:3.4.0-SNAPSHOT`. Create an instance of the Apache FreeMarker template engine
 using: `io.vertx.ext.web.templ.FreeMarkerTemplateEngine#create()`.
 
 When using the Apache FreeMarker template engine, it will by default look for
@@ -2330,7 +2344,7 @@ You can retrieve the client library using a dependency manager:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
   <classifier>client</classifier>
   <type>js</type>
 </dependency>
@@ -2340,7 +2354,7 @@ You can retrieve the client library using a dependency manager:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-web:3.3.3:client'
+compile 'io.vertx:vertx-web:3.4.0-SNAPSHOT:client'
 ----
 
 The library is also available on https://www.npmjs.com/package/vertx3-eventbus-client[NPM] and on

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Route.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Route.java
@@ -208,6 +208,15 @@ public class Route {
     return this;
   }
 
+  public Route then(Handler<RoutingContext> handler) { 
+    Route ret = Route.newInstance(delegate.then(new Handler<io.vertx.ext.web.RoutingContext>() {
+      public void handle(io.vertx.ext.web.RoutingContext event) {
+        handler.handle(RoutingContext.newInstance(event));
+      }
+    }));
+    return ret;
+  }
+
   /**
    * If true then the normalised request path will be used when routing (e.g. removing duplicate /)
    * Default is true

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Router.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/Router.java
@@ -22,6 +22,7 @@ import io.vertx.rxjava.core.http.HttpServerRequest;
 import java.util.List;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava.core.Vertx;
+import java.util.Set;
 import io.vertx.core.Handler;
 
 /**
@@ -83,6 +84,17 @@ public class Router {
    */
   public Route route(HttpMethod method, String path) { 
     Route ret = Route.newInstance(delegate.route(method, path));
+    return ret;
+  }
+
+  /**
+   * Add a route that matches the specified HTTP methods and path
+   * @param methods the HTTP methods to match
+   * @param path URI paths that begin with this path will match
+   * @return the route
+   */
+  public Route routes(Set<HttpMethod> methods, String path) { 
+    Route ret = Route.newInstance(delegate.routes(methods, path));
     return ret;
   }
 

--- a/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/generated/io/vertx/rxjava/ext/web/handler/StaticHandler.java
@@ -213,6 +213,16 @@ public class StaticHandler implements Handler<RoutingContext> {
     return this;
   }
 
+  /**
+   * Set whether vary header should be sent with response.
+   * @param varyHeader true to sent vary header
+   * @return a reference to this, so the API can be used fluently
+   */
+  public StaticHandler setSendVaryHeader(boolean varyHeader) { 
+    delegate.setSendVaryHeader(varyHeader);
+    return this;
+  }
+
 
   public static StaticHandler newInstance(io.vertx.ext.web.handler.StaticHandler arg) {
     return arg != null ? new StaticHandler(arg) : null;

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Route.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Route.groovy
@@ -186,6 +186,14 @@ public class Route {
     delegate.enable();
     return this;
   }
+  public Route then(Handler<RoutingContext> handler) {
+    def ret = InternalHelper.safeCreate(delegate.then(handler != null ? new Handler<io.vertx.ext.web.RoutingContext>(){
+      public void handle(io.vertx.ext.web.RoutingContext event) {
+        handler.handle(InternalHelper.safeCreate(event, io.vertx.groovy.ext.web.RoutingContext.class));
+      }
+    } : null), io.vertx.groovy.ext.web.Route.class);
+    return ret;
+  }
   /**
    * If true then the normalised request path will be used when routing (e.g. removing duplicate /)
    * Default is true

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Router.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/Router.groovy
@@ -22,6 +22,7 @@ import io.vertx.groovy.core.http.HttpServerRequest
 import java.util.List
 import io.vertx.core.http.HttpMethod
 import io.vertx.groovy.core.Vertx
+import java.util.Set
 import io.vertx.core.Handler
 /**
  * A router receives request from an {@link io.vertx.groovy.core.http.HttpServer} and routes it to the first matching
@@ -72,6 +73,16 @@ public class Router {
    */
   public Route route(HttpMethod method, String path) {
     def ret = InternalHelper.safeCreate(delegate.route(method, path), io.vertx.groovy.ext.web.Route.class);
+    return ret;
+  }
+  /**
+   * Add a route that matches the specified HTTP methods and path
+   * @param methods the HTTP methods to match
+   * @param path URI paths that begin with this path will match
+   * @return the route
+   */
+  public Route routes(Set<HttpMethod> methods, String path) {
+    def ret = InternalHelper.safeCreate(delegate.routes(methods != null ? (Set)methods.collect({it}) as Set : null, path), io.vertx.groovy.ext.web.Route.class);
     return ret;
   }
   /**

--- a/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/StaticHandler.groovy
+++ b/vertx-web/src/main/groovy/io/vertx/groovy/ext/web/handler/StaticHandler.groovy
@@ -187,4 +187,13 @@ public class StaticHandler implements Handler<RoutingContext> {
     delegate.setEnableRangeSupport(enableRangeSupport);
     return this;
   }
+  /**
+   * Set whether vary header should be sent with response.
+   * @param varyHeader true to sent vary header
+   * @return a reference to this, so the API can be used fluently
+   */
+  public StaticHandler setSendVaryHeader(boolean varyHeader) {
+    delegate.setSendVaryHeader(varyHeader);
+    return this;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -166,6 +166,8 @@ public interface Route {
   @Fluent
   Route enable();
 
+  Route then(Handler<RoutingContext> handler);
+
   /**
    * If true then the normalised request path will be used when routing (e.g. removing duplicate /)
    * Default is true

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
@@ -26,6 +27,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.impl.RouterImpl;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A router receives request from an {@link io.vertx.core.http.HttpServer} and routes it to the first matching
@@ -73,6 +75,28 @@ public interface Router {
    * @return the route
    */
   Route route(HttpMethod method, String path);
+
+  /**
+   * Add a route that matches the specified HTTP methods and path
+   *
+   * @param methods the HTTP methods to match
+   * @param path  URI paths that begin with this path will match
+   *
+   * @return the route
+   */
+  Route routes(Set<HttpMethod> methods, String path);
+
+  /**
+   * Add a route that matches the specified HTTP methods and path
+   * (utility function for java users)
+   *
+   * @param methods the HTTP methods to match
+   * @param path  URI paths that begin with this path will match
+   *
+   * @return the route
+   */
+  @GenIgnore
+  Route routes(String path, HttpMethod... methods);
 
   /**
    * Add a route that matches the specified path

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -68,6 +68,13 @@ public class RouteImpl implements Route {
     setPath(path);
   }
 
+  RouteImpl(RouterImpl router, int order, Collection<HttpMethod> methods, String path) {
+    this(router, order);
+    this.methods.addAll(methods);
+    checkPath(path);
+    setPath(path);
+  }
+
   RouteImpl(RouterImpl router, int order, String path) {
     this(router, order);
     checkPath(path);
@@ -176,6 +183,11 @@ public class RouteImpl implements Route {
   public synchronized Route enable() {
     enabled = true;
     return this;
+  }
+
+  @Override
+  public synchronized Route then(Handler<RoutingContext> handler) {
+    return router.routes(this.path, this.methods.toArray(new HttpMethod[0])).handler(handler);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -90,6 +90,16 @@ public class RouterImpl implements Router {
   }
 
   @Override
+  public Route routes(String path, HttpMethod... methods) {
+    return new RouteImpl(this, orderSequence.getAndIncrement(), Arrays.asList(methods), path);
+  }
+
+  @Override
+  public Route routes(Set<HttpMethod> methods, String path) {
+    return new RouteImpl(this, orderSequence.getAndIncrement(), methods, path);
+  }
+
+  @Override
   public Route route(String path) {
     return new RouteImpl(this, orderSequence.getAndIncrement(), path);
   }

--- a/vertx-web/src/main/resources/vertx-web-js/route.js
+++ b/vertx-web/src/main/resources/vertx-web-js/route.js
@@ -255,6 +255,21 @@ var Route = function(j_val) {
   };
 
   /**
+
+   @public
+   @param handler {function} 
+   @return {Route}
+   */
+  this.then = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_route["then(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(jVal, RoutingContext));
+    }), Route);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    If true then the normalised request path will be used when routing (e.g. removing duplicate /)
    Default is true
 

--- a/vertx-web/src/main/resources/vertx-web-js/router.js
+++ b/vertx-web/src/main/resources/vertx-web-js/router.js
@@ -69,6 +69,21 @@ var Router = function(j_val) {
   };
 
   /**
+   Add a route that matches the specified HTTP methods and path
+
+   @public
+   @param methods {Array.<Object>} the HTTP methods to match 
+   @param path {string} URI paths that begin with this path will match 
+   @return {Route} the route
+   */
+  this.routes = function(methods, path) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'string') {
+      return utils.convReturnVertxGen(j_router["routes(java.util.Set,java.lang.String)"](utils.convParamSetEnum(methods, function(val) { return Packages.io.vertx.core.http.HttpMethod.valueOf(val); }), path), Route);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    Add a route that matches the specified HTTP method and path regex
 
    @public

--- a/vertx-web/src/main/resources/vertx-web-js/static_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/static_handler.js
@@ -269,6 +269,21 @@ var StaticHandler = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Set whether vary header should be sent with response.
+
+   @public
+   @param varyHeader {boolean} true to sent vary header 
+   @return {StaticHandler} a reference to this, so the API can be used fluently
+   */
+  this.setSendVaryHeader = function(varyHeader) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] ==='boolean') {
+      j_staticHandler["setSendVaryHeader(boolean)"](varyHeader);
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/route.rb
+++ b/vertx-web/src/main/resources/vertx-web/route.rb
@@ -159,6 +159,14 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling enable()"
     end
+    # @yield 
+    # @return [::VertxWeb::Route]
+    def then
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:then, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(::Vertx::Util::Utils.safe_create(event,::VertxWeb::RoutingContext)) })),::VertxWeb::Route)
+      end
+      raise ArgumentError, "Invalid arguments when calling then()"
+    end
     #  If true then the normalised request path will be used when routing (e.g. removing duplicate /)
     #  Default is true
     # @param [true,false] useNormalisedPath use normalised path for routing?

--- a/vertx-web/src/main/resources/vertx-web/router.rb
+++ b/vertx-web/src/main/resources/vertx-web/router.rb
@@ -58,6 +58,16 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling route(param_1,param_2)"
     end
+    #  Add a route that matches the specified HTTP methods and path
+    # @param [Set<:OPTIONS,:GET,:HEAD,:POST,:PUT,:DELETE,:TRACE,:CONNECT,:PATCH,:OTHER>] methods the HTTP methods to match
+    # @param [String] path URI paths that begin with this path will match
+    # @return [::VertxWeb::Route] the route
+    def routes(methods=nil,path=nil)
+      if methods.class == Set && path.class == String && !block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:routes, [Java::JavaUtil::Set.java_class,Java::java.lang.String.java_class]).call(Java::JavaUtil::LinkedHashSet.new(methods.map { |element| Java::IoVertxCoreHttp::HttpMethod.valueOf(element) }),path),::VertxWeb::Route)
+      end
+      raise ArgumentError, "Invalid arguments when calling routes(methods,path)"
+    end
     #  Add a route that matches the specified HTTP method and path regex
     # @overload routeWithRegex(regex)
     #   @param [String] regex URI paths that begin with a match for this regex will match

--- a/vertx-web/src/main/resources/vertx-web/static_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/static_handler.rb
@@ -183,5 +183,15 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling set_enable_range_support(enableRangeSupport)"
     end
+    #  Set whether vary header should be sent with response.
+    # @param [true,false] varyHeader true to sent vary header
+    # @return [self]
+    def set_send_vary_header(varyHeader=nil)
+      if (varyHeader.class == TrueClass || varyHeader.class == FalseClass) && !block_given?
+        @j_del.java_method(:setSendVaryHeader, [Java::boolean.java_class]).call(varyHeader)
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling set_send_vary_header(varyHeader)"
+    end
   end
 end

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -18,9 +18,11 @@ package io.vertx.ext.web;
 
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -1855,4 +1857,24 @@ public class RouterTest extends WebTestBase {
     });
     testRequest(HttpMethod.GET, "/some+path?q1=some+query", 200, "foo");
   }
+
+  @Test
+  public void testMultipleRoutes() throws Exception {
+    router.routes("/multipleRoutes", HttpMethod.GET, HttpMethod.POST).handler(rc -> rc.response().end("multiple"));
+    testRequests(Arrays.asList(HttpMethod.GET, HttpMethod.POST), "/multipleRoutes", 200, "OK", Buffer.buffer("multiple"));
+  }
+
+  @Test
+  public void testRouteComposition() throws Exception {
+    router.route("/composed").handler(rc -> {
+      rc.response().setChunked(true);
+      rc.response().write(Buffer.buffer("firstHandler "));
+      rc.next();
+    }).then(rc -> {
+      rc.response().end("secondHandler");
+    });
+    testRequest(HttpMethod.GET, "/composed", 200, "OK", Buffer.buffer("firstHandler secondHandler"));
+  }
+
+
 }


### PR DESCRIPTION
- Allows user to specify a collection of methods to match instead of a single method.
  - and add an utility method for Java users with varargs
- Allows user to compose routes with the `then` keyword so that he can chain route declarations in the following way : 

``` java
router.routes("/api/v1/*", GET, POST, PUT, PATCH, DELETE)
  .handler(CorsHandler.create("*"))
  .then(BodyHandler.create())
  .then(this::checkAcceptLanguage)
  .then(this::setContentType)
// ...
```

I could not test the whole project for non-regression (because of `SockJSProtocolTest`) so please be very careful as this could lead to huge regressions.

Please let me know if anything is wrong, I'd be happy to correct it or revert the PR.
