### PR TITLE
Enhance handlebars template context handling

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/HandlebarsTemplateEngine.java
@@ -17,6 +17,8 @@
 package io.vertx.ext.web.templ;
 
 import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.ValueResolver;
+
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.ext.web.templ.impl.HandlebarsTemplateEngineImpl;
@@ -72,5 +74,21 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
    */
   @GenIgnore
   Handlebars getHandlebars();
+
+  /**
+   * Return the array of configured handlebars context value resolvers.
+   * @return array of configured resolvers
+   */
+  @GenIgnore
+  ValueResolver[] getResolvers();
+
+  /**
+   * Set the array of handlebars context value resolvers.
+   * 
+   * @param resolvers the value resolvers to be used
+   * @return a reference to the internal Handlebars instance.
+   */
+  @GenIgnore
+  HandlebarsTemplateEngine setResolvers(ValueResolver... resolvers);
 
 }

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/JsonArrayValueResolver.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/JsonArrayValueResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.impl;
+
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.github.jknack.handlebars.ValueResolver;
+
+import io.vertx.core.json.JsonArray;
+
+/**
+ * @author <a href="https://github.com/Jotschi">Johannes Schüth</a>
+ */
+public class JsonArrayValueResolver implements ValueResolver {
+
+  public static final ValueResolver INSTANCE = new JsonArrayValueResolver();
+
+  @Override
+  public Object resolve(final Object context) {
+    if (context instanceof JsonArray) {
+      return context;
+    }
+    return UNRESOLVED;
+  }
+
+  @Override
+  public Object resolve(Object context, String name) {
+    if (context instanceof JsonArray) {
+      JsonArray jsonArray = ((JsonArray) context);
+      if ("length".equals(name) || "size".equals(name)) {
+        return jsonArray.size();
+      }
+      // NumberFormatException will bubble up and cause a HandlebarsException with line, row info
+      Object value = jsonArray.getValue(Integer.valueOf(name));
+      if (value != null) {
+        return value;
+      }
+    }
+    return UNRESOLVED;
+  }
+
+  @Override
+  public Set<Entry<String, Object>> propertySet(final Object context) {
+    return Collections.emptySet();
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/JsonObjectValueResolver.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/JsonObjectValueResolver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.impl;
+
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.github.jknack.handlebars.ValueResolver;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author <a href="https://github.com/Jotschi">Johannes Schüth</a>
+ */
+public class JsonObjectValueResolver implements ValueResolver {
+
+  public static final ValueResolver INSTANCE = new JsonObjectValueResolver();
+
+  @Override
+  public Object resolve(final Object context, final String name) {
+    Object value = null;
+    if (context instanceof JsonObject) {
+      value = ((JsonObject) context).getValue(name);
+    }
+    return value == null ? UNRESOLVED : value;
+  }
+
+  @Override
+  public Object resolve(final Object context) {
+    if (context instanceof JsonObject) {
+      return context;
+    }
+    return UNRESOLVED;
+  }
+
+  @Override
+  public Set<Entry<String, Object>> propertySet(final Object context) {
+    if (context instanceof JsonObject) {
+      return ((JsonObject) context).getMap().entrySet();
+    }
+    return Collections.emptySet();
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template4.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template4.hbs
@@ -1,0 +1,1 @@
+Goodbye {{foo.bar.one}} and {{foo.bar.two}}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template5.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template5.hbs
@@ -1,0 +1,1 @@
+Iterator: {{#each foo}}{{this}},{{/each}} Element by index:{{foo.[1]}} - {{foo.[2].name}} - Out of bounds: {{foo.[42].name}} - Size:{{foo.length}}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template6.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template6.hbs
@@ -1,0 +1,1 @@
+No number index: {{foo.[bar].name}}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
@@ -16,7 +16,18 @@
 
 package io.vertx.ext.web.templ;
 
+import java.util.Set;
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicReference;
+import com.github.jknack.handlebars.HandlebarsException;
+import com.github.jknack.handlebars.ValueResolver;
+
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.TemplateHandler;
 import org.junit.Test;
@@ -30,6 +41,86 @@ public class HandlebarsTemplateTest extends WebTestBase {
   public void testTemplateOnClasspath() throws Exception {
     TemplateEngine engine = HandlebarsTemplateEngine.create();
     testTemplateHandler(engine, "somedir", "test-handlebars-template2.hbs", "Hello badger and fox");
+  }
+
+  @Test
+  public void testTemplateJsonObjectResolver() throws Exception {
+    TemplateEngine engine = HandlebarsTemplateEngine.create();
+    JsonObject json = new JsonObject();
+    json.put("bar", new JsonObject().put("one", "badger").put("two", "fox"));
+
+    testTemplateHandlerWithContext(engine, "src/test/filesystemtemplates", "test-handlebars-template4.hbs", "Goodbye badger and fox", context -> {
+      context.put("foo", json);
+      context.next();
+    });
+  }
+
+  @Test
+  public void testTemplateJsonArrayResolver() throws Exception {
+    TemplateEngine engine = HandlebarsTemplateEngine.create();
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add("badger").add("fox").add(new JsonObject().put("name", "joe"));
+    String expected = "Iterator: badger,fox,{&quot;name&quot;:&quot;joe&quot;}, Element by index:fox - joe - Out of bounds:  - Size:3";
+    testTemplateHandlerWithContext(engine, "src/test/filesystemtemplates", "test-handlebars-template5.hbs", expected, context -> {
+      context.put("foo", jsonArray);
+      context.next();
+    });
+  }
+
+  @Test
+  public void testCustomResolver() throws Exception {
+    HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create();
+    engine.setResolvers(new ValueResolver() {
+      @Override
+      public Object resolve(Object context, String name) {
+        return "custom";
+      }
+
+      @Override
+      public Object resolve(Object context) {
+        return "custom";
+      }
+
+      @Override
+      public Set<Entry<String, Object>> propertySet(Object context) {
+        return Collections.emptySet();
+      }
+    });
+
+    testTemplateHandlerWithContext(engine, "src/test/filesystemtemplates", "test-handlebars-template3.hbs", "Goodbye custom and custom", context -> {
+      context.put("foo", "Badger");
+      context.put("bar", "Fox");
+      context.next();
+    });
+  }
+
+  @Test
+  public void testTemplateJsonArrayResolverError() throws Exception {
+    TemplateEngine engine = HandlebarsTemplateEngine.create();
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add("badger").add("fox").add(new JsonObject().put("name", "joe"));
+
+    AtomicReference<RoutingContext> contextRef = new AtomicReference<>();
+    router.route().handler(context -> {
+      context.put("foo", jsonArray);
+      context.next();
+      contextRef.set(context);
+    });
+    router.route().handler(TemplateHandler.create(engine, "src/test/filesystemtemplates", "text/plain"));
+    testRequest(HttpMethod.GET, "/" + "test-handlebars-template6.hbs", 500, "Internal Server Error");
+    if(contextRef.get().failure() instanceof HandlebarsException) {
+      HandlebarsException exception = ((HandlebarsException)contextRef.get().failure());
+      assertTrue(exception.getMessage().contains("test-handlebars-template6.hbs:1:19"));
+    } else {
+      fail("We would expect an handlebars exception with detailed location information.");
+    }
+  }
+
+  private void testTemplateHandlerWithContext(TemplateEngine engine, String directoryName, String templateName, String expected,
+    Handler<RoutingContext> contextHandler) throws Exception {
+    router.route().handler(contextHandler);
+    router.route().handler(TemplateHandler.create(engine, directoryName, "text/plain"));
+    testRequest(HttpMethod.GET, "/" + templateName, 200, "OK", expected);
   }
 
   @Test


### PR DESCRIPTION
### Motivation

It is currently not possible to resolve properties of Vert.x JsonObjects (io.vertx.core.json) using the `HandlebarsTemplateEngine`. This makes it impossible to resolve properties if JsonObjects have been added to the template context.

### Implementation

Handlebars is able to resolve regular collections (e.g. Maps) but JsonObject#getMap() is only returning the inner map and it is not transforming the whole io.vertx.core.json.JsonObject.

It is fortunately possible to add custom resolvers to the Handlebars context. I wrote a custom JsonObject resolver which allows resolving of Vert.x JsonObject properties within Handlebars Templates.