### PR TITLE
StaticHandlerImpl: Fix handling of range end offset

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -322,9 +322,9 @@ public class StaticHandlerImpl implements StaticHandler {
             part = m.group(2);
             if (part != null && part.length() > 0) {
               // ranges are inclusive
-              end = Long.parseLong(part);
-              // offset must fall inside the limits of the file
-              if (end < offset || end >= fileProps.size()) {
+              end = Math.min(end, Long.parseLong(part));
+              // end offset must not be smaller than start offset
+              if (end < offset) {
                 throw new IndexOutOfBoundsException();
               }
             }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -491,6 +491,7 @@ public class StaticHandlerTest extends WebTestBase {
     // 1. request a head to a static image, this should tell us the server supports ranges
     // 2. make a request of the 1st 1000 bytes
     // 3. request all bytes after 1000
+    // 4. request bytes from 1000 up to 5000000 if available (which isn't)
 
     testRequest(HttpMethod.HEAD, "/somedir/range.jpg", null, res -> {
       assertEquals("bytes", res.headers().get("Accept-Ranges"));
@@ -507,6 +508,13 @@ public class StaticHandlerTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/somedir/range.jpg", req -> {
       req.headers().set("Range", "bytes=1000-");
+    }, res -> {
+      assertEquals("bytes", res.headers().get("Accept-Ranges"));
+      assertEquals("14783", res.headers().get("Content-Length"));
+      assertEquals("bytes 1000-15782/15783", res.headers().get("Content-Range"));
+    }, 206, "Partial Content", null);
+    testRequest(HttpMethod.GET, "/somedir/range.jpg", req -> {
+      req.headers().set("Range", "bytes=1000-5000000");
     }, res -> {
       assertEquals("bytes", res.headers().get("Accept-Ranges"));
       assertEquals("14783", res.headers().get("Content-Length"));


### PR DESCRIPTION
RFC7233 (and all earlier) state that it's ok to specify an end offset larger than the actual file size so that the client can request to limit the amount of data transferred without knowing the exact content length in advance. Quoting:

> A client can limit the number of bytes requested without knowing the
size of the selected representation.  If the last-byte-pos value is
absent, or if the value is greater than or equal to the current
length of the representation data, the byte range is interpreted as
the remainder of the representation (i.e., the server replaces the
value of last-byte-pos with a value that is one less than the current
length of the selected representation).

https://tools.ietf.org/html/rfc7233#section-2.1

Updated implementation and unit tests to match this.