### PR TITLE
Update OAuth2AuthHandlerImpl

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -74,7 +74,7 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
     try {
       for (String authority : authorities) {
         scopes.append(URLEncoder.encode(authority, "UTF-8"));
-        scopes.append(',');
+        scopes.append(' ');
       }
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Fixing a bug when multiple authority values (scopes) are added.  OAuth2 servers require a scope parameter with a space-delimited list of scopes as a value.  The current implementation is using commas to separate the scopes.
