### PR TITLE
Integrate FreeMarker engine with Vertx Json classes properly

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-freemarker/pom.xml
@@ -30,10 +30,29 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-lang-js</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>addTestSources</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateEngineImpl.java
@@ -23,7 +23,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
-
 import io.vertx.ext.web.templ.FreeMarkerTemplateEngine;
 
 import java.io.ByteArrayOutputStream;
@@ -44,7 +43,7 @@ public class FreeMarkerTemplateEngineImpl extends CachingTemplateEngine<Template
 
     loader = new FreeMarkerTemplateLoader();
     config = new Configuration(Configuration.VERSION_2_3_22);
-
+    config.setObjectWrapper(new VertxWebObjectWrapper(config.getIncompatibleImprovements()));
     config.setTemplateLoader(loader);
   }
 

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/JsonArrayAdapter.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/JsonArrayAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.templ.impl;
+
+import freemarker.template.AdapterTemplateModel;
+import freemarker.template.ObjectWrapper;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateSequenceModel;
+import freemarker.template.WrappingTemplateModel;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * @author Thomas Segismont
+ */
+public class JsonArrayAdapter extends WrappingTemplateModel implements TemplateSequenceModel, AdapterTemplateModel {
+
+  private final JsonArray jsonArray;
+
+  public JsonArrayAdapter(JsonArray jsonArray, ObjectWrapper ow) {
+    super(ow);
+    this.jsonArray = jsonArray;
+  }
+
+  @Override
+  public int size() throws TemplateModelException {
+    return jsonArray.size();
+  }
+
+  @Override
+  public TemplateModel get(int index) throws TemplateModelException {
+    return index >= 0 && index < jsonArray.size() ? wrap(jsonArray.getValue(index)) : null;
+  }
+
+  @Override
+  public Object getAdaptedObject(Class hint) {
+    return jsonArray;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/JsonObjectAdapter.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/JsonObjectAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.templ.impl;
+
+import freemarker.template.AdapterTemplateModel;
+import freemarker.template.ObjectWrapper;
+import freemarker.template.SimpleCollection;
+import freemarker.template.TemplateCollectionModel;
+import freemarker.template.TemplateHashModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.WrappingTemplateModel;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author Thomas Segismont
+ */
+public class JsonObjectAdapter extends WrappingTemplateModel implements TemplateHashModelEx, AdapterTemplateModel {
+
+  private final JsonObject jsonObject;
+
+  public JsonObjectAdapter(JsonObject jsonObject, ObjectWrapper ow) {
+    super(ow);
+    this.jsonObject = jsonObject;
+  }
+
+  @Override
+  public TemplateModel get(String key) throws TemplateModelException {
+    Object value = jsonObject.getValue(key);
+    return value == null ? null : wrap(value);
+  }
+
+  @Override
+  public boolean isEmpty() throws TemplateModelException {
+    return jsonObject.isEmpty();
+  }
+
+  @Override
+  public int size() throws TemplateModelException {
+    return jsonObject.size();
+  }
+
+  @Override
+  public TemplateCollectionModel keys() throws TemplateModelException {
+    return new SimpleCollection(jsonObject.fieldNames(), getObjectWrapper());
+  }
+
+  @Override
+  public TemplateCollectionModel values() throws TemplateModelException {
+    return new SimpleCollection(jsonObject.getMap().values(), getObjectWrapper());
+  }
+
+  @Override
+  public Object getAdaptedObject(Class hint) {
+    return jsonObject;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/VertxWebObjectWrapper.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/VertxWebObjectWrapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.templ.impl;
+
+import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.Version;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author Thomas Segismont
+ */
+public class VertxWebObjectWrapper extends DefaultObjectWrapper {
+
+  public VertxWebObjectWrapper(Version incompatibleImprovements) {
+    super(incompatibleImprovements);
+  }
+
+  @Override
+  protected TemplateModel handleUnknownType(final Object obj) throws TemplateModelException {
+    if (obj instanceof JsonArray) {
+      return new JsonArrayAdapter((JsonArray) obj, this);
+    }
+    if (obj instanceof JsonObject) {
+      return new JsonObjectAdapter((JsonObject) obj, this);
+    }
+    return super.handleUnknownType(obj);
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/groovy/FreeMarkerGroovyTemplateTest.groovy
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/groovy/FreeMarkerGroovyTemplateTest.groovy
@@ -1,0 +1,57 @@
+import io.vertx.core.http.HttpMethod
+import io.vertx.ext.web.WebTestBase
+import io.vertx.ext.web.handler.TemplateHandler
+import io.vertx.ext.web.templ.FreeMarkerTemplateEngine
+import org.junit.Test
+
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the 'License')' you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @author Thomas Segismont
+ */
+class FreeMarkerGroovyTemplateTest extends WebTestBase {
+
+  @Test
+  void testTemplateHandler() throws Exception {
+    def engine = FreeMarkerTemplateEngine.create()
+    router.route().handler({ context ->
+      context.put('foo', 'badger')
+      context.put('bar', ['pipo', 'molo'])
+      context.put('baz', [top: 'pipo', bottom: 'molo'])
+      context.put('team', [
+        'grenoble' : ['Clément'],
+        'lyon'     : ['Julien'],
+        'amsterdam': ['Paulo'],
+        'marseille': ['Julien', 'Thomas']
+      ])
+      context.next()
+    })
+    router.route().handler(TemplateHandler.create(engine, 'somedir', 'text/plain'))
+    def expected = """Hello badger
+There is a pipo
+There is a molo
+top
+bottom
+pipo
+molo
+Julien loves Olympique de Marseille
+Thomas loves Olympique de Marseille
+"""
+    testRequest(HttpMethod.GET, '/altlang.ftl', 200, 'OK', expected)
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerJavascriptTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerJavascriptTemplateTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.templ;
+
+import io.vertx.lang.js.ClasspathFileResolver;
+import io.vertx.test.lang.js.JSTestBase;
+import org.junit.Test;
+
+/**
+ * @author Thomas Segismont
+ */
+public class FreeMarkerJavascriptTemplateTest extends JSTestBase {
+
+  static {
+    ClasspathFileResolver.init();
+  }
+
+  @Override
+  protected String getTestFile() {
+    return "freemarker_javascript_template_test.js";
+  }
+
+  @Test
+  public void testTemplate() throws Exception {
+    runTest();
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/resources/freemarker_javascript_template_test.js
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/resources/freemarker_javascript_template_test.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Assert = org.junit.Assert;
+
+var CountDownLatch = java.util.concurrent.CountDownLatch;
+var TimeUnit = java.util.concurrent.TimeUnit;
+
+var Vertx = require("vertx-js/vertx");
+
+var console = require("vertx-js/util/console");
+
+var Router = require("vertx-web-js/router");
+var FreeMarkerTemplateEngine = require("vertx-web-js/free_marker_template_engine");
+var TemplateHandler = require("vertx-web-js/template_handler");
+
+function testTemplate() {
+  var vertx = Vertx.vertx();
+  var server = vertx.createHttpServer();
+  var router = Router.router(vertx);
+
+  var engine = FreeMarkerTemplateEngine.create();
+  var handler = TemplateHandler.create(engine, "somedir", "text/plain");
+
+  router.route().handler(function (context) {
+    context.put("foo", "badger");
+    context.put("bar", ["pipo", "molo"]);
+    context.put("baz", {"top": "pipo", "bottom": "molo"});
+    context.put("team", {
+      "grenoble": ["Clément"],
+      "lyon": ["Julien"],
+      "amsterdam": ["Paulo"],
+      "marseille": ["Julien", "Thomas"]
+    });
+    context.next();
+  });
+  router.get().handler(handler.handle);
+
+  var listenLatch = new CountDownLatch(1);
+  server.requestHandler(router.accept).listen(8080, function (res, res_err) {
+    if (res_err != null) {
+      Assert.fail(res_err)
+    }
+    listenLatch.countDown();
+  });
+  Assert.assertTrue(listenLatch.await(5, TimeUnit.SECONDS));
+
+  var responseLatch = new CountDownLatch(1);
+  var client = vertx.createHttpClient();
+  client.getNow(8080, "localhost", "/altlang", function (response) {
+    Assert.assertTrue(200 == response.statusCode());
+    response.bodyHandler(function (buffer) {
+      var lines = [];
+      lines.push("Hello badger");
+      lines.push("There is a pipo");
+      lines.push("There is a molo");
+      lines.push("top");
+      lines.push("bottom");
+      lines.push("pipo");
+      lines.push("molo");
+      lines.push("Julien loves Olympique de Marseille");
+      lines.push("Thomas loves Olympique de Marseille");
+      lines.push("");
+      Assert.assertEquals(lines.join("\n"), buffer.toString());
+      responseLatch.countDown();
+    });
+  });
+  Assert.assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
+}
+
+if (typeof this[testName] === "undefined") {
+  throw "No such test: " + testName;
+}
+
+this[testName]();

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/resources/somedir/altlang.ftl
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/resources/somedir/altlang.ftl
@@ -1,0 +1,13 @@
+Hello ${context.foo}
+<#list context.bar as thing>
+There is a ${thing}
+</#list>
+<#list context.baz?keys as k>
+${k}
+</#list>
+<#list context.baz?values as v>
+${v}
+</#list>
+<#list context.team.marseille as peep>
+${peep} loves Olympique de Marseille
+</#list>


### PR DESCRIPTION
This is useful for alternate languages (Groovy, Javascript, Ruby) in particular since when lists/maps are added to the routing context, they are converted to JsonArray/JsonObject.
Then it feels unnatural for the user, because the expectation is that you can simply iterate other these objects but you can't.

Tests for Groovy and JS have been added to reflect the new behavior.