### PR TITLE
change "/foo/bar" to "/bar/foo" in the section Routing with regular e…

### DIFF
--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -377,7 +377,7 @@ route.handler(routingContext -> {
   // /some/path/foo
   // /foo
   // /foo/bar/wibble/foo
-  // /foo/bar
+  // /bar/foo
 
   // But not:
   // /bar/wibble


### PR DESCRIPTION
…xpressions

.*foo will not match "/foo/bar" but "/bar/foo". I also write a simple demo that a simple http server just echo back the request's path.  The request /foo/bar will return **Resource not found** rather than "/foo/bar".So I thout this might be a bug and fixed it.