### PR TITLE
Session management following OWASP recommendations

### DIFF
--- a/vertx-sockjs-service-proxy/src/test/kotlin/io/vertx/kotlin/serviceproxy/testmodel/TestDataObject.kt
+++ b/vertx-sockjs-service-proxy/src/test/kotlin/io/vertx/kotlin/serviceproxy/testmodel/TestDataObject.kt
@@ -3,21 +3,21 @@ package io.vertx.kotlin.serviceproxy.testmodel
 import io.vertx.serviceproxy.testmodel.TestDataObject
 
 fun TestDataObject(
-        bool: Boolean? = null,
-    number: Int? = null,
-    string: String? = null): TestDataObject = io.vertx.serviceproxy.testmodel.TestDataObject().apply {
+    bool: Boolean? = null,
+  number: Int? = null,
+  string: String? = null): TestDataObject = io.vertx.serviceproxy.testmodel.TestDataObject().apply {
 
-    if (bool != null) {
-        this.isBool = bool
-    }
+  if (bool != null) {
+    this.isBool = bool
+  }
 
-    if (number != null) {
-        this.number = number
-    }
+  if (number != null) {
+    this.number = number
+  }
 
-    if (string != null) {
-        this.string = string
-    }
+  if (string != null) {
+    this.string = string
+  }
 
 }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/Session.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Session.java
@@ -39,6 +39,11 @@ import java.util.Map;
 public interface Session {
 
   /**
+   * @return The new unique ID of the session.
+   */
+  Session regenerateId();
+
+  /**
    * @return The unique ID of the session. This is generated using a random secure UUID.
    */
   String id();
@@ -89,6 +94,16 @@ public interface Session {
    * @return has the session been destroyed?
    */
   boolean isDestroyed();
+
+  /**
+   * @return has the session been renewed?
+   */
+  boolean isRegenerated();
+
+  /**
+   * @return old ID if renewed
+   */
+  String oldId();
 
   /**
    * @return the amount of time in ms, after which the session will expire, if not accessed.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -67,13 +67,19 @@ public interface SessionHandler extends Handler<RoutingContext> {
   boolean DEFAULT_COOKIE_SECURE_FLAG = false;
 
   /**
+   * Default min length for a session id.
+   * More info: https://www.owasp.org/index.php/Session_Management_Cheat_Sheet
+   */
+  int DEFAULT_SESSIONID_MIN_LENGTH = 16;
+
+  /**
    * Create a session handler
    *
    * @param sessionStore  the session store
    * @return the handler
    */
   static SessionHandler create(SessionStore sessionStore) {
-    return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_TIMEOUT, DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG, sessionStore);
+    return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_TIMEOUT, DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG, DEFAULT_SESSIONID_MIN_LENGTH, sessionStore);
   }
 
   /**
@@ -123,4 +129,12 @@ public interface SessionHandler extends Handler<RoutingContext> {
   @Fluent
   SessionHandler setSessionCookieName(String sessionCookieName);
 
+  /**
+   * Set the session cookie name
+   *
+   * @param minLength  the session id minimal length
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  SessionHandler setMinLength(int minLength);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -130,7 +130,7 @@ public interface SessionHandler extends Handler<RoutingContext> {
   SessionHandler setSessionCookieName(String sessionCookieName);
 
   /**
-   * Set the session cookie name
+   * Set expected session id minimum length.
    *
    * @param minLength  the session id minimal length
    * @return a reference to this, so the API can be used fluently

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
@@ -99,6 +99,10 @@ public class FormLoginHandlerImpl implements FormLoginHandler {
             User user = res.result();
             context.setUser(user);
             if (session != null) {
+              // the user has upgraded from unauthenticated to authenticated
+              // session should be upgraded as recommended by owasp
+              session.regenerateId();
+
               String returnURL = session.remove(returnURLParam);
               if (returnURL != null) {
                 // Now redirect back to the original url

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -27,6 +27,7 @@ import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.JWTAuthHandler;
 
 import java.util.List;
@@ -122,6 +123,12 @@ public class JWTAuthHandlerImpl extends AuthHandlerImpl implements JWTAuthHandle
         if (res.succeeded()) {
           final User user2 = res.result();
           context.setUser(user2);
+          Session session = context.session();
+          if (session != null) {
+            // the user has upgraded from unauthenticated to authenticated
+            // session should be upgraded as recommended by owasp
+            session.regenerateId();
+          }
           authorise(user2, context);
         } else {
           log.warn("JWT decode failure", res.cause());

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -127,12 +127,12 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
             session.regenerateId();
             // we should redirect the UA so this link becomes invalid
             ctx.response()
-              .putHeader("Location", relative_redirect_uri)
+              .putHeader("Location", state)
               .setStatusCode(302)
-              .end("Redirecting to " + relative_redirect_uri + ".");
+              .end("Redirecting to " + state + ".");
           } else {
             // there is no session object so we cannot keep state
-            ctx.reroute(relative_redirect_uri);
+            ctx.reroute(state);
           }
         }
       });

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -21,6 +21,7 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.OAuth2AuthHandler;
 
 import java.io.UnsupportedEncodingException;
@@ -115,7 +116,20 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
           ctx.fail(res.cause());
         } else {
           ctx.setUser(res.result());
-          ctx.reroute(relative_redirect_uri);
+          Session session = ctx.session();
+          if (session != null) {
+            // the user has upgraded from unauthenticated to authenticated
+            // session should be upgraded as recommended by owasp
+            session.regenerateId();
+            // we should redirect the UA so this link becomes invalid
+            ctx.response()
+              .putHeader("Location", relative_redirect_uri)
+              .setStatusCode(302)
+              .end("Redirecting to " + relative_redirect_uri + ".");
+          } else {
+            // there is no session object so we cannot keep state
+            ctx.reroute(relative_redirect_uri);
+          }
         }
       });
     });

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -213,7 +213,7 @@ public class SessionHandlerImpl implements SessionHandler {
   }
 
   private void createNewSession(RoutingContext context) {
-    Session session = sessionStore.createSession(sessionTimeout);
+    Session session = sessionStore.createSession(sessionTimeout, minLength);
     context.setSession(session);
     Cookie cookie = Cookie.cookie(sessionCookieName, session.id());
     cookie.setPath("/");

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -40,14 +40,16 @@ public class SessionHandlerImpl implements SessionHandler {
   private boolean nagHttps;
   private boolean sessionCookieSecure;
   private boolean sessionCookieHttpOnly;
+  private int minLength;
 
-  public SessionHandlerImpl(String sessionCookieName, long sessionTimeout, boolean nagHttps, boolean sessionCookieSecure, boolean sessionCookieHttpOnly, SessionStore sessionStore) {
+  public SessionHandlerImpl(String sessionCookieName, long sessionTimeout, boolean nagHttps, boolean sessionCookieSecure, boolean sessionCookieHttpOnly, int minLength, SessionStore sessionStore) {
     this.sessionCookieName = sessionCookieName;
     this.sessionTimeout = sessionTimeout;
     this.nagHttps = nagHttps;
     this.sessionStore = sessionStore;
     this.sessionCookieSecure = sessionCookieSecure;
     this.sessionCookieHttpOnly = sessionCookieHttpOnly;
+    this.minLength = minLength;
   }
 
   @Override
@@ -81,13 +83,19 @@ public class SessionHandlerImpl implements SessionHandler {
   }
 
   @Override
+  public SessionHandler setMinLength(int minLength) {
+    this.minLength = minLength;
+    return this;
+  }
+
+  @Override
   public void handle(RoutingContext context) {
     context.response().ended();
 
-    if (nagHttps) {
+    if (nagHttps && log.isDebugEnabled()) {
       String uri = context.request().absoluteURI();
       if (!uri.startsWith("https:")) {
-        log.warn("Using session cookies without https could make you susceptible to session hijacking: " + uri);
+        log.debug("Using session cookies without https could make you susceptible to session hijacking: " + uri);
       }
     }
 
@@ -96,28 +104,34 @@ public class SessionHandlerImpl implements SessionHandler {
     if (cookie != null) {
       // Look up session
       String sessionID = cookie.getValue();
-      getSession(context.vertx(), sessionID, res -> {
-        if (res.succeeded()) {
-          Session session = res.result();
-          if (session != null) {
-            context.setSession(session);
-            session.setAccessed();
-            addStoreSessionHandler(context);
+      if (sessionID != null && sessionID.length() > minLength) {
+        // we passed the OWASP min length requirements
+        getSession(context.vertx(), sessionID, res -> {
+          if (res.succeeded()) {
+            Session session = res.result();
+            if (session != null) {
+              context.setSession(session);
+              session.setAccessed();
+              addStoreSessionHandler(context);
+            } else {
+              // Cannot find session - either it timed out, or was explicitly destroyed at the server side on a
+              // previous request.
+
+              // OWASP clearly states that we shouldn't recreate the session as it allows session fixation.
+              // create a new anonymous session.
+              createNewSession(context);
+            }
           } else {
-            // Cannot find session - either it timed out, or was explicitly destroyed at the server side on a
-            // previous request.
-            // Either way, we create a new one.
-            createNewSession(context);
+            context.fail(res.cause());
           }
-        } else {
-          context.fail(res.cause());
-        }
-        context.next();
-      });
-    } else {
-      createNewSession(context);
-      context.next();
+          context.next();
+        });
+        return;
+      }
     }
+    // requirements were not met, so a anonymous session is created.
+    createNewSession(context);
+    context.next();
   }
 
   private void getSession(Vertx vertx, String sessionID, Handler<AsyncResult<Session>> resultHandler) {
@@ -150,11 +164,40 @@ public class SessionHandlerImpl implements SessionHandler {
         // Store the session (only and only if there was no error)
         if (currentStatusCode >= 200 && currentStatusCode < 400) {
           session.setAccessed();
-          sessionStore.put(session, res -> {
-            if (res.failed()) {
-              log.error("Failed to store session", res.cause());
-            }
-          });
+          if (session.isRegenerated()) {
+            // this means that a session id has been changed, usually it means a session upgrade
+            // (e.g.: anonymous to authenticated) or that the security requirements have changed
+            // see: https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Session_ID_Life_Cycle
+
+            // the session cookie needs to be updated to the new id
+            final Cookie cookie = context.getCookie(sessionCookieName);
+            // restore defaults
+            cookie
+              .setValue(session.id())
+              .setPath("/")
+              .setSecure(sessionCookieSecure)
+              .setHttpOnly(sessionCookieHttpOnly);
+
+            // we must invalidate the old id
+            sessionStore.delete(session.oldId(), delete -> {
+              if (delete.failed()) {
+                log.error("Failed to delete previous session", delete.cause());
+              } else {
+                // we must wait for the result of the previous call in order to save the new one
+                sessionStore.put(session, res -> {
+                  if (res.failed()) {
+                    log.error("Failed to store session", res.cause());
+                  }
+                });
+              }
+            });
+          } else {
+            sessionStore.put(session, res -> {
+              if (res.failed()) {
+                log.error("Failed to store session", res.cause());
+              }
+            });
+          }
         } else {
           // don't send a cookie if status is not 2xx or 3xx
           context.removeCookie(sessionCookieName);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
@@ -44,7 +44,8 @@ public class UserHolder implements ClusterSerializable {
 
   @Override
   public void writeToBuffer(Buffer buffer) {
-    User user = context.user();
+    // try to get the user from the context otherwise fall back to any cached version
+    User user = context != null ? context.user() : this.user;
     if (user != null && user instanceof ClusterSerializable) {
       buffer.appendByte((byte)1);
       String className = user.getClass().getCanonicalName();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserSessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserSessionHandlerImpl.java
@@ -54,7 +54,13 @@ public class UserSessionHandlerImpl implements UserSessionHandler {
         }
         holder.context = routingContext;
       } else {
-        session.put(SESSION_USER_HOLDER_KEY, new UserHolder(routingContext));
+        // only at the time we are writing the header we should store the user to the session
+        routingContext.addHeadersEndHandler(v -> {
+          // during the request the user might have been removed
+          if (routingContext.user() != null) {
+            session.put(SESSION_USER_HOLDER_KEY, new UserHolder(routingContext));
+          }
+        });
       }
       if (user != null) {
         routingContext.setUser(user);

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -749,6 +749,20 @@
  * To create a session handler you need to have a session store instance. The session store is the object that
  * holds the actual sessions for your application.
  *
+ * The session store is responsible for holding a secure random number generator in order to guarantee secure session
+ * ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
+ * session id of store B since they have different seeds and states.
+ *
+ * By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
+ * every 5 minutes with 64bits of new entropy. However this can all be configured using the environment properties:
+ *
+ * * io.vertx.ext.web.session.algorith e.g.: SHA1PRNG
+ * * io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
+ * * io.vertx.ext.web.session.seed.bits e.g.: 128
+ *
+ * Most users should not need to configure these values unless if you notice that the performance of your application is
+ * being affected by the PRNG algorithm.
+ *
  * Vert.x-Web comes with two session store implementations out of the box, and you can also write your own if you prefer.
  *
  * ==== Local session store

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -749,14 +749,14 @@
  * To create a session handler you need to have a session store instance. The session store is the object that
  * holds the actual sessions for your application.
  *
- * The session store is responsible for holding a secure random number generator in order to guarantee secure session
+ * The session store is responsible for holding a secure pseudo random number generator in order to guarantee secure session
  * ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
  * session id of store B since they have different seeds and states.
  *
  * By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
- * every 5 minutes with 64bits of new entropy. However this can all be configured using the environment properties:
+ * every 5 minutes with 64bits of new entropy. However this can all be configured using the system properties:
  *
- * * io.vertx.ext.web.session.algorith e.g.: SHA1PRNG
+ * * io.vertx.ext.web.session.algorithm e.g.: SHA1PRNG
  * * io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
  * * io.vertx.ext.web.session.seed.bits e.g.: 128
  *

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/SessionStore.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/SessionStore.java
@@ -31,6 +31,12 @@ import io.vertx.ext.web.Session;
 public interface SessionStore {
 
   /**
+   * Default length for a session id.
+   * More info: https://www.owasp.org/index.php/Session_Management_Cheat_Sheet
+   */
+  int DEFAULT_SESSIONID_LENGTH = 16;
+
+  /**
    * The retry timeout value in milli seconds used by the session handler when it retrieves a value from the store.<p/>
    *
    * A non positive value means there is no retry at all.
@@ -40,13 +46,23 @@ public interface SessionStore {
   long retryTimeout();
 
   /**
-   * Create a new session
+   * Create a new session using the default min length.
    *
    * @param timeout - the session timeout, in ms
    *
    * @return the session
    */
   Session createSession(long timeout);
+
+  /**
+   * Create a new session
+   *
+   * @param timeout - the session timeout, in ms
+   * @param length - the required length for the session id
+   *
+   * @return the session
+   */
+  Session createSession(long timeout, int length);
 
   /**
    * Get the session with the specified ID

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
@@ -30,6 +30,7 @@ import io.vertx.ext.web.sstore.ClusteredSessionStore;
 public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
 
   private final Vertx vertx;
+  private final PRNG random;
   private final String sessionMapName;
   private final long retryTimeout;
 
@@ -40,6 +41,7 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
     this.vertx = vertx;
     this.sessionMapName = sessionMapName;
     this.retryTimeout = retryTimeout;
+    this.random = new PRNG(vertx);
   }
 
   @Override
@@ -49,12 +51,12 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
 
   @Override
   public Session createSession(long timeout) {
-    return new SessionImpl(timeout, DEFAULT_SESSIONID_LENGTH);
+    return new SessionImpl(random, timeout, DEFAULT_SESSIONID_LENGTH);
   }
 
   @Override
   public Session createSession(long timeout, int length) {
-    return new SessionImpl(timeout, length);
+    return new SessionImpl(random, timeout, length);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
@@ -49,7 +49,12 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
 
   @Override
   public Session createSession(long timeout) {
-    return new SessionImpl(timeout);
+    return new SessionImpl(timeout, DEFAULT_SESSIONID_LENGTH);
+  }
+
+  @Override
+  public Session createSession(long timeout, int length) {
+    return new SessionImpl(timeout, length);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
@@ -170,6 +170,8 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
 
   @Override
   public void close() {
+    // stop seeding the PRNG
+    random.close();
   }
 
   private void getMap(Handler<AsyncResult<AsyncMap<String, Session>>> resultHandler) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
@@ -32,11 +32,13 @@ import java.util.Set;
  */
 public class LocalSessionStoreImpl implements LocalSessionStore, Handler<Long> {
 
-  protected final Vertx vertx;
-  protected final LocalMap<String, Session> localMap;
+  private final LocalMap<String, Session> localMap;
   private final long reaperInterval;
+
   private long timerID = -1;
   private boolean closed;
+
+  protected final Vertx vertx;
 
   public LocalSessionStoreImpl(Vertx vertx, String sessionMapName, long reaperInterval) {
     this.vertx = vertx;
@@ -62,11 +64,24 @@ public class LocalSessionStoreImpl implements LocalSessionStore, Handler<Long> {
 
   @Override
   public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) {
-    resultHandler.handle(Future.succeededFuture(localMap.remove(id) != null));
+    localMap.remove(id);
+    resultHandler.handle(Future.succeededFuture(true));
   }
 
   @Override
   public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) {
+    final SessionImpl oldSession = (SessionImpl) localMap.get(session.id());
+    final SessionImpl newSession = (SessionImpl) session;
+
+    if (oldSession != null) {
+      // there was already some stored data in this case we need to validate versions
+      if (oldSession.version() != newSession.version()) {
+        resultHandler.handle(Future.failedFuture("Version mismatch"));
+        return;
+      }
+    }
+
+    newSession.incrementVersion();
     localMap.put(session.id(), session);
     resultHandler.handle(Future.succeededFuture(true));
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
@@ -49,7 +49,12 @@ public class LocalSessionStoreImpl implements LocalSessionStore, Handler<Long> {
 
   @Override
   public Session createSession(long timeout) {
-    return new SessionImpl(timeout);
+    return new SessionImpl(timeout, DEFAULT_SESSIONID_LENGTH);
+  }
+
+  @Override
+  public Session createSession(long timeout, int length) {
+    return new SessionImpl(timeout, length);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/PRNG.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/PRNG.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.sstore.impl;
+
+import io.vertx.core.Vertx;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+/**
+ * Wrapper around secure random that periodically seeds the PRNG with new entropy.
+ *
+ * @author Paulo Lopes
+ */
+public class PRNG {
+
+  private static final int DEFAULT_SEED_INTERVAL_MILLIS = 300000;
+  private static final int DEFAULT_SEED_BITS = 64;
+
+  private final SecureRandom random;
+  private final long seedID;
+
+  private final Vertx vertx;
+
+  public PRNG(Vertx vertx) {
+    this.vertx = vertx;
+
+    final String algorithm = System.getProperty("io.vertx.ext.web.session.algorith");
+    final int seedInterval = getProperty("io.vertx.ext.web.session.seed.interval", DEFAULT_SEED_INTERVAL_MILLIS);
+    final int seedBits = getProperty("io.vertx.ext.web.session.seed.bits", DEFAULT_SEED_BITS);
+
+    if (algorithm != null) {
+      // the user has made a conscious decision to not use the JVM defaults
+      try {
+        random = SecureRandom.getInstance(algorithm);
+      } catch (NoSuchAlgorithmException e) {
+        // the algorithm is not available
+        throw new RuntimeException(e);
+      }
+    } else {
+      // initialize a secure random (note that on unices JDK8 will default to a mixed mode nativeprng
+      // (non-blocking fot getBytes() blocking for generateSeed()). A similar behavior is expected with SHA1PRNG which
+      // will be the fallback on Windows
+      random = new SecureRandom();
+    }
+
+    // Make sure default seeding happens now to avoid calling setSeed() too early
+    random.nextBytes(new byte[1]);
+
+    // seed internal and bits must be enabled
+    if (seedInterval > 0 && seedBits > 0) {
+      // Add a 64bit entropy every five minutes
+      // see: https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Session_ID_Entropy
+      seedID = vertx.setPeriodic(
+        seedInterval,
+        id -> vertx.<byte[]>executeBlocking(
+          future -> future.complete(random.generateSeed(seedBits / 8)),
+          asyncResult -> random.setSeed(asyncResult.result())));
+    } else {
+      seedID = -1;
+    }
+  }
+
+  void close() {
+    // stop seeding the PRNG
+    if (seedID != -1) {
+      vertx.cancelTimer(seedID);
+    }
+  }
+
+  void nextBytes(byte[] bytes) {
+    random.nextBytes(bytes);
+  }
+
+  private static int getProperty(String name, int defaultValue) {
+    try {
+      String value = System.getProperty(name);
+      if (value == null) {
+        return defaultValue;
+      } else {
+        return Integer.parseInt(value);
+      }
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/PRNG.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/PRNG.java
@@ -38,9 +38,9 @@ public class PRNG {
   public PRNG(Vertx vertx) {
     this.vertx = vertx;
 
-    final String algorithm = System.getProperty("io.vertx.ext.web.session.algorith");
-    final int seedInterval = getProperty("io.vertx.ext.web.session.seed.interval", DEFAULT_SEED_INTERVAL_MILLIS);
-    final int seedBits = getProperty("io.vertx.ext.web.session.seed.bits", DEFAULT_SEED_BITS);
+    final String algorithm = System.getProperty("io.vertx.ext.web.session.algorithm");
+    final int seedInterval = Integer.getInteger("io.vertx.ext.web.session.seed.interval", DEFAULT_SEED_INTERVAL_MILLIS);
+    final int seedBits = Integer.getInteger("io.vertx.ext.web.session.seed.bits", DEFAULT_SEED_BITS);
 
     if (algorithm != null) {
       // the user has made a conscious decision to not use the JVM defaults
@@ -52,7 +52,7 @@ public class PRNG {
       }
     } else {
       // initialize a secure random (note that on unices JDK8 will default to a mixed mode nativeprng
-      // (non-blocking fot getBytes() blocking for generateSeed()). A similar behavior is expected with SHA1PRNG which
+      // (non-blocking for getBytes() blocking for generateSeed()). A similar behavior is expected with SHA1PRNG which
       // will be the fallback on Windows
       random = new SecureRandom();
     }
@@ -68,6 +68,7 @@ public class PRNG {
         seedInterval,
         id -> vertx.<byte[]>executeBlocking(
           future -> future.complete(random.generateSeed(seedBits / 8)),
+          false,
           asyncResult -> random.setSeed(asyncResult.result())));
     } else {
       seedID = -1;
@@ -83,18 +84,5 @@ public class PRNG {
 
   void nextBytes(byte[] bytes) {
     random.nextBytes(bytes);
-  }
-
-  private static int getProperty(String name, int defaultValue) {
-    try {
-      String value = System.getProperty(name);
-      if (value == null) {
-        return defaultValue;
-      } else {
-        return Integer.parseInt(value);
-      }
-    } catch (NumberFormatException e) {
-      return defaultValue;
-    }
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -18,8 +18,6 @@ package io.vertx.ext.web.sstore.impl;
 
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 import io.vertx.ext.web.Session;

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -54,6 +54,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private long timeout;
   private Map<String, Object> data;
   private long lastAccessed;
+  private int version;
   // state management
   private boolean destroyed;
   private boolean renewed;
@@ -154,12 +155,21 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     return oldId;
   }
 
+  public int version() {
+    return version;
+  }
+
+  public int incrementVersion() {
+    return ++version;
+  }
+
   @Override
   public void writeToBuffer(Buffer buff) {
     byte[] bytes = id.getBytes(UTF8);
     buff.appendInt(bytes.length).appendBytes(bytes);
     buff.appendLong(timeout);
     buff.appendLong(lastAccessed);
+    buff.appendInt(version);
     Buffer dataBuf = writeDataToBuffer();
     buff.appendBuffer(dataBuf);
   }
@@ -175,6 +185,8 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     pos += 8;
     lastAccessed = buffer.getLong(pos);
     pos += 8;
+    version = buffer.getInt(pos);
+    pos += 4;
     pos = readDataFromBuffer(pos, buffer);
     return pos;
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -36,7 +36,6 @@ import java.util.UUID;
  */
 public class SessionImpl implements Session, ClusterSerializable, Shareable {
 
-  private static final Logger log = LoggerFactory.getLogger(SessionImpl.class);
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
   private static final byte TYPE_LONG = 1;
@@ -57,7 +56,10 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private long timeout;
   private Map<String, Object> data;
   private long lastAccessed;
+  // state management
   private boolean destroyed;
+  private boolean renewed;
+  private String oldId;
 
   public SessionImpl() {
   }
@@ -71,6 +73,18 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @Override
   public String id() {
     return id;
+  }
+
+  @Override
+  public Session regenerateId() {
+    if (oldId == null) {
+      // keep track of just the first one since the
+      // regeneration during the remaining lifecycle are ephemeral
+      oldId = id;
+    }
+    id = UUID.randomUUID().toString();
+    renewed = true;
+    return this;
   }
 
   @Override
@@ -122,6 +136,16 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   @Override
   public boolean isDestroyed() {
     return destroyed;
+  }
+
+  @Override
+  public boolean isRegenerated() {
+    return renewed;
+  }
+
+  @Override
+  public String oldId() {
+    return oldId;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionImpl.java
@@ -22,11 +22,9 @@ import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.impl.Utils;
-import sun.security.jca.Providers;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.security.Provider;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -52,7 +50,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private static final byte TYPE_SERIALIZABLE = 12;
   private static final byte TYPE_CLUSTER_SERIALIZABLE = 13;
 
-  private final PRNG rng;
+  private final PRNG prng;
 
   private String id;
   private long timeout;
@@ -65,12 +63,12 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
   private String oldId;
 
   public SessionImpl(PRNG random) {
-    this.rng = random;
+    this.prng = random;
   }
 
   public SessionImpl(PRNG random, long timeout, int length) {
-    this.rng = random;
-    this.id = generateId(rng, length);
+    this.prng = random;
+    this.id = generateId(prng, length);
     this.timeout = timeout;
     this.lastAccessed = System.currentTimeMillis();
   }
@@ -88,7 +86,7 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
       oldId = id;
     }
     // ids are stored in hex, so the original size is half of the hex encodec length
-    id = generateId(rng, oldId.length() / 2);
+    id = generateId(prng, oldId.length() / 2);
     renewed = true;
     return this;
   }
@@ -166,8 +164,8 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     return version;
   }
 
-  public int incrementVersion() {
-    return ++version;
+  public void incrementVersion() {
+    ++version;
   }
 
   @Override
@@ -386,16 +384,6 @@ public class SessionImpl implements Session, ClusterSerializable, Shareable {
     }
 
     return new String(hex);
-  }
-
-  public static void main(String[] args) {
-    for (Provider p : Providers.getProviderList().providers()) {
-      for (Provider.Service s : p.getServices()) {
-        if (s.getType().equals("SecureRandom")) {
-          System.out.println(s);
-        }
-      }
-    }
   }
 }
 

--- a/vertx-web/src/main/resources/vertx-web-js/session.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session.js
@@ -40,6 +40,19 @@ var Session = function(j_val) {
 
    @public
 
+   @return {Session} The new unique ID of the session.
+   */
+  this.regenerateId = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(j_session["regenerateId()"](), Session);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
    @return {string} The unique ID of the session. This is generated using a random secure UUID.
    */
   this.id = function() {
@@ -129,6 +142,32 @@ var Session = function(j_val) {
     var __args = arguments;
     if (__args.length === 0) {
       return j_session["isDestroyed()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {boolean} has the session been renewed?
+   */
+  this.isRegenerated = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_session["isRegenerated()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {string} old ID if renewed
+   */
+  this.oldId = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_session["oldId()"]();
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/vertx-web/src/main/resources/vertx-web-js/session_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session_handler.js
@@ -122,6 +122,21 @@ var SessionHandler = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Set the session cookie name
+
+   @public
+   @param minLength {number} the session id minimal length 
+   @return {SessionHandler} a reference to this, so the API can be used fluently
+   */
+  this.setMinLength = function(minLength) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] ==='number') {
+      j_sessionHandler["setMinLength(int)"](minLength);
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-web/src/main/resources/vertx-web/session_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/session_handler.rb
@@ -108,5 +108,15 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling set_session_cookie_name(#{sessionCookieName})"
     end
+    #  Set the session cookie name
+    # @param [Fixnum] minLength the session id minimal length
+    # @return [self]
+    def set_min_length(minLength=nil)
+      if minLength.class == Fixnum && !block_given?
+        @j_del.java_method(:setMinLength, [Java::int.java_class]).call(minLength)
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling set_min_length(minLength)"
+    end
   end
 end

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -26,6 +26,7 @@ import io.vertx.core.shareddata.impl.ClusterSerializable;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.sstore.SessionStore;
+import io.vertx.ext.web.sstore.impl.PRNG;
 import io.vertx.ext.web.sstore.impl.SessionImpl;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.shiro.ShiroAuth;
@@ -208,6 +209,7 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
   private class SerializingSessionStore implements SessionStore {
 
     private Map<String, Buffer> sessions = new ConcurrentHashMap<>();
+    private final PRNG prng = new PRNG(vertx);
 
     @Override
     public long retryTimeout() {
@@ -216,12 +218,12 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
 
     @Override
     public Session createSession(long timeout) {
-      return new SessionImpl(timeout, DEFAULT_SESSIONID_LENGTH);
+      return new SessionImpl(prng, timeout, DEFAULT_SESSIONID_LENGTH);
     }
 
     @Override
     public Session createSession(long timeout, int length) {
-      return new SessionImpl(timeout, length);
+      return new SessionImpl(prng, timeout, length);
     }
 
     @Override
@@ -229,7 +231,7 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
       Buffer buff = sessions.get(id);
       SessionImpl sess;
       if (buff != null) {
-        sess = new SessionImpl();
+        sess = new SessionImpl(prng);
         sess.readFromBuffer(0, buff);
       } else {
         sess = null;

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -216,7 +216,12 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
 
     @Override
     public Session createSession(long timeout) {
-      return new SessionImpl(timeout);
+      return new SessionImpl(timeout, DEFAULT_SESSIONID_LENGTH);
+    }
+
+    @Override
+    public Session createSession(long timeout, int length) {
+      return new SessionImpl(timeout, length);
     }
 
     @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
@@ -60,7 +60,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
     doLogin(rc -> {
       Session sess = rc.session();
       assertNotNull(sess);
-      assertEquals(sessionCookie.get().substring(18, 54), sess.id());
+      assertEquals(sessionCookie.get().substring(18, 50), sess.id());
       assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
@@ -198,6 +198,11 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
 
     // do post with credentials
     testRequest(HttpMethod.POST, "/login", sendLoginRequestConsumer(), resp -> {
+      // session will be upgraded
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+      sessionCookie.set(setCookie);
+
       String location = resp.headers().get("location");
       assertNotNull(location);
       assertEquals("/protected/somepage?param=1", location);
@@ -234,6 +239,10 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
   private void doLogin(Handler<RoutingContext> handler) throws Exception {
     doLoginCommon(handler);
     testRequest(HttpMethod.POST, "/login", sendLoginRequestConsumer(), resp -> {
+      // session will be upgraded
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+      sessionCookie.set(setCookie);
       String location = resp.headers().get("location");
       assertNotNull(location);
       assertEquals("/protected/somepage", location);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
@@ -399,4 +399,24 @@ public abstract class SessionHandlerTestBase extends WebTestBase {
 
     awaitLatch(latch);
   }
+
+  @Test
+  public void testSessionIdLength() throws Exception {
+
+    router.route().handler(CookieHandler.create());
+    router.route().handler(SessionHandler.create(store));
+
+    router.route("/1").handler(rc -> {
+      // previous id must match
+      assertFalse("abc".equals(rc.session().id()));
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.GET, "/1", req -> {
+      req.putHeader("cookie", "vertx-web.session=abc; Path=/");
+    }, resp -> {
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+    }, 200, "OK", null);
+  }
 }


### PR DESCRIPTION
Fixes #399 #400 #403 

When dealing with sessions when a user upgrades its security level it is recommended that a session id is also regenerated. The reason is to avoid session fixing. Also there are requirements that state what a minimal session id length should be for security concerns.

This PR implements these requirements.

A follow up will be to perform regeneration on the current auth handlers