### PR TITLE
Issues/easy oauth2

### DIFF
--- a/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestBaseImportsService.java
+++ b/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestBaseImportsService.java
@@ -18,6 +18,7 @@ package io.vertx.rxjava.serviceproxy.testmodel;
 
 import java.util.Map;
 import rx.Observable;
+import rx.Single;
 
 /**
  * Test base imports are corrects.

--- a/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestConnection.java
+++ b/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestConnection.java
@@ -18,6 +18,7 @@ package io.vertx.rxjava.serviceproxy.testmodel;
 
 import java.util.Map;
 import rx.Observable;
+import rx.Single;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -50,10 +51,17 @@ public class TestConnection {
     return this;
   }
 
+  @Deprecated()
   public Observable<String> startTransactionObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     startTransaction(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxStartTransaction() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      startTransaction(fut);
+    }));
   }
 
   public TestConnection insert(String name, JsonObject data, Handler<AsyncResult<String>> resultHandler) { 
@@ -61,10 +69,17 @@ public class TestConnection {
     return this;
   }
 
+  @Deprecated()
   public Observable<String> insertObservable(String name, JsonObject data) { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     insert(name, data, resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxInsert(String name, JsonObject data) { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      insert(name, data, fut);
+    }));
   }
 
   public TestConnection commit(Handler<AsyncResult<String>> resultHandler) { 
@@ -72,10 +87,17 @@ public class TestConnection {
     return this;
   }
 
+  @Deprecated()
   public Observable<String> commitObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     commit(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxCommit() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      commit(fut);
+    }));
   }
 
   public TestConnection rollback(Handler<AsyncResult<String>> resultHandler) { 
@@ -83,10 +105,17 @@ public class TestConnection {
     return this;
   }
 
+  @Deprecated()
   public Observable<String> rollbackObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     rollback(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxRollback() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      rollback(fut);
+    }));
   }
 
   public void close() { 

--- a/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestConnectionWithCloseFuture.java
+++ b/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestConnectionWithCloseFuture.java
@@ -18,6 +18,7 @@ package io.vertx.rxjava.serviceproxy.testmodel;
 
 import java.util.Map;
 import rx.Observable;
+import rx.Single;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
@@ -48,20 +49,34 @@ public class TestConnectionWithCloseFuture {
     delegate.close(handler);
   }
 
+  @Deprecated()
   public Observable<Void> closeObservable() { 
     io.vertx.rx.java.ObservableFuture<Void> handler = io.vertx.rx.java.RxHelper.observableFuture();
     close(handler.toHandler());
     return handler;
   }
 
+  public Single<Void> rxClose() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      close(fut);
+    }));
+  }
+
   public void someMethod(Handler<AsyncResult<String>> resultHandler) { 
     delegate.someMethod(resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> someMethodObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     someMethod(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxSomeMethod() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      someMethod(fut);
+    }));
   }
 
 

--- a/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestService.java
+++ b/vertx-sockjs-service-proxy/src/test/generated/io/vertx/rxjava/serviceproxy/testmodel/TestService.java
@@ -18,6 +18,7 @@ package io.vertx.rxjava.serviceproxy.testmodel;
 
 import java.util.Map;
 import rx.Observable;
+import rx.Single;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.rxjava.core.Vertx;
 import java.util.Set;
@@ -71,20 +72,34 @@ public class TestService {
     delegate.longDeliverySuccess(resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> longDeliverySuccessObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     longDeliverySuccess(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<String> rxLongDeliverySuccess() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      longDeliverySuccess(fut);
+    }));
+  }
+
   public void longDeliveryFailed(Handler<AsyncResult<String>> resultHandler) { 
     delegate.longDeliveryFailed(resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> longDeliveryFailedObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     longDeliveryFailed(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxLongDeliveryFailed() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      longDeliveryFailed(fut);
+    }));
   }
 
   public void createConnection(String str, Handler<AsyncResult<TestConnection>> resultHandler) { 
@@ -99,10 +114,17 @@ public class TestService {
     });
   }
 
+  @Deprecated()
   public Observable<TestConnection> createConnectionObservable(String str) { 
     io.vertx.rx.java.ObservableFuture<TestConnection> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     createConnection(str, resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<TestConnection> rxCreateConnection(String str) { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      createConnection(str, fut);
+    }));
   }
 
   public void createConnectionWithCloseFuture(Handler<AsyncResult<TestConnectionWithCloseFuture>> resultHandler) { 
@@ -117,10 +139,17 @@ public class TestService {
     });
   }
 
+  @Deprecated()
   public Observable<TestConnectionWithCloseFuture> createConnectionWithCloseFutureObservable() { 
     io.vertx.rx.java.ObservableFuture<TestConnectionWithCloseFuture> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     createConnectionWithCloseFuture(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<TestConnectionWithCloseFuture> rxCreateConnectionWithCloseFuture() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      createConnectionWithCloseFuture(fut);
+    }));
   }
 
   public void noParams() { 
@@ -159,20 +188,34 @@ public class TestService {
     delegate.enumTypeAsResult(someEnum);
   }
 
+  @Deprecated()
   public Observable<SomeEnum> enumTypeAsResultObservable() { 
     io.vertx.rx.java.ObservableFuture<SomeEnum> someEnum = io.vertx.rx.java.RxHelper.observableFuture();
     enumTypeAsResult(someEnum.toHandler());
     return someEnum;
   }
 
+  public Single<SomeEnum> rxEnumTypeAsResult() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      enumTypeAsResult(fut);
+    }));
+  }
+
   public void enumTypeAsResultNull(Handler<AsyncResult<SomeEnum>> someEnum) { 
     delegate.enumTypeAsResultNull(someEnum);
   }
 
+  @Deprecated()
   public Observable<SomeEnum> enumTypeAsResultNullObservable() { 
     io.vertx.rx.java.ObservableFuture<SomeEnum> someEnum = io.vertx.rx.java.RxHelper.observableFuture();
     enumTypeAsResultNull(someEnum.toHandler());
     return someEnum;
+  }
+
+  public Single<SomeEnum> rxEnumTypeAsResultNull() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      enumTypeAsResultNull(fut);
+    }));
   }
 
   public void dataObjectType(TestDataObject options) { 
@@ -199,250 +242,425 @@ public class TestService {
     delegate.stringHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> stringHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     stringHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<String> rxStringHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      stringHandler(fut);
+    }));
+  }
+
   public void stringNullHandler(Handler<AsyncResult<String>> resultHandler) { 
     delegate.stringNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> stringNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     stringNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<String> rxStringNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      stringNullHandler(fut);
+    }));
+  }
+
   public void byteHandler(Handler<AsyncResult<Byte>> resultHandler) { 
     delegate.byteHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Byte> byteHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Byte> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     byteHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Byte> rxByteHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      byteHandler(fut);
+    }));
+  }
+
   public void byteNullHandler(Handler<AsyncResult<Byte>> resultHandler) { 
     delegate.byteNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Byte> byteNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Byte> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     byteNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Byte> rxByteNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      byteNullHandler(fut);
+    }));
+  }
+
   public void shortHandler(Handler<AsyncResult<Short>> resultHandler) { 
     delegate.shortHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Short> shortHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Short> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     shortHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Short> rxShortHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      shortHandler(fut);
+    }));
+  }
+
   public void shortNullHandler(Handler<AsyncResult<Short>> resultHandler) { 
     delegate.shortNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Short> shortNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Short> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     shortNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Short> rxShortNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      shortNullHandler(fut);
+    }));
+  }
+
   public void intHandler(Handler<AsyncResult<Integer>> resultHandler) { 
     delegate.intHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Integer> intHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Integer> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     intHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Integer> rxIntHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      intHandler(fut);
+    }));
+  }
+
   public void intNullHandler(Handler<AsyncResult<Integer>> resultHandler) { 
     delegate.intNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Integer> intNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Integer> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     intNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Integer> rxIntNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      intNullHandler(fut);
+    }));
+  }
+
   public void longHandler(Handler<AsyncResult<Long>> resultHandler) { 
     delegate.longHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Long> longHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Long> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     longHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Long> rxLongHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      longHandler(fut);
+    }));
+  }
+
   public void longNullHandler(Handler<AsyncResult<Long>> resultHandler) { 
     delegate.longNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Long> longNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Long> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     longNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Long> rxLongNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      longNullHandler(fut);
+    }));
+  }
+
   public void floatHandler(Handler<AsyncResult<Float>> resultHandler) { 
     delegate.floatHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Float> floatHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Float> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     floatHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Float> rxFloatHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      floatHandler(fut);
+    }));
+  }
+
   public void floatNullHandler(Handler<AsyncResult<Float>> resultHandler) { 
     delegate.floatNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Float> floatNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Float> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     floatNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Float> rxFloatNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      floatNullHandler(fut);
+    }));
+  }
+
   public void doubleHandler(Handler<AsyncResult<Double>> resultHandler) { 
     delegate.doubleHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Double> doubleHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Double> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     doubleHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Double> rxDoubleHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      doubleHandler(fut);
+    }));
+  }
+
   public void doubleNullHandler(Handler<AsyncResult<Double>> resultHandler) { 
     delegate.doubleNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Double> doubleNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Double> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     doubleNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Double> rxDoubleNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      doubleNullHandler(fut);
+    }));
+  }
+
   public void charHandler(Handler<AsyncResult<Character>> resultHandler) { 
     delegate.charHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Character> charHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Character> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     charHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Character> rxCharHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      charHandler(fut);
+    }));
+  }
+
   public void charNullHandler(Handler<AsyncResult<Character>> resultHandler) { 
     delegate.charNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Character> charNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Character> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     charNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Character> rxCharNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      charNullHandler(fut);
+    }));
+  }
+
   public void booleanHandler(Handler<AsyncResult<Boolean>> resultHandler) { 
     delegate.booleanHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Boolean> booleanHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Boolean> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     booleanHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Boolean> rxBooleanHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      booleanHandler(fut);
+    }));
+  }
+
   public void booleanNullHandler(Handler<AsyncResult<Boolean>> resultHandler) { 
     delegate.booleanNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Boolean> booleanNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Boolean> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     booleanNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Boolean> rxBooleanNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      booleanNullHandler(fut);
+    }));
+  }
+
   public void jsonObjectHandler(Handler<AsyncResult<JsonObject>> resultHandler) { 
     delegate.jsonObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<JsonObject> jsonObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     jsonObjectHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<JsonObject> rxJsonObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      jsonObjectHandler(fut);
+    }));
+  }
+
   public void jsonObjectNullHandler(Handler<AsyncResult<JsonObject>> resultHandler) { 
     delegate.jsonObjectNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<JsonObject> jsonObjectNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     jsonObjectNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<JsonObject> rxJsonObjectNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      jsonObjectNullHandler(fut);
+    }));
+  }
+
   public void jsonArrayHandler(Handler<AsyncResult<JsonArray>> resultHandler) { 
     delegate.jsonArrayHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<JsonArray> jsonArrayHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<JsonArray> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     jsonArrayHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<JsonArray> rxJsonArrayHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      jsonArrayHandler(fut);
+    }));
+  }
+
   public void jsonArrayNullHandler(Handler<AsyncResult<JsonArray>> resultHandler) { 
     delegate.jsonArrayNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<JsonArray> jsonArrayNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<JsonArray> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     jsonArrayNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<JsonArray> rxJsonArrayNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      jsonArrayNullHandler(fut);
+    }));
+  }
+
   public void dataObjectHandler(Handler<AsyncResult<TestDataObject>> resultHandler) { 
     delegate.dataObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<TestDataObject> dataObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<TestDataObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     dataObjectHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<TestDataObject> rxDataObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      dataObjectHandler(fut);
+    }));
+  }
+
   public void dataObjectNullHandler(Handler<AsyncResult<TestDataObject>> resultHandler) { 
     delegate.dataObjectNullHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<TestDataObject> dataObjectNullHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<TestDataObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     dataObjectNullHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<TestDataObject> rxDataObjectNullHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      dataObjectNullHandler(fut);
+    }));
+  }
+
   public void voidHandler(Handler<AsyncResult<Void>> resultHandler) { 
     delegate.voidHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Void> voidHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Void> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     voidHandler(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<Void> rxVoidHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      voidHandler(fut);
+    }));
   }
 
   public TestService fluentMethod(String str, Handler<AsyncResult<String>> resultHandler) { 
@@ -450,10 +668,17 @@ public class TestService {
     return this;
   }
 
+  @Deprecated()
   public Observable<String> fluentMethodObservable(String str) { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     fluentMethod(str, resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<String> rxFluentMethod(String str) { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      fluentMethod(str, fut);
+    }));
   }
 
   public TestService fluentNoParams() { 
@@ -465,260 +690,442 @@ public class TestService {
     delegate.failingMethod(resultHandler);
   }
 
+  @Deprecated()
   public Observable<JsonObject> failingMethodObservable() { 
     io.vertx.rx.java.ObservableFuture<JsonObject> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     failingMethod(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<JsonObject> rxFailingMethod() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      failingMethod(fut);
+    }));
+  }
+
   public void invokeWithMessage(JsonObject object, String str, int i, char chr, SomeEnum senum, Handler<AsyncResult<String>> resultHandler) { 
     delegate.invokeWithMessage(object, str, i, chr, senum, resultHandler);
   }
 
+  @Deprecated()
   public Observable<String> invokeWithMessageObservable(JsonObject object, String str, int i, char chr, SomeEnum senum) { 
     io.vertx.rx.java.ObservableFuture<String> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     invokeWithMessage(object, str, i, chr, senum, resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<String> rxInvokeWithMessage(JsonObject object, String str, int i, char chr, SomeEnum senum) { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      invokeWithMessage(object, str, i, chr, senum, fut);
+    }));
+  }
+
   public void listStringHandler(Handler<AsyncResult<List<String>>> resultHandler) { 
     delegate.listStringHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<String>> listStringHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<String>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listStringHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<String>> rxListStringHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listStringHandler(fut);
+    }));
+  }
+
   public void listByteHandler(Handler<AsyncResult<List<Byte>>> resultHandler) { 
     delegate.listByteHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Byte>> listByteHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Byte>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listByteHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Byte>> rxListByteHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listByteHandler(fut);
+    }));
+  }
+
   public void listShortHandler(Handler<AsyncResult<List<Short>>> resultHandler) { 
     delegate.listShortHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Short>> listShortHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Short>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listShortHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Short>> rxListShortHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listShortHandler(fut);
+    }));
+  }
+
   public void listIntHandler(Handler<AsyncResult<List<Integer>>> resultHandler) { 
     delegate.listIntHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Integer>> listIntHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Integer>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listIntHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Integer>> rxListIntHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listIntHandler(fut);
+    }));
+  }
+
   public void listLongHandler(Handler<AsyncResult<List<Long>>> resultHandler) { 
     delegate.listLongHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Long>> listLongHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Long>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listLongHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Long>> rxListLongHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listLongHandler(fut);
+    }));
+  }
+
   public void listFloatHandler(Handler<AsyncResult<List<Float>>> resultHandler) { 
     delegate.listFloatHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Float>> listFloatHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Float>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listFloatHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Float>> rxListFloatHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listFloatHandler(fut);
+    }));
+  }
+
   public void listDoubleHandler(Handler<AsyncResult<List<Double>>> resultHandler) { 
     delegate.listDoubleHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Double>> listDoubleHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Double>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listDoubleHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Double>> rxListDoubleHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listDoubleHandler(fut);
+    }));
+  }
+
   public void listCharHandler(Handler<AsyncResult<List<Character>>> resultHandler) { 
     delegate.listCharHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Character>> listCharHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Character>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listCharHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Character>> rxListCharHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listCharHandler(fut);
+    }));
+  }
+
   public void listBoolHandler(Handler<AsyncResult<List<Boolean>>> resultHandler) { 
     delegate.listBoolHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<Boolean>> listBoolHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<Boolean>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listBoolHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<Boolean>> rxListBoolHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listBoolHandler(fut);
+    }));
+  }
+
   public void listJsonObjectHandler(Handler<AsyncResult<List<JsonObject>>> resultHandler) { 
     delegate.listJsonObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<JsonObject>> listJsonObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<JsonObject>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listJsonObjectHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<JsonObject>> rxListJsonObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listJsonObjectHandler(fut);
+    }));
+  }
+
   public void listJsonArrayHandler(Handler<AsyncResult<List<JsonArray>>> resultHandler) { 
     delegate.listJsonArrayHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<JsonArray>> listJsonArrayHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<JsonArray>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listJsonArrayHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<JsonArray>> rxListJsonArrayHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listJsonArrayHandler(fut);
+    }));
+  }
+
   public void listDataObjectHandler(Handler<AsyncResult<List<TestDataObject>>> resultHandler) { 
     delegate.listDataObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<List<TestDataObject>> listDataObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<List<TestDataObject>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     listDataObjectHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<List<TestDataObject>> rxListDataObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      listDataObjectHandler(fut);
+    }));
+  }
+
   public void setStringHandler(Handler<AsyncResult<Set<String>>> resultHandler) { 
     delegate.setStringHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<String>> setStringHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<String>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setStringHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<String>> rxSetStringHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setStringHandler(fut);
+    }));
+  }
+
   public void setByteHandler(Handler<AsyncResult<Set<Byte>>> resultHandler) { 
     delegate.setByteHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Byte>> setByteHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Byte>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setByteHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Byte>> rxSetByteHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setByteHandler(fut);
+    }));
+  }
+
   public void setShortHandler(Handler<AsyncResult<Set<Short>>> resultHandler) { 
     delegate.setShortHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Short>> setShortHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Short>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setShortHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Short>> rxSetShortHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setShortHandler(fut);
+    }));
+  }
+
   public void setIntHandler(Handler<AsyncResult<Set<Integer>>> resultHandler) { 
     delegate.setIntHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Integer>> setIntHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Integer>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setIntHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Integer>> rxSetIntHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setIntHandler(fut);
+    }));
+  }
+
   public void setLongHandler(Handler<AsyncResult<Set<Long>>> resultHandler) { 
     delegate.setLongHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Long>> setLongHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Long>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setLongHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Long>> rxSetLongHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setLongHandler(fut);
+    }));
+  }
+
   public void setFloatHandler(Handler<AsyncResult<Set<Float>>> resultHandler) { 
     delegate.setFloatHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Float>> setFloatHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Float>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setFloatHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Float>> rxSetFloatHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setFloatHandler(fut);
+    }));
+  }
+
   public void setDoubleHandler(Handler<AsyncResult<Set<Double>>> resultHandler) { 
     delegate.setDoubleHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Double>> setDoubleHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Double>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setDoubleHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Double>> rxSetDoubleHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setDoubleHandler(fut);
+    }));
+  }
+
   public void setCharHandler(Handler<AsyncResult<Set<Character>>> resultHandler) { 
     delegate.setCharHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Character>> setCharHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Character>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setCharHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Character>> rxSetCharHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setCharHandler(fut);
+    }));
+  }
+
   public void setBoolHandler(Handler<AsyncResult<Set<Boolean>>> resultHandler) { 
     delegate.setBoolHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<Boolean>> setBoolHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<Boolean>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setBoolHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<Boolean>> rxSetBoolHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setBoolHandler(fut);
+    }));
+  }
+
   public void setJsonObjectHandler(Handler<AsyncResult<Set<JsonObject>>> resultHandler) { 
     delegate.setJsonObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<JsonObject>> setJsonObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<JsonObject>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setJsonObjectHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<JsonObject>> rxSetJsonObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setJsonObjectHandler(fut);
+    }));
+  }
+
   public void setJsonArrayHandler(Handler<AsyncResult<Set<JsonArray>>> resultHandler) { 
     delegate.setJsonArrayHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<JsonArray>> setJsonArrayHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<JsonArray>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setJsonArrayHandler(resultHandler.toHandler());
     return resultHandler;
   }
 
+  public Single<Set<JsonArray>> rxSetJsonArrayHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setJsonArrayHandler(fut);
+    }));
+  }
+
   public void setDataObjectHandler(Handler<AsyncResult<Set<TestDataObject>>> resultHandler) { 
     delegate.setDataObjectHandler(resultHandler);
   }
 
+  @Deprecated()
   public Observable<Set<TestDataObject>> setDataObjectHandlerObservable() { 
     io.vertx.rx.java.ObservableFuture<Set<TestDataObject>> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     setDataObjectHandler(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  public Single<Set<TestDataObject>> rxSetDataObjectHandler() { 
+    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+      setDataObjectHandler(fut);
+    }));
   }
 
   public void ignoredMethod() { 

--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -1275,6 +1275,20 @@ that yourself.
 To create a session handler you need to have a session store instance. The session store is the object that
 holds the actual sessions for your application.
 
+The session store is responsible for holding a secure pseudo random number generator in order to guarantee secure session
+ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
+session id of store B since they have different seeds and states.
+
+By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
+every 5 minutes with 64bits of new entropy. However this can all be configured using the system properties:
+
+* io.vertx.ext.web.session.algorithm e.g.: SHA1PRNG
+* io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
+* io.vertx.ext.web.session.seed.bits e.g.: 128
+
+Most users should not need to configure these values unless if you notice that the performance of your application is
+being affected by the PRNG algorithm.
+
 Vert.x-Web comes with two session store implementations out of the box, and you can also write your own if you prefer.
 
 ==== Local session store
@@ -2741,24 +2755,18 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,groovy]
 ----
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.ext.auth.oauth2.OAuth2Auth
+import io.vertx.ext.auth.oauth2.providers.GithubAuth
 import io.vertx.ext.web.handler.OAuth2AuthHandler
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to github
-def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, [
-  clientID:"CLIENT_ID",
-  clientSecret:"CLIENT_SECRET",
-  site:"https://github.com/login",
-  tokenPath:"/oauth/access_token",
-  authorizationPath:"/oauth/authorize"
-])
+def authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET")
 
-// create a oauth2 handler on our domain: "http://localhost:8080"
-def oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080")
+// create a oauth2 handler on our running server
+// the second argument is the full url to the callback as you entered in your provider management console.
+def oauth2 = OAuth2AuthHandler.create(authProvider, "https://myserver.com/callback")
 
 // setup the callback handler for receiving the GitHub callback
-oauth2.setupCallback(router.get("/callback"))
+oauth2.setupCallback(router.route())
 
 // protect everything under /protected
 router.route("/protected/*").handler(oauth2)
@@ -2783,8 +2791,29 @@ A rule of thumb is once a valid callback is executed issue a client side redirec
 redirect should also create a session cookie (or other session mechanism) so the user is not required to authenticate
 for every request.
 
-Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers, for
-example, if you are planning to use Google Auth you implement it as:
+Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers but
+vertx-auth provides you with many out of the box implementations:
+
+
+* App.net `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/AppNetAuth.html[AppNetAuth]`
+* Azure Active Directory `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/AzureADAuth.html[AzureADAuth]`
+* Box.com `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/BoxAuth.html[BoxAuth]`
+* Dropbox `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/DropboxAuth.html[DropboxAuth]`
+* Facebook `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/FacebookAuth.html[FacebookAuth]`
+* Foursquare `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/FoursquareAuth.html[FoursquareAuth]`
+* Github `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/GithubAuth.html[GithubAuth]`
+* Google `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/GoogleAuth.html[GoogleAuth]`
+* Instagram `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/InstagramAuth.html[InstagramAuth]`
+* Keycloak `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.html[KeycloakAuth]`
+* LinkedIn `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/LinkedInAuth.html[LinkedInAuth]`
+* Mailchimp `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/MailchimpAuth.html[MailchimpAuth]`
+* Salesforce `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/SalesforceAuth.html[SalesforceAuth]`
+* Shopify `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/ShopifyAuth.html[ShopifyAuth]`
+* Soundcloud `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/SoundcloudAuth.html[SoundcloudAuth]`
+* Stripe `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/StripeAuth.html[StripeAuth]`
+* Twitter `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/TwitterAuth.html[TwitterAuth]`
+
+However if you're using an unlisted provider you can still do it using the base API like this:
 
 [source,groovy]
 ----
@@ -2824,141 +2853,27 @@ router.get("/").handler({ ctx ->
 
 ----
 
-The changes are only on the configuration, note that the token uri must now be a full URL since it is generated from
-a different server than the authorization one.
+You will need to provide all the details of your provider manually but the end result is the same.
 
-Important to note that for google OAuth you must register all your callback URLs in the developer console, so for the
-current example you would need to register `http://localhost:8080/callback`.
+The handler will pin your application the the configured callback url. The usage is simple as providing the handler
+a route instance and all setup will be done for you. In a typical use case your provider will ask you what is the
+callback url to your application, your then enter a url like: `https://myserver.com/callback`. This is the second
+argument to the handler now you just need to set it up. To make it easier to the end user all you need to do is call
+the setupCallback method.
 
-If you're looking to integrate with LinkedIn then your config should be:
+This is how you pin your handler to the server `https://myserver.com:8447/callback`. Note that the port number is not
+mandatory for the default values, 80 for http, 443 for https.
 
 [source,groovy]
 ----
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.ext.auth.oauth2.OAuth2Auth
 import io.vertx.ext.web.handler.OAuth2AuthHandler
-
-// create an OAuth2 provider, clientID and clientSecret should be requested to LinkedIn
-def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, [
-  clientID:"CLIENT_ID",
-  clientSecret:"CLIENT_SECRET",
-  site:"https://www.linkedin.com",
-  authorizationPath:"/uas/oauth2/authorization",
-  tokenPath:"/uas/oauth2/accessToken"
-])
-
-// create a oauth2 handler on our domain: "http://localhost:8080"
-def oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080")
-
-// these are the scopes
-oauth2.addAuthority("r_basicprofile")
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"))
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2)
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler({ rc ->
-  rc.response().end("Welcome to the protected resource!")
-})
-
-// welcome page
-router.get("/").handler({ ctx ->
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>")
-})
+// create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
+def oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback")
+// now allow the handler to setup the callback url for you
+oauth2.setupCallback(router.route())
 
 ----
 
-When dealing with Microsoft Azure AD you should have to create an application key in order to get a client secret
-and extract the application GUID from the endpoints panel and finally know your resource GUID which you can inspect
-from the manifest.
-
-[source,groovy]
-----
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.groovy.ext.auth.oauth2.OAuth2Auth
-import io.vertx.groovy.ext.web.handler.OAuth2AuthHandler
-
-// create an OAuth2 provider, clientID and clientSecret should be requested to Azure AD
-def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, [
-  clientID:"APPLICATION_ID",
-  clientSecret:"APPLICATION_KEYS_SECRET",
-  site:"https://login.windows.net/YOUR_CLIENT_GUID",
-  authorizationPath:"/oauth2/token",
-  tokenPath:"/oauth2/authorize"
-])
-
-// create a oauth2 handler (Azure requires HTTPS) and your resource GUID
-def oauth2 = OAuth2AuthHandler.create(authProvider, "https://localhost:8443").extraParams([
-  resource:"00000002-0000-0000-c000-000000000000"
-])
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"))
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2)
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler({ rc ->
-  rc.response().end("Welcome to the protected resource!")
-})
-
-// welcome page
-router.get("/").handler({ ctx ->
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>")
-})
-
-----
-
-As it can be seen from the examples all you need to know is 2 urls, the authorization path and the token path. You
-will find all these configurations on your provider documentation we have also listed on the auth project examples
-for:
-
-* google
-* twitter
-* github
-* linkedin
-* facebook
-* keycloak
-* azure AD
-
-For keycloak we have a slighter easier setup, just export the json file from the keycloak admin console and load it
-into the handler. Keycloak has some differences from the other providers in the sense that it can also use the token
-to specify grants. You can validate against these grants like this:
-
-[source,groovy]
-----
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.ext.auth.oauth2.OAuth2Auth
-import io.vertx.ext.web.handler.OAuth2AuthHandler
-// create an OAuth2 provider for keycloak
-def authProvider = OAuth2Auth.createKeycloak(vertx, OAuth2FlowType.AUTH_CODE, [:])
-
-// create a oauth2 handler on our domain: "http://localhost:8000"
-def oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8000")
-
-// setup the callback handler for receiving the keycloak callback
-oauth2.setupCallback(router.get("/callback"))
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2)
-
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler({ rc ->
-  // you can now do authZ based on keycloak grants
-  rc.user().isAuthorised("account:manage-account", { manageAccount ->
-    if (manageAccount.result()) {
-      rc.response().end("Welcome to the protected resource and you can manage your account!")
-    } else {
-      rc.response().end("Welcome to the protected resource but you cannot manage your account!")
-    }
-  })
-})
-
-// welcome page
-router.get("/").handler({ ctx ->
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by keycloak</a>")
-})
-
-----
+In the example the route object is created inline by `Router.route()` however if you want to have full control of the
+order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
+create the route object before and pass it as a reference to this method.

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1171,6 +1171,20 @@ that yourself.
 To create a session handler you need to have a session store instance. The session store is the object that
 holds the actual sessions for your application.
 
+The session store is responsible for holding a secure pseudo random number generator in order to guarantee secure session
+ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
+session id of store B since they have different seeds and states.
+
+By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
+every 5 minutes with 64bits of new entropy. However this can all be configured using the system properties:
+
+* io.vertx.ext.web.session.algorithm e.g.: SHA1PRNG
+* io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
+* io.vertx.ext.web.session.seed.bits e.g.: 128
+
+Most users should not need to configure these values unless if you notice that the performance of your application is
+being affected by the PRNG algorithm.
+
 Vert.x-Web comes with two session store implementations out of the box, and you can also write your own if you prefer.
 
 ==== Local session store
@@ -2441,18 +2455,14 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,java]
 ----
-OAuth2Auth authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, new OAuth2ClientOptions()
-    .setClientID("CLIENT_ID")
-    .setClientSecret("CLIENT_SECRET")
-    .setSite("https://github.com/login")
-    .setTokenPath("/oauth/access_token")
-    .setAuthorizationPath("/oauth/authorize"));
+OAuth2Auth authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET");
 
-// create a oauth2 handler on our domain: "http://localhost:8080"
-OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080");
+// create a oauth2 handler on our running server
+// the second argument is the full url to the callback as you entered in your provider management console.
+OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider, "https://myserver.com/callback");
 
 // setup the callback handler for receiving the GitHub callback
-oauth2.setupCallback(router.get("/callback"));
+oauth2.setupCallback(router.route());
 
 // protect everything under /protected
 router.route("/protected/*").handler(oauth2);
@@ -2476,8 +2486,29 @@ A rule of thumb is once a valid callback is executed issue a client side redirec
 redirect should also create a session cookie (or other session mechanism) so the user is not required to authenticate
 for every request.
 
-Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers, for
-example, if you are planning to use Google Auth you implement it as:
+Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers but
+vertx-auth provides you with many out of the box implementations:
+
+
+* App.net `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/AppNetAuth.html[AppNetAuth]`
+* Azure Active Directory `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/AzureADAuth.html[AzureADAuth]`
+* Box.com `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/BoxAuth.html[BoxAuth]`
+* Dropbox `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/DropboxAuth.html[DropboxAuth]`
+* Facebook `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/FacebookAuth.html[FacebookAuth]`
+* Foursquare `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/FoursquareAuth.html[FoursquareAuth]`
+* Github `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/GithubAuth.html[GithubAuth]`
+* Google `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/GoogleAuth.html[GoogleAuth]`
+* Instagram `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/InstagramAuth.html[InstagramAuth]`
+* Keycloak `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.html[KeycloakAuth]`
+* LinkedIn `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/LinkedInAuth.html[LinkedInAuth]`
+* Mailchimp `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/MailchimpAuth.html[MailchimpAuth]`
+* Salesforce `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/SalesforceAuth.html[SalesforceAuth]`
+* Shopify `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/ShopifyAuth.html[ShopifyAuth]`
+* Soundcloud `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/SoundcloudAuth.html[SoundcloudAuth]`
+* Stripe `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/StripeAuth.html[StripeAuth]`
+* Twitter `link:../../apidocs/io/vertx/ext/auth/oauth2/providers/TwitterAuth.html[TwitterAuth]`
+
+However if you're using an unlisted provider you can still do it using the base API like this:
 
 [source,java]
 ----
@@ -2510,122 +2541,24 @@ router.get("/").handler(ctx -> {
 });
 ----
 
-The changes are only on the configuration, note that the token uri must now be a full URL since it is generated from
-a different server than the authorization one.
+You will need to provide all the details of your provider manually but the end result is the same.
 
-Important to note that for google OAuth you must register all your callback URLs in the developer console, so for the
-current example you would need to register `http://localhost:8080/callback`.
+The handler will pin your application the the configured callback url. The usage is simple as providing the handler
+a route instance and all setup will be done for you. In a typical use case your provider will ask you what is the
+callback url to your application, your then enter a url like: `https://myserver.com/callback`. This is the second
+argument to the handler now you just need to set it up. To make it easier to the end user all you need to do is call
+the setupCallback method.
 
-If you're looking to integrate with LinkedIn then your config should be:
-
-[source,java]
-----
-OAuth2Auth authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, new OAuth2ClientOptions()
-    .setClientID("CLIENT_ID")
-    .setClientSecret("CLIENT_SECRET")
-    .setSite("https://www.linkedin.com")
-    .setAuthorizationPath("/uas/oauth2/authorization")
-    .setTokenPath("/uas/oauth2/accessToken"));
-
-// create a oauth2 handler on our domain: "http://localhost:8080"
-OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080");
-
-// these are the scopes
-oauth2.addAuthority("r_basicprofile");
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2);
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(rc -> {
-  rc.response().end("Welcome to the protected resource!");
-});
-
-// welcome page
-router.get("/").handler(ctx -> {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>");
-});
-----
-
-When dealing with Microsoft Azure AD you should have to create an application key in order to get a client secret
-and extract the application GUID from the endpoints panel and finally know your resource GUID which you can inspect
-from the manifest.
+This is how you pin your handler to the server `https://myserver.com:8447/callback`. Note that the port number is not
+mandatory for the default values, 80 for http, 443 for https.
 
 [source,java]
 ----
-OAuth2Auth authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, new OAuth2ClientOptions()
-        .setClientID("APPLICATION_ID")
-        .setClientSecret("APPLICATION_KEYS_SECRET")
-        .setSite("https://login.windows.net/YOUR_CLIENT_GUID")
-        .setAuthorizationPath("/oauth2/token")
-        .setTokenPath("/oauth2/authorize"));
-
-// create a oauth2 handler (Azure requires HTTPS) and your resource GUID
-OAuth2AuthHandler oauth2 = OAuth2AuthHandler
-        .create(authProvider, "https://localhost:8443")
-        .extraParams(new JsonObject().put("resource", "00000002-0000-0000-c000-000000000000"));
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2);
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(rc -> {
-  rc.response().end("Welcome to the protected resource!");
-});
-
-// welcome page
-router.get("/").handler(ctx -> {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>");
-});
+OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback");
+// now allow the handler to setup the callback url for you
+oauth2.setupCallback(router.route());
 ----
 
-As it can be seen from the examples all you need to know is 2 urls, the authorization path and the token path. You
-will find all these configurations on your provider documentation we have also listed on the auth project examples
-for:
-
-* google
-* twitter
-* github
-* linkedin
-* facebook
-* keycloak
-* azure AD
-
-For keycloak we have a slighter easier setup, just export the json file from the keycloak admin console and load it
-into the handler. Keycloak has some differences from the other providers in the sense that it can also use the token
-to specify grants. You can validate against these grants like this:
-
-[source,java]
-----
-OAuth2Auth authProvider = OAuth2Auth.createKeycloak(vertx, OAuth2FlowType.AUTH_CODE, new JsonObject());
-
-// create a oauth2 handler on our domain: "http://localhost:8000"
-OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8000");
-
-// setup the callback handler for receiving the keycloak callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2);
-
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(rc -> {
-  // you can now do authZ based on keycloak grants
-  rc.user().isAuthorised("account:manage-account", manageAccount -> {
-    if (manageAccount.result()) {
-      rc.response().end("Welcome to the protected resource and you can manage your account!");
-    } else {
-      rc.response().end("Welcome to the protected resource but you cannot manage your account!");
-    }
-  });
-});
-
-// welcome page
-router.get("/").handler(ctx -> {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by keycloak</a>");
-});
-----
+In the example the route object is created inline by `Router.route()` however if you want to have full control of the
+order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
+create the route object before and pass it as a reference to this method.

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -1270,6 +1270,20 @@ that yourself.
 To create a session handler you need to have a session store instance. The session store is the object that
 holds the actual sessions for your application.
 
+The session store is responsible for holding a secure pseudo random number generator in order to guarantee secure session
+ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
+session id of store B since they have different seeds and states.
+
+By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
+every 5 minutes with 64bits of new entropy. However this can all be configured using the system properties:
+
+* io.vertx.ext.web.session.algorithm e.g.: SHA1PRNG
+* io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
+* io.vertx.ext.web.session.seed.bits e.g.: 128
+
+Most users should not need to configure these values unless if you notice that the performance of your application is
+being affected by the PRNG algorithm.
+
 Vert.x-Web comes with two session store implementations out of the box, and you can also write your own if you prefer.
 
 ==== Local session store
@@ -2736,23 +2750,18 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,js]
 ----
-var OAuth2Auth = require("vertx-auth-oauth2-js/o_auth2_auth");
+var GithubAuth = require("vertx-auth-oauth2-js/github_auth");
 var OAuth2AuthHandler = require("vertx-web-js/o_auth2_auth_handler");
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to github
-var authProvider = OAuth2Auth.create(vertx, 'AUTH_CODE', {
-  "clientID" : "CLIENT_ID",
-  "clientSecret" : "CLIENT_SECRET",
-  "site" : "https://github.com/login",
-  "tokenPath" : "/oauth/access_token",
-  "authorizationPath" : "/oauth/authorize"
-});
+var authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET");
 
-// create a oauth2 handler on our domain: "http://localhost:8080"
-var oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080");
+// create a oauth2 handler on our running server
+// the second argument is the full url to the callback as you entered in your provider management console.
+var oauth2 = OAuth2AuthHandler.create(authProvider, "https://myserver.com/callback");
 
 // setup the callback handler for receiving the GitHub callback
-oauth2.setupCallback(router.get("/callback"));
+oauth2.setupCallback(router.route());
 
 // protect everything under /protected
 router.route("/protected/*").handler(oauth2.handle);
@@ -2777,8 +2786,29 @@ A rule of thumb is once a valid callback is executed issue a client side redirec
 redirect should also create a session cookie (or other session mechanism) so the user is not required to authenticate
 for every request.
 
-Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers, for
-example, if you are planning to use Google Auth you implement it as:
+Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers but
+vertx-auth provides you with many out of the box implementations:
+
+
+* App.net `link:../../jsdoc/module-vertx-auth-oauth2-js_app_net_auth-AppNetAuth.html[AppNetAuth]`
+* Azure Active Directory `link:../../jsdoc/module-vertx-auth-oauth2-js_azure_ad_auth-AzureADAuth.html[AzureADAuth]`
+* Box.com `link:../../jsdoc/module-vertx-auth-oauth2-js_box_auth-BoxAuth.html[BoxAuth]`
+* Dropbox `link:../../jsdoc/module-vertx-auth-oauth2-js_dropbox_auth-DropboxAuth.html[DropboxAuth]`
+* Facebook `link:../../jsdoc/module-vertx-auth-oauth2-js_facebook_auth-FacebookAuth.html[FacebookAuth]`
+* Foursquare `link:../../jsdoc/module-vertx-auth-oauth2-js_foursquare_auth-FoursquareAuth.html[FoursquareAuth]`
+* Github `link:../../jsdoc/module-vertx-auth-oauth2-js_github_auth-GithubAuth.html[GithubAuth]`
+* Google `link:../../jsdoc/module-vertx-auth-oauth2-js_google_auth-GoogleAuth.html[GoogleAuth]`
+* Instagram `link:../../jsdoc/module-vertx-auth-oauth2-js_instagram_auth-InstagramAuth.html[InstagramAuth]`
+* Keycloak `link:../../jsdoc/module-vertx-auth-oauth2-js_keycloak_auth-KeycloakAuth.html[KeycloakAuth]`
+* LinkedIn `link:../../jsdoc/module-vertx-auth-oauth2-js_linked_in_auth-LinkedInAuth.html[LinkedInAuth]`
+* Mailchimp `link:../../jsdoc/module-vertx-auth-oauth2-js_mailchimp_auth-MailchimpAuth.html[MailchimpAuth]`
+* Salesforce `link:../../jsdoc/module-vertx-auth-oauth2-js_salesforce_auth-SalesforceAuth.html[SalesforceAuth]`
+* Shopify `link:../../jsdoc/module-vertx-auth-oauth2-js_shopify_auth-ShopifyAuth.html[ShopifyAuth]`
+* Soundcloud `link:../../jsdoc/module-vertx-auth-oauth2-js_soundcloud_auth-SoundcloudAuth.html[SoundcloudAuth]`
+* Stripe `link:../../jsdoc/module-vertx-auth-oauth2-js_stripe_auth-StripeAuth.html[StripeAuth]`
+* Twitter `link:../../jsdoc/module-vertx-auth-oauth2-js_twitter_auth-TwitterAuth.html[TwitterAuth]`
+
+However if you're using an unlisted provider you can still do it using the base API like this:
 
 [source,js]
 ----
@@ -2817,139 +2847,27 @@ router.get("/").handler(function (ctx) {
 
 ----
 
-The changes are only on the configuration, note that the token uri must now be a full URL since it is generated from
-a different server than the authorization one.
+You will need to provide all the details of your provider manually but the end result is the same.
 
-Important to note that for google OAuth you must register all your callback URLs in the developer console, so for the
-current example you would need to register `http://localhost:8080/callback`.
+The handler will pin your application the the configured callback url. The usage is simple as providing the handler
+a route instance and all setup will be done for you. In a typical use case your provider will ask you what is the
+callback url to your application, your then enter a url like: `https://myserver.com/callback`. This is the second
+argument to the handler now you just need to set it up. To make it easier to the end user all you need to do is call
+the setupCallback method.
 
-If you're looking to integrate with LinkedIn then your config should be:
-
-[source,js]
-----
-var OAuth2Auth = require("vertx-auth-oauth2-js/o_auth2_auth");
-var OAuth2AuthHandler = require("vertx-web-js/o_auth2_auth_handler");
-
-// create an OAuth2 provider, clientID and clientSecret should be requested to LinkedIn
-var authProvider = OAuth2Auth.create(vertx, 'AUTH_CODE', {
-  "clientID" : "CLIENT_ID",
-  "clientSecret" : "CLIENT_SECRET",
-  "site" : "https://www.linkedin.com",
-  "authorizationPath" : "/uas/oauth2/authorization",
-  "tokenPath" : "/uas/oauth2/accessToken"
-});
-
-// create a oauth2 handler on our domain: "http://localhost:8080"
-var oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8080");
-
-// these are the scopes
-oauth2.addAuthority("r_basicprofile");
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2.handle);
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(function (rc) {
-  rc.response().end("Welcome to the protected resource!");
-});
-
-// welcome page
-router.get("/").handler(function (ctx) {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>");
-});
-
-----
-
-When dealing with Microsoft Azure AD you should have to create an application key in order to get a client secret
-and extract the application GUID from the endpoints panel and finally know your resource GUID which you can inspect
-from the manifest.
+This is how you pin your handler to the server `https://myserver.com:8447/callback`. Note that the port number is not
+mandatory for the default values, 80 for http, 443 for https.
 
 [source,js]
 ----
-var OAuth2Auth = require("vertx-auth-oauth2-js/o_auth2_auth");
 var OAuth2AuthHandler = require("vertx-web-js/o_auth2_auth_handler");
-
-// create an OAuth2 provider, clientID and clientSecret should be requested to Azure AD
-var authProvider = OAuth2Auth.create(vertx, 'AUTH_CODE', {
-  "clientID" : "APPLICATION_ID",
-  "clientSecret" : "APPLICATION_KEYS_SECRET",
-  "site" : "https://login.windows.net/YOUR_CLIENT_GUID",
-  "authorizationPath" : "/oauth2/token",
-  "tokenPath" : "/oauth2/authorize"
-});
-
-// create a oauth2 handler (Azure requires HTTPS) and your resource GUID
-var oauth2 = OAuth2AuthHandler.create(authProvider, "https://localhost:8443").extraParams({
-  "resource" : "00000002-0000-0000-c000-000000000000"
-});
-
-// setup the callback handler for receiving the LinkedIn callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2.handle);
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(function (rc) {
-  rc.response().end("Welcome to the protected resource!");
-});
-
-// welcome page
-router.get("/").handler(function (ctx) {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>");
-});
+// create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
+var oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback");
+// now allow the handler to setup the callback url for you
+oauth2.setupCallback(router.route());
 
 ----
 
-As it can be seen from the examples all you need to know is 2 urls, the authorization path and the token path. You
-will find all these configurations on your provider documentation we have also listed on the auth project examples
-for:
-
-* google
-* twitter
-* github
-* linkedin
-* facebook
-* keycloak
-* azure AD
-
-For keycloak we have a slighter easier setup, just export the json file from the keycloak admin console and load it
-into the handler. Keycloak has some differences from the other providers in the sense that it can also use the token
-to specify grants. You can validate against these grants like this:
-
-[source,js]
-----
-var OAuth2Auth = require("vertx-auth-oauth2-js/o_auth2_auth");
-var OAuth2AuthHandler = require("vertx-web-js/o_auth2_auth_handler");
-// create an OAuth2 provider for keycloak
-var authProvider = OAuth2Auth.createKeycloak(vertx, 'AUTH_CODE', {
-});
-
-// create a oauth2 handler on our domain: "http://localhost:8000"
-var oauth2 = OAuth2AuthHandler.create(authProvider, "http://localhost:8000");
-
-// setup the callback handler for receiving the keycloak callback
-oauth2.setupCallback(router.get("/callback"));
-
-// protect everything under /protected
-router.route("/protected/*").handler(oauth2.handle);
-
-// mount some handler under the protected zone
-router.route("/protected/somepage").handler(function (rc) {
-  // you can now do authZ based on keycloak grants
-  rc.user().isAuthorised("account:manage-account", function (manageAccount, manageAccount_err) {
-    if (manageAccount) {
-      rc.response().end("Welcome to the protected resource and you can manage your account!");
-    } else {
-      rc.response().end("Welcome to the protected resource but you cannot manage your account!");
-    }
-  });
-});
-
-// welcome page
-router.get("/").handler(function (ctx) {
-  ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by keycloak</a>");
-});
-
-----
+In the example the route object is created inline by `Router.route()` however if you want to have full control of the
+order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
+create the route object before and pass it as a reference to this method.

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -1270,6 +1270,20 @@ that yourself.
 To create a session handler you need to have a session store instance. The session store is the object that
 holds the actual sessions for your application.
 
+The session store is responsible for holding a secure pseudo random number generator in order to guarantee secure session
+ids. This PRNG is independent of the store which means that given a session id from store A one cannot derive the
+session id of store B since they have different seeds and states.
+
+By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
+every 5 minutes with 64bits of new entropy. However this can all be configured using the system properties:
+
+* io.vertx.ext.web.session.algorithm e.g.: SHA1PRNG
+* io.vertx.ext.web.session.seed.interval e.g.: 1000 (every second)
+* io.vertx.ext.web.session.seed.bits e.g.: 128
+
+Most users should not need to configure these values unless if you notice that the performance of your application is
+being affected by the PRNG algorithm.
+
 Vert.x-Web comes with two session store implementations out of the box, and you can also write your own if you prefer.
 
 ==== Local session store
@@ -2736,23 +2750,18 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,ruby]
 ----
-require 'vertx-auth-oauth2/o_auth2_auth'
+require 'vertx-auth-oauth2/github_auth'
 require 'vertx-web/o_auth2_auth_handler'
 
 # create an OAuth2 provider, clientID and clientSecret should be requested to github
-authProvider = VertxAuthOauth2::OAuth2Auth.create(vertx, :AUTH_CODE, {
-  'clientID' => "CLIENT_ID",
-  'clientSecret' => "CLIENT_SECRET",
-  'site' => "https://github.com/login",
-  'tokenPath' => "/oauth/access_token",
-  'authorizationPath' => "/oauth/authorize"
-})
+authProvider = VertxAuthOauth2::GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET")
 
-# create a oauth2 handler on our domain: "http://localhost:8080"
-oauth2 = VertxWeb::OAuth2AuthHandler.create(authProvider, "http://localhost:8080")
+# create a oauth2 handler on our running server
+# the second argument is the full url to the callback as you entered in your provider management console.
+oauth2 = VertxWeb::OAuth2AuthHandler.create(authProvider, "https://myserver.com/callback")
 
 # setup the callback handler for receiving the GitHub callback
-oauth2.setup_callback(router.get("/callback"))
+oauth2.setup_callback(router.route())
 
 # protect everything under /protected
 router.route("/protected/*").handler(&oauth2.method(:handle))
@@ -2777,8 +2786,29 @@ A rule of thumb is once a valid callback is executed issue a client side redirec
 redirect should also create a session cookie (or other session mechanism) so the user is not required to authenticate
 for every request.
 
-Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers, for
-example, if you are planning to use Google Auth you implement it as:
+Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers but
+vertx-auth provides you with many out of the box implementations:
+
+
+* App.net `link:../../yardoc/VertxAuthOauth2/AppNetAuth.html[AppNetAuth]`
+* Azure Active Directory `link:../../yardoc/VertxAuthOauth2/AzureADAuth.html[AzureADAuth]`
+* Box.com `link:../../yardoc/VertxAuthOauth2/BoxAuth.html[BoxAuth]`
+* Dropbox `link:../../yardoc/VertxAuthOauth2/DropboxAuth.html[DropboxAuth]`
+* Facebook `link:../../yardoc/VertxAuthOauth2/FacebookAuth.html[FacebookAuth]`
+* Foursquare `link:../../yardoc/VertxAuthOauth2/FoursquareAuth.html[FoursquareAuth]`
+* Github `link:../../yardoc/VertxAuthOauth2/GithubAuth.html[GithubAuth]`
+* Google `link:../../yardoc/VertxAuthOauth2/GoogleAuth.html[GoogleAuth]`
+* Instagram `link:../../yardoc/VertxAuthOauth2/InstagramAuth.html[InstagramAuth]`
+* Keycloak `link:../../yardoc/VertxAuthOauth2/KeycloakAuth.html[KeycloakAuth]`
+* LinkedIn `link:../../yardoc/VertxAuthOauth2/LinkedInAuth.html[LinkedInAuth]`
+* Mailchimp `link:../../yardoc/VertxAuthOauth2/MailchimpAuth.html[MailchimpAuth]`
+* Salesforce `link:../../yardoc/VertxAuthOauth2/SalesforceAuth.html[SalesforceAuth]`
+* Shopify `link:../../yardoc/VertxAuthOauth2/ShopifyAuth.html[ShopifyAuth]`
+* Soundcloud `link:../../yardoc/VertxAuthOauth2/SoundcloudAuth.html[SoundcloudAuth]`
+* Stripe `link:../../yardoc/VertxAuthOauth2/StripeAuth.html[StripeAuth]`
+* Twitter `link:../../yardoc/VertxAuthOauth2/TwitterAuth.html[TwitterAuth]`
+
+However if you're using an unlisted provider you can still do it using the base API like this:
 
 [source,ruby]
 ----
@@ -2817,139 +2847,27 @@ router.get("/").handler() { |ctx|
 
 ----
 
-The changes are only on the configuration, note that the token uri must now be a full URL since it is generated from
-a different server than the authorization one.
+You will need to provide all the details of your provider manually but the end result is the same.
 
-Important to note that for google OAuth you must register all your callback URLs in the developer console, so for the
-current example you would need to register `http://localhost:8080/callback`.
+The handler will pin your application the the configured callback url. The usage is simple as providing the handler
+a route instance and all setup will be done for you. In a typical use case your provider will ask you what is the
+callback url to your application, your then enter a url like: `https://myserver.com/callback`. This is the second
+argument to the handler now you just need to set it up. To make it easier to the end user all you need to do is call
+the setupCallback method.
 
-If you're looking to integrate with LinkedIn then your config should be:
-
-[source,ruby]
-----
-require 'vertx-auth-oauth2/o_auth2_auth'
-require 'vertx-web/o_auth2_auth_handler'
-
-# create an OAuth2 provider, clientID and clientSecret should be requested to LinkedIn
-authProvider = VertxAuthOauth2::OAuth2Auth.create(vertx, :AUTH_CODE, {
-  'clientID' => "CLIENT_ID",
-  'clientSecret' => "CLIENT_SECRET",
-  'site' => "https://www.linkedin.com",
-  'authorizationPath' => "/uas/oauth2/authorization",
-  'tokenPath' => "/uas/oauth2/accessToken"
-})
-
-# create a oauth2 handler on our domain: "http://localhost:8080"
-oauth2 = VertxWeb::OAuth2AuthHandler.create(authProvider, "http://localhost:8080")
-
-# these are the scopes
-oauth2.add_authority("r_basicprofile")
-
-# setup the callback handler for receiving the LinkedIn callback
-oauth2.setup_callback(router.get("/callback"))
-
-# protect everything under /protected
-router.route("/protected/*").handler(&oauth2.method(:handle))
-# mount some handler under the protected zone
-router.route("/protected/somepage").handler() { |rc|
-  rc.response().end("Welcome to the protected resource!")
-}
-
-# welcome page
-router.get("/").handler() { |ctx|
-  ctx.response().put_header("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>")
-}
-
-----
-
-When dealing with Microsoft Azure AD you should have to create an application key in order to get a client secret
-and extract the application GUID from the endpoints panel and finally know your resource GUID which you can inspect
-from the manifest.
+This is how you pin your handler to the server `https://myserver.com:8447/callback`. Note that the port number is not
+mandatory for the default values, 80 for http, 443 for https.
 
 [source,ruby]
 ----
-require 'vertx-auth-oauth2/o_auth2_auth'
 require 'vertx-web/o_auth2_auth_handler'
-
-# create an OAuth2 provider, clientID and clientSecret should be requested to Azure AD
-authProvider = VertxAuthOauth2::OAuth2Auth.create(vertx, :AUTH_CODE, {
-  'clientID' => "APPLICATION_ID",
-  'clientSecret' => "APPLICATION_KEYS_SECRET",
-  'site' => "https://login.windows.net/YOUR_CLIENT_GUID",
-  'authorizationPath' => "/oauth2/token",
-  'tokenPath' => "/oauth2/authorize"
-})
-
-# create a oauth2 handler (Azure requires HTTPS) and your resource GUID
-oauth2 = VertxWeb::OAuth2AuthHandler.create(authProvider, "https://localhost:8443").extra_params({
-  'resource' => "00000002-0000-0000-c000-000000000000"
-})
-
-# setup the callback handler for receiving the LinkedIn callback
-oauth2.setup_callback(router.get("/callback"))
-
-# protect everything under /protected
-router.route("/protected/*").handler(&oauth2.method(:handle))
-# mount some handler under the protected zone
-router.route("/protected/somepage").handler() { |rc|
-  rc.response().end("Welcome to the protected resource!")
-}
-
-# welcome page
-router.get("/").handler() { |ctx|
-  ctx.response().put_header("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>")
-}
+# create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
+oauth2 = VertxWeb::OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback")
+# now allow the handler to setup the callback url for you
+oauth2.setup_callback(router.route())
 
 ----
 
-As it can be seen from the examples all you need to know is 2 urls, the authorization path and the token path. You
-will find all these configurations on your provider documentation we have also listed on the auth project examples
-for:
-
-* google
-* twitter
-* github
-* linkedin
-* facebook
-* keycloak
-* azure AD
-
-For keycloak we have a slighter easier setup, just export the json file from the keycloak admin console and load it
-into the handler. Keycloak has some differences from the other providers in the sense that it can also use the token
-to specify grants. You can validate against these grants like this:
-
-[source,ruby]
-----
-require 'vertx-auth-oauth2/o_auth2_auth'
-require 'vertx-web/o_auth2_auth_handler'
-# create an OAuth2 provider for keycloak
-authProvider = VertxAuthOauth2::OAuth2Auth.create_keycloak(vertx, :AUTH_CODE, {
-})
-
-# create a oauth2 handler on our domain: "http://localhost:8000"
-oauth2 = VertxWeb::OAuth2AuthHandler.create(authProvider, "http://localhost:8000")
-
-# setup the callback handler for receiving the keycloak callback
-oauth2.setup_callback(router.get("/callback"))
-
-# protect everything under /protected
-router.route("/protected/*").handler(&oauth2.method(:handle))
-
-# mount some handler under the protected zone
-router.route("/protected/somepage").handler() { |rc|
-  # you can now do authZ based on keycloak grants
-  rc.user().is_authorised("account:manage-account") { |manageAccount_err,manageAccount|
-    if (manageAccount)
-      rc.response().end("Welcome to the protected resource and you can manage your account!")
-    else
-      rc.response().end("Welcome to the protected resource but you cannot manage your account!")
-    end
-  }
-}
-
-# welcome page
-router.get("/").handler() { |ctx|
-  ctx.response().put_header("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by keycloak</a>")
-}
-
-----
+In the example the route object is created inline by `Router.route()` however if you want to have full control of the
+order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
+create the route object before and pass it as a reference to this method.

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -1144,10 +1144,11 @@ public class WebExamples {
     OAuth2Auth authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET");
 
     // create a oauth2 handler on our running server
-    OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider);
+    // the second argument is the full url to the callback as you entered in your provider management console.
+    OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(authProvider, "https://myserver.com/callback");
 
     // setup the callback handler for receiving the GitHub callback
-    oauth2.setupCallback(router.get("/callback"));
+    oauth2.setupCallback(router.route());
 
     // protect everything under /protected
     router.route("/protected/*").handler(oauth2);
@@ -1194,8 +1195,10 @@ public class WebExamples {
     });
   }
   public void example61(Vertx vertx, Router router, OAuth2Auth provider) {
-    // create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447"
-    OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447");
+    // create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
+    OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback");
+    // now allow the handler to setup the callback url for you
+    oauth2.setupCallback(router.route());
   }
 
   public void example62(Vertx vertx, Router router) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -33,13 +33,24 @@ import io.vertx.ext.web.handler.impl.OAuth2AuthHandlerImpl;
 public interface OAuth2AuthHandler extends AuthHandler {
 
   /**
+   * Create a OAuth2 auth handler with host pinning
+   *
+   * @param authProvider  the auth provider to use
+   * @param host the host as in http header that points to the server where this will be running e.g.: https://myserver:8888
+   * @return the auth handler
+   */
+  static OAuth2AuthHandler create(OAuth2Auth authProvider, String host) {
+    return new OAuth2AuthHandlerImpl(authProvider, host);
+  }
+
+  /**
    * Create a OAuth2 auth handler
    *
    * @param authProvider  the auth provider to use
    * @return the auth handler
    */
-  static OAuth2AuthHandler create(OAuth2Auth authProvider, String uri) {
-    return new OAuth2AuthHandlerImpl(authProvider, uri);
+  static OAuth2AuthHandler create(OAuth2Auth authProvider) {
+    return new OAuth2AuthHandlerImpl(authProvider, null);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -19,7 +19,6 @@ package io.vertx.ext.web.handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.handler.impl.OAuth2AuthHandlerImpl;
@@ -36,21 +35,11 @@ public interface OAuth2AuthHandler extends AuthHandler {
    * Create a OAuth2 auth handler with host pinning
    *
    * @param authProvider  the auth provider to use
-   * @param host the host as in http header that points to the server where this will be running e.g.: https://myserver:8888
+   * @param callbackURL the callback URL you entered in your provider admin console, usually it should be something like: `https://myserver:8888/callback`
    * @return the auth handler
    */
-  static OAuth2AuthHandler create(OAuth2Auth authProvider, String host) {
-    return new OAuth2AuthHandlerImpl(authProvider, host);
-  }
-
-  /**
-   * Create a OAuth2 auth handler
-   *
-   * @param authProvider  the auth provider to use
-   * @return the auth handler
-   */
-  static OAuth2AuthHandler create(OAuth2Auth authProvider) {
-    return new OAuth2AuthHandlerImpl(authProvider, null);
+  static OAuth2AuthHandler create(OAuth2Auth authProvider, String callbackURL) {
+    return new OAuth2AuthHandlerImpl(authProvider, callbackURL);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -25,7 +25,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.JWTAuthHandler;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -54,11 +54,6 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
 
   @Override
   public void handle(RoutingContext ctx) {
-    if (host == null) {
-      ctx.fail(new RuntimeException("Callback is not configured!"));
-      return;
-    }
-
     User user = ctx.user();
     if (user != null) {
       // Already authenticated.

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1845,7 +1845,7 @@
  *
  * Mixing OAuth2 and JWT
  *
- * Some providers use JWT tokens as access tokens, this is a feature of <a href="https://tools.ietf.org/html/rfc6750">RFC6750</a>
+ * Some providers use JWT tokens as access tokens, this is a feature of https://tools.ietf.org/html/rfc6750[RFC6750]
  * and can be quite useful when one wants to mix client based authentication and API authorization. For example say that
  * you have a application that provides some protected HTML documents but you also want it to be available for API's to
  * consume. In this case an API cannot easily perform the redirect handshake required by OAuth2 but can use a Token

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1843,6 +1843,19 @@
  * order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
  * create the route object before and pass it as a reference to this method.
  *
+ * Mixing OAuth2 and JWT
+ *
+ * Some providers use JWT tokens as access tokens, this is a feature of <a href="https://tools.ietf.org/html/rfc6750">RFC6750</a>
+ * and can be quite useful when one wants to mix client based authentication and API authorization. For example say that
+ * you have a application that provides some protected HTML documents but you also want it to be available for API's to
+ * consume. In this case an API cannot easily perform the redirect handshake required by OAuth2 but can use a Token
+ * provided before hand.
+ *
+ * This is handled automatically by the handler as long as the provider is configured to support JWTs.
+ *
+ * In real life this means that your API's can access your protected resources using the header `Authorization` with the
+ * value `Bearer BASE64_ACCESS_TOKEN`.
+ *
  */
 @Document(fileName = "index.adoc")
 @ModuleGen(name = "vertx-web", groupPackage = "io.vertx")

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1825,21 +1825,23 @@
  *
  * You will need to provide all the details of your provider manually but the end result is the same.
  *
- * If you're really interested in secure your application it is recommended to use the handler with host name. And avoid
- * using the runtime detection of the server hostname. This is what is commonly called pinning. In order to pin your
- * application to a specific host you should configure it passing a string that should include the protocol and the
- * hostname. It should not be needed to say that anything other than https is not secure and should be avoided.
+ * The handler will pin your application the the configured callback url. The usage is simple as providing the handler
+ * a route instance and all setup will be done for you. In a typical use case your provider will ask you what is the
+ * callback url to your application, your then enter a url like: `https://myserver.com/callback`. This is the second
+ * argument to the handler now you just need to set it up. To make it easier to the end user all you need to do is call
+ * the setupCallback method.
  *
- * This is how you pin your handler to the server `myserver.com`:
+ * This is how you pin your handler to the server `https://myserver.com:8447/callback`. Note that the port number is not
+ * mandatory for the default values, 80 for http, 443 for https.
  *
  * [source,$lang]
  * ----
  * {@link examples.WebExamples#example61}
  * ----
  *
- * By doing this, you make sure that all oauth2 redirects will be done to the specified host. This is useful for cases
- * where your server is running behind a load balancer or in a cluster where the machine name does not necessarily
- * matches the external name.
+ * In the example the route object is created inline by `Router.route()` however if you want to have full control of the
+ * order the handler is called (for example you want it to be called as soon as possible in the chain) you can always
+ * create the route object before and pass it as a reference to this method.
  *
  */
 @Document(fileName = "index.adoc")

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1794,56 +1794,52 @@
  * redirect should also create a session cookie (or other session mechanism) so the user is not required to authenticate
  * for every request.
  *
- * Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers, for
- * example, if you are planning to use Google Auth you implement it as:
+ * Due to the nature of OAuth2 spec there are slight changes required in order to use other OAuth2 providers but
+ * vertx-auth provides you with many out of the box implementations:
+ *
+ *
+ * * App.net {@link io.vertx.ext.auth.oauth2.providers.AppNetAuth}
+ * * Azure Active Directory {@link io.vertx.ext.auth.oauth2.providers.AzureADAuth}
+ * * Box.com {@link io.vertx.ext.auth.oauth2.providers.BoxAuth}
+ * * Dropbox {@link io.vertx.ext.auth.oauth2.providers.DropboxAuth}
+ * * Facebook {@link io.vertx.ext.auth.oauth2.providers.FacebookAuth}
+ * * Foursquare {@link io.vertx.ext.auth.oauth2.providers.FoursquareAuth}
+ * * Github {@link io.vertx.ext.auth.oauth2.providers.GithubAuth}
+ * * Google {@link io.vertx.ext.auth.oauth2.providers.GoogleAuth}
+ * * Instagram {@link io.vertx.ext.auth.oauth2.providers.InstagramAuth}
+ * * Keycloak {@link io.vertx.ext.auth.oauth2.providers.KeycloakAuth}
+ * * LinkedIn {@link io.vertx.ext.auth.oauth2.providers.LinkedInAuth}
+ * * Mailchimp {@link io.vertx.ext.auth.oauth2.providers.MailchimpAuth}
+ * * Salesforce {@link io.vertx.ext.auth.oauth2.providers.SalesforceAuth}
+ * * Shopify {@link io.vertx.ext.auth.oauth2.providers.ShopifyAuth}
+ * * Soundcloud {@link io.vertx.ext.auth.oauth2.providers.SoundcloudAuth}
+ * * Stripe {@link io.vertx.ext.auth.oauth2.providers.StripeAuth}
+ * * Twitter {@link io.vertx.ext.auth.oauth2.providers.TwitterAuth}
+ *
+ * However if you're using an unlisted provider you can still do it using the base API like this:
  *
  * [source,$lang]
  * ----
  * {@link examples.WebExamples#example59}
  * ----
  *
- * The changes are only on the configuration, note that the token uri must now be a full URL since it is generated from
- * a different server than the authorization one.
+ * You will need to provide all the details of your provider manually but the end result is the same.
  *
- * Important to note that for google OAuth you must register all your callback URLs in the developer console, so for the
- * current example you would need to register `http://localhost:8080/callback`.
+ * If you're really interested in secure your application it is recommended to use the handler with host name. And avoid
+ * using the runtime detection of the server hostname. This is what is commonly called pinning. In order to pin your
+ * application to a specific host you should configure it passing a string that should include the protocol and the
+ * hostname. It should not be needed to say that anything other than https is not secure and should be avoided.
  *
- * If you're looking to integrate with LinkedIn then your config should be:
- *
- * [source,$lang]
- * ----
- * {@link examples.WebExamples#example60}
- * ----
- *
- * When dealing with Microsoft Azure AD you should have to create an application key in order to get a client secret
- * and extract the application GUID from the endpoints panel and finally know your resource GUID which you can inspect
- * from the manifest.
- *
- * [source,$lang]
- * ----
- * {@link examples.WebExamples#example62}
- * ----
- *
- * As it can be seen from the examples all you need to know is 2 urls, the authorization path and the token path. You
- * will find all these configurations on your provider documentation we have also listed on the auth project examples
- * for:
- *
- * * google
- * * twitter
- * * github
- * * linkedin
- * * facebook
- * * keycloak
- * * azure AD
- *
- * For keycloak we have a slighter easier setup, just export the json file from the keycloak admin console and load it
- * into the handler. Keycloak has some differences from the other providers in the sense that it can also use the token
- * to specify grants. You can validate against these grants like this:
+ * This is how you pin your handler to the server `myserver.com`:
  *
  * [source,$lang]
  * ----
  * {@link examples.WebExamples#example61}
  * ----
+ *
+ * By doing this, you make sure that all oauth2 redirects will be done to the specified host. This is useful for cases
+ * where your server is running behind a load balancer or in a cluster where the machine name does not necessarily
+ * matches the external name.
  *
  */
 @Document(fileName = "index.adoc")

--- a/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/BridgeOptions.kt
+++ b/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/BridgeOptions.kt
@@ -3,26 +3,26 @@ package io.vertx.kotlin.ext.web.handler.sockjs
 import io.vertx.ext.web.handler.sockjs.BridgeOptions
 
 fun BridgeOptions(
-        maxAddressLength: Int? = null,
-    maxHandlersPerSocket: Int? = null,
-    pingTimeout: Long? = null,
-    replyTimeout: Long? = null): BridgeOptions = io.vertx.ext.web.handler.sockjs.BridgeOptions().apply {
+    maxAddressLength: Int? = null,
+  maxHandlersPerSocket: Int? = null,
+  pingTimeout: Long? = null,
+  replyTimeout: Long? = null): BridgeOptions = io.vertx.ext.web.handler.sockjs.BridgeOptions().apply {
 
-    if (maxAddressLength != null) {
-        this.maxAddressLength = maxAddressLength
-    }
+  if (maxAddressLength != null) {
+    this.maxAddressLength = maxAddressLength
+  }
 
-    if (maxHandlersPerSocket != null) {
-        this.maxHandlersPerSocket = maxHandlersPerSocket
-    }
+  if (maxHandlersPerSocket != null) {
+    this.maxHandlersPerSocket = maxHandlersPerSocket
+  }
 
-    if (pingTimeout != null) {
-        this.pingTimeout = pingTimeout
-    }
+  if (pingTimeout != null) {
+    this.pingTimeout = pingTimeout
+  }
 
-    if (replyTimeout != null) {
-        this.replyTimeout = replyTimeout
-    }
+  if (replyTimeout != null) {
+    this.replyTimeout = replyTimeout
+  }
 
 }
 

--- a/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/PermittedOptions.kt
+++ b/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/PermittedOptions.kt
@@ -3,26 +3,26 @@ package io.vertx.kotlin.ext.web.handler.sockjs
 import io.vertx.ext.web.handler.sockjs.PermittedOptions
 
 fun PermittedOptions(
-        address: String? = null,
-    addressRegex: String? = null,
-    match: io.vertx.core.json.JsonObject? = null,
-    requiredAuthority: String? = null): PermittedOptions = io.vertx.ext.web.handler.sockjs.PermittedOptions().apply {
+    address: String? = null,
+  addressRegex: String? = null,
+  match: io.vertx.core.json.JsonObject? = null,
+  requiredAuthority: String? = null): PermittedOptions = io.vertx.ext.web.handler.sockjs.PermittedOptions().apply {
 
-    if (address != null) {
-        this.address = address
-    }
+  if (address != null) {
+    this.address = address
+  }
 
-    if (addressRegex != null) {
-        this.addressRegex = addressRegex
-    }
+  if (addressRegex != null) {
+    this.addressRegex = addressRegex
+  }
 
-    if (match != null) {
-        this.match = match
-    }
+  if (match != null) {
+    this.match = match
+  }
 
-    if (requiredAuthority != null) {
-        this.requiredAuthority = requiredAuthority
-    }
+  if (requiredAuthority != null) {
+    this.requiredAuthority = requiredAuthority
+  }
 
 }
 

--- a/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSHandlerOptions.kt
+++ b/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSHandlerOptions.kt
@@ -3,31 +3,31 @@ package io.vertx.kotlin.ext.web.handler.sockjs
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions
 
 fun SockJSHandlerOptions(
-        heartbeatInterval: Long? = null,
-    insertJSESSIONID: Boolean? = null,
-    libraryURL: String? = null,
-    maxBytesStreaming: Int? = null,
-    sessionTimeout: Long? = null): SockJSHandlerOptions = io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions().apply {
+    heartbeatInterval: Long? = null,
+  insertJSESSIONID: Boolean? = null,
+  libraryURL: String? = null,
+  maxBytesStreaming: Int? = null,
+  sessionTimeout: Long? = null): SockJSHandlerOptions = io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions().apply {
 
-    if (heartbeatInterval != null) {
-        this.heartbeatInterval = heartbeatInterval
-    }
+  if (heartbeatInterval != null) {
+    this.heartbeatInterval = heartbeatInterval
+  }
 
-    if (insertJSESSIONID != null) {
-        this.isInsertJSESSIONID = insertJSESSIONID
-    }
+  if (insertJSESSIONID != null) {
+    this.isInsertJSESSIONID = insertJSESSIONID
+  }
 
-    if (libraryURL != null) {
-        this.libraryURL = libraryURL
-    }
+  if (libraryURL != null) {
+    this.libraryURL = libraryURL
+  }
 
-    if (maxBytesStreaming != null) {
-        this.maxBytesStreaming = maxBytesStreaming
-    }
+  if (maxBytesStreaming != null) {
+    this.maxBytesStreaming = maxBytesStreaming
+  }
 
-    if (sessionTimeout != null) {
-        this.sessionTimeout = sessionTimeout
-    }
+  if (sessionTimeout != null) {
+    this.sessionTimeout = sessionTimeout
+  }
 
 }
 

--- a/vertx-web/src/main/resources/vertx-web-js/clustered_session_store.js
+++ b/vertx-web/src/main/resources/vertx-web-js/clustered_session_store.js
@@ -56,12 +56,15 @@ var ClusteredSessionStore = function(j_val) {
 
    @public
    @param timeout {number} - the session timeout, in ms 
+   @param length {number} - the required length for the session id 
    @return {Session} the session
    */
-  this.createSession = function(timeout) {
+  this.createSession = function() {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] ==='number') {
-      return utils.convReturnVertxGen(Session, j_clusteredSessionStore["createSession(long)"](timeout));
+      return utils.convReturnVertxGen(Session, j_clusteredSessionStore["createSession(long)"](__args[0]));
+    }  else if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] ==='number') {
+      return utils.convReturnVertxGen(Session, j_clusteredSessionStore["createSession(long,int)"](__args[0], __args[1]));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/vertx-web/src/main/resources/vertx-web-js/local_session_store.js
+++ b/vertx-web/src/main/resources/vertx-web-js/local_session_store.js
@@ -58,12 +58,15 @@ var LocalSessionStore = function(j_val) {
 
    @public
    @param timeout {number} - the session timeout, in ms 
+   @param length {number} - the required length for the session id 
    @return {Session} the session
    */
-  this.createSession = function(timeout) {
+  this.createSession = function() {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] ==='number') {
-      return utils.convReturnVertxGen(Session, j_localSessionStore["createSession(long)"](timeout));
+      return utils.convReturnVertxGen(Session, j_localSessionStore["createSession(long)"](__args[0]));
+    }  else if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] ==='number') {
+      return utils.convReturnVertxGen(Session, j_localSessionStore["createSession(long,int)"](__args[0], __args[1]));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/vertx-web/src/main/resources/vertx-web-js/o_auth2_auth_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/o_auth2_auth_handler.js
@@ -134,17 +134,17 @@ OAuth2AuthHandler._create = function(jdel) {
   return obj;
 }
 /**
- Create a OAuth2 auth handler
+ Create a OAuth2 auth handler with host pinning
 
  @memberof module:vertx-web-js/o_auth2_auth_handler
  @param authProvider {OAuth2Auth} the auth provider to use 
- @param uri {string} 
+ @param callbackURL {string} the callback URL you entered in your provider admin console, usually it should be something like: `https://myserver:8888/callback` 
  @return {OAuth2AuthHandler} the auth handler
  */
-OAuth2AuthHandler.create = function(authProvider, uri) {
+OAuth2AuthHandler.create = function(authProvider, callbackURL) {
   var __args = arguments;
   if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'string') {
-    return utils.convReturnVertxGen(OAuth2AuthHandler, JOAuth2AuthHandler["create(io.vertx.ext.auth.oauth2.OAuth2Auth,java.lang.String)"](authProvider._jdel, uri));
+    return utils.convReturnVertxGen(OAuth2AuthHandler, JOAuth2AuthHandler["create(io.vertx.ext.auth.oauth2.OAuth2Auth,java.lang.String)"](authProvider._jdel, callbackURL));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 

--- a/vertx-web/src/main/resources/vertx-web-js/session.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session.js
@@ -45,7 +45,7 @@ var Session = function(j_val) {
   this.regenerateId = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_session["regenerateId()"](), Session);
+      return utils.convReturnVertxGen(Session, j_session["regenerateId()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/vertx-web/src/main/resources/vertx-web-js/session_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session_handler.js
@@ -123,7 +123,7 @@ var SessionHandler = function(j_val) {
   };
 
   /**
-   Set the session cookie name
+   Set expected session id minimum length.
 
    @public
    @param minLength {number} the session id minimal length 

--- a/vertx-web/src/main/resources/vertx-web-js/session_store.js
+++ b/vertx-web/src/main/resources/vertx-web-js/session_store.js
@@ -53,12 +53,15 @@ var SessionStore = function(j_val) {
 
    @public
    @param timeout {number} - the session timeout, in ms 
+   @param length {number} - the required length for the session id 
    @return {Session} the session
    */
-  this.createSession = function(timeout) {
+  this.createSession = function() {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] ==='number') {
-      return utils.convReturnVertxGen(Session, j_sessionStore["createSession(long)"](timeout));
+      return utils.convReturnVertxGen(Session, j_sessionStore["createSession(long)"](__args[0]));
+    }  else if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] ==='number') {
+      return utils.convReturnVertxGen(Session, j_sessionStore["createSession(long,int)"](__args[0], __args[1]));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/vertx-web/src/main/resources/vertx-web/clustered_session_store.rb
+++ b/vertx-web/src/main/resources/vertx-web/clustered_session_store.rb
@@ -45,12 +45,15 @@ module VertxWeb
     end
     #  Create a new session
     # @param [Fixnum] timeout - the session timeout, in ms
+    # @param [Fixnum] length - the required length for the session id
     # @return [::VertxWeb::Session] the session
-    def create_session(timeout=nil)
-      if timeout.class == Fixnum && !block_given?
+    def create_session(timeout=nil,length=nil)
+      if timeout.class == Fixnum && !block_given? && length == nil
         return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class]).call(timeout),::VertxWeb::Session)
+      elsif timeout.class == Fixnum && length.class == Fixnum && !block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class,Java::int.java_class]).call(timeout,length),::VertxWeb::Session)
       end
-      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout})"
+      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout},#{length})"
     end
     #  Get the session with the specified ID
     # @param [String] id the unique ID of the session

--- a/vertx-web/src/main/resources/vertx-web/local_session_store.rb
+++ b/vertx-web/src/main/resources/vertx-web/local_session_store.rb
@@ -47,12 +47,15 @@ module VertxWeb
     end
     #  Create a new session
     # @param [Fixnum] timeout - the session timeout, in ms
+    # @param [Fixnum] length - the required length for the session id
     # @return [::VertxWeb::Session] the session
-    def create_session(timeout=nil)
-      if timeout.class == Fixnum && !block_given?
+    def create_session(timeout=nil,length=nil)
+      if timeout.class == Fixnum && !block_given? && length == nil
         return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class]).call(timeout),::VertxWeb::Session)
+      elsif timeout.class == Fixnum && length.class == Fixnum && !block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class,Java::int.java_class]).call(timeout,length),::VertxWeb::Session)
       end
-      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout})"
+      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout},#{length})"
     end
     #  Get the session with the specified ID
     # @param [String] id the unique ID of the session

--- a/vertx-web/src/main/resources/vertx-web/o_auth2_auth_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/o_auth2_auth_handler.rb
@@ -62,25 +62,25 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling add_authorities(#{authorities})"
     end
-    #  Create a OAuth2 auth handler
+    #  Create a OAuth2 auth handler with host pinning
     # @param [::VertxAuthOauth2::OAuth2Auth] authProvider the auth provider to use
-    # @param [String] uri 
+    # @param [String] callbackURL the callback URL you entered in your provider admin console, usually it should be something like: `https://myserver:8888/callback`
     # @return [::VertxWeb::OAuth2AuthHandler] the auth handler
-    def self.create(authProvider=nil,uri=nil)
-      if authProvider.class.method_defined?(:j_del) && uri.class == String && !block_given?
-        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtWebHandler::OAuth2AuthHandler.java_method(:create, [Java::IoVertxExtAuthOauth2::OAuth2Auth.java_class,Java::java.lang.String.java_class]).call(authProvider.j_del,uri),::VertxWeb::OAuth2AuthHandler)
+    def self.create(authProvider=nil,callbackURL=nil)
+      if authProvider.class.method_defined?(:j_del) && callbackURL.class == String && !block_given?
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtWebHandler::OAuth2AuthHandler.java_method(:create, [Java::IoVertxExtAuthOauth2::OAuth2Auth.java_class,Java::java.lang.String.java_class]).call(authProvider.j_del,callbackURL),::VertxWeb::OAuth2AuthHandler)
       end
-      raise ArgumentError, "Invalid arguments when calling create(#{authProvider},#{uri})"
+      raise ArgumentError, "Invalid arguments when calling create(#{authProvider},#{callbackURL})"
     end
-    #  Build the authorization URL.
-    # @param [String] redirectURL where is the callback mounted.
-    # @param [String] state state opaque token to avoid forged requests
-    # @return [String] the redirect URL
-    def auth_uri(redirectURL=nil,state=nil)
-      if redirectURL.class == String && state.class == String && !block_given?
-        return @j_del.java_method(:authURI, [Java::java.lang.String.java_class,Java::java.lang.String.java_class]).call(redirectURL,state)
+    #  Extra parameters needed to be passed while requesting a token.
+    # @param [Hash{String => Object}] extraParams extra optional parameters.
+    # @return [self]
+    def extra_params(extraParams=nil)
+      if extraParams.class == Hash && !block_given?
+        @j_del.java_method(:extraParams, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(extraParams))
+        return self
       end
-      raise ArgumentError, "Invalid arguments when calling auth_uri(#{redirectURL},#{state})"
+      raise ArgumentError, "Invalid arguments when calling extra_params(#{extraParams})"
     end
     #  add the callback handler to a given route.
     # @param [::VertxWeb::Route] route a given route e.g.: `/callback`

--- a/vertx-web/src/main/resources/vertx-web/session.rb
+++ b/vertx-web/src/main/resources/vertx-web/session.rb
@@ -37,6 +37,13 @@ module VertxWeb
     def self.j_class
       Java::IoVertxExtWeb::Session.java_class
     end
+    # @return [::VertxWeb::Session] The new unique ID of the session.
+    def regenerate_id
+      if !block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:regenerateId, []).call(),::VertxWeb::Session)
+      end
+      raise ArgumentError, "Invalid arguments when calling regenerate_id()"
+    end
     # @return [String] The unique ID of the session. This is generated using a random secure UUID.
     def id
       if !block_given?
@@ -94,6 +101,20 @@ module VertxWeb
         return @j_del.java_method(:isDestroyed, []).call()
       end
       raise ArgumentError, "Invalid arguments when calling destroyed?()"
+    end
+    # @return [true,false] has the session been renewed?
+    def regenerated?
+      if !block_given?
+        return @j_del.java_method(:isRegenerated, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling regenerated?()"
+    end
+    # @return [String] old ID if renewed
+    def old_id
+      if !block_given?
+        return @j_del.java_method(:oldId, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling old_id()"
     end
     # @return [Fixnum] the amount of time in ms, after which the session will expire, if not accessed.
     def timeout

--- a/vertx-web/src/main/resources/vertx-web/session_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/session_handler.rb
@@ -108,7 +108,7 @@ module VertxWeb
       end
       raise ArgumentError, "Invalid arguments when calling set_session_cookie_name(#{sessionCookieName})"
     end
-    #  Set the session cookie name
+    #  Set expected session id minimum length.
     # @param [Fixnum] minLength the session id minimal length
     # @return [self]
     def set_min_length(minLength=nil)
@@ -116,7 +116,7 @@ module VertxWeb
         @j_del.java_method(:setMinLength, [Java::int.java_class]).call(minLength)
         return self
       end
-      raise ArgumentError, "Invalid arguments when calling set_min_length(minLength)"
+      raise ArgumentError, "Invalid arguments when calling set_min_length(#{minLength})"
     end
   end
 end

--- a/vertx-web/src/main/resources/vertx-web/session_store.rb
+++ b/vertx-web/src/main/resources/vertx-web/session_store.rb
@@ -42,12 +42,15 @@ module VertxWeb
     end
     #  Create a new session
     # @param [Fixnum] timeout - the session timeout, in ms
+    # @param [Fixnum] length - the required length for the session id
     # @return [::VertxWeb::Session] the session
-    def create_session(timeout=nil)
-      if timeout.class == Fixnum && !block_given?
+    def create_session(timeout=nil,length=nil)
+      if timeout.class == Fixnum && !block_given? && length == nil
         return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class]).call(timeout),::VertxWeb::Session)
+      elsif timeout.class == Fixnum && length.class == Fixnum && !block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:createSession, [Java::long.java_class,Java::int.java_class]).call(timeout,length),::VertxWeb::Session)
       end
-      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout})"
+      raise ArgumentError, "Invalid arguments when calling create_session(#{timeout},#{length})"
     end
     #  Get the session with the specified ID
     # @param [String] id the unique ID of the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -80,11 +80,11 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
 
     latch.await();
 
-    // create a oauth2 handler on our domain: "http://localhost:8080"
-    OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(oauth2);
+    // create a oauth2 handler on our domain to the callback: "http://localhost:8080/callback"
+    OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(oauth2, "http://localhost:8080/callback");
 
     // setup the callback handler for receiving the callback
-    oauth2Handler.setupCallback(router.get("/callback"));
+    oauth2Handler.setupCallback(router.route());
 
     // protect everything under /protected
     router.route("/protected/*").handler(oauth2Handler);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -81,7 +81,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     latch.await();
 
     // create a oauth2 handler on our domain: "http://localhost:8080"
-    OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(oauth2, "http://localhost:8080");
+    OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(oauth2);
 
     // setup the callback handler for receiving the callback
     oauth2Handler.setupCallback(router.get("/callback"));


### PR DESCRIPTION
This is a follow up from vertx-auth.

Document how to use the new oauth2 providers and simplify the callback setup.

Before the end user would need to understand the semantics of the callback handler and slit the host from the past to configure it. Now the callback url is passed in the oauth2 handler constructor (as before) but the callback path is then extracted and used during the setup.

Extra steps were added like prevent caching result of oauth2 flows and redirect using http 302 if there is a session handler in place (this solve the refresh issue when using internal redirects).

The session id's are now also upgraded as per OWASP security guidelines.