### PR TITLE
Named regex router parameters in capture groups

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -254,7 +254,7 @@ public class RouteImpl implements Route {
             // decode the path as it could contain escaped chars.
             for (int i = 0; i < groups.size(); i++) {
               final String k = groups.get(i);
-              final String value = Utils.urlDecode(m.group("p" + i), false);
+              final String value = Utils.urlDecode(m.group(i+1), false);
               if (!request.params().contains(k)) {
                 params.put(k, value);
               } else {
@@ -363,8 +363,16 @@ public class RouteImpl implements Route {
     }
   }
 
+  private static final Pattern RE_GROUP_NAMES = Pattern.compile("\\?<(\\w+)>");
   private void setRegex(String regex) {
     pattern = Pattern.compile(regex);
+    Matcher matcher = RE_GROUP_NAMES.matcher(regex);
+    if (matcher.find()) {
+    	groups = new ArrayList<>();
+    	do {
+    		groups.add(matcher.group(1));
+    	} while (matcher.find());
+    }    
   }
 
   // intersection of regex chars and https://tools.ietf.org/html/rfc3986#section-3.3

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -894,6 +894,33 @@ public class RouterTest extends WebTestBase {
     });
     testPattern("/dog/cat", "dogcat");
   }
+  
+  @Test
+  public void testNamedRegex1() throws Exception {
+    router.routeWithRegex("\\/(?<animal1>[^\\/]+)\\/(?<animal2>[^\\/]+)").handler(rc -> {
+      MultiMap params = rc.request().params();
+      rc.response().setStatusMessage(params.get("animal1") + params.get("animal2")).end();
+    });
+    testPattern("/dog/cat", "dogcat");
+  }  
+  
+  @Test
+  public void testNamedRegex2() throws Exception {
+    router.routeWithRegex("\\/(?<animal1>[^\\/]+)\\/(?<animal2>[^\\/]+)/blah").handler(rc -> {
+      MultiMap params = rc.request().params();
+      rc.response().setStatusMessage(params.get("animal1") + params.get("animal2")).end();
+    });
+    testPattern("/dog/cat/blah", "dogcat");
+  }  
+  
+  @Test
+  public void testIncompleteNamedRegex1() throws Exception {
+    router.routeWithRegex("\\/(?<animal1>[^\\/]+)\\/([^\\/]+)").handler(rc -> {
+      MultiMap params = rc.request().params();
+      rc.response().setStatusMessage(params.get("animal1") + params.get("param1")).end();
+    });
+    testPattern("/dog/cat", "dognull");
+  }    
 
   @Test
   public void testRegex1WithMethod() throws Exception {


### PR DESCRIPTION
Simple solution to using named parameters with getWithRegex. May break backwards compatibility if existing code bases already have named capture groups (going unused). Will require a documentation update. First contrib on this project, so hope I've covered most of what is needed.

See https://github.com/vert-x3/issues/issues/222