### PR TITLE
Auto set content type from most acceptable match

### DIFF
--- a/vertx-web-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/groovy/index.adoc
@@ -54,7 +54,6 @@ You create an `link:../../apidocs/io/vertx/ext/web/client/WebClient.html[WebClie
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 def client = WebClient.create(vertx)
 
 ----
@@ -63,7 +62,6 @@ If you want to configure options for the client, you create it as follows
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 def options = [
   userAgent:"My-App/1.2.3"
 ]
@@ -78,7 +76,6 @@ If your already have an HTTP Client in your application you can also reuse it
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 def client = WebClient.wrap(httpClient)
 
 ----
@@ -92,7 +89,6 @@ and HEAD requests
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 
 def client = WebClient.create(vertx)
 
@@ -253,7 +249,6 @@ variant.
 
 [source,groovy]
 ----
-import io.vertx.core.MultiMap
 def form = MultiMap.caseInsensitiveMultiMap()
 form.set("firstName", "Dale")
 form.set("lastName", "Cooper")
@@ -272,7 +267,6 @@ the `content-type` header to `multipart/form-data` instead
 
 [source,groovy]
 ----
-import io.vertx.core.MultiMap
 def form = MultiMap.caseInsensitiveMultiMap()
 form.set("firstName", "Dale")
 form.set("lastName", "Cooper")
@@ -421,7 +415,6 @@ Use `link:../../apidocs/io/vertx/ext/web/codec/BodyCodec.html#jsonObject--[BodyC
 
 [source,groovy]
 ----
-import io.vertx.ext.web.codec.BodyCodec
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.jsonObject()).send({ ar ->
   if (ar.succeeded()) {
     def response = ar.result()
@@ -440,7 +433,6 @@ In Java, Groovy or Kotlin, custom Json mapped POJO can be decoded
 
 [source,groovy]
 ----
-import io.vertx.ext.web.codec.BodyCodec
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.json(examples.WebClientExamples.User.class)).send({ ar ->
   if (ar.succeeded()) {
     def response = ar.result()
@@ -461,7 +453,6 @@ and signals the success or the failure of the operation in the async result resp
 
 [source,groovy]
 ----
-import io.vertx.ext.web.codec.BodyCodec
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.pipe(writeStream)).send({ ar ->
   if (ar.succeeded()) {
 
@@ -480,7 +471,6 @@ simply discards the entire response body
 
 [source,groovy]
 ----
-import io.vertx.ext.web.codec.BodyCodec
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.none()).send({ ar ->
   if (ar.succeeded()) {
 
@@ -523,7 +513,6 @@ By default the client follows redirections, you can configure the default behavi
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 
 // Change the default behavior to not follow redirects
 def client = WebClient.create(vertx, [
@@ -536,7 +525,6 @@ The client will follow at most `16` requests redirections, it can be changed in 
 
 [source,groovy]
 ----
-import io.vertx.ext.web.client.WebClient
 
 // Follow at most 5 redirections
 def client = WebClient.create(vertx, [

--- a/vertx-web-client/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/kotlin/index.adoc
@@ -54,8 +54,6 @@ You create an `link:../../apidocs/io/vertx/ext/web/client/WebClient.html[WebClie
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-
 var client = WebClient.create(vertx)
 
 ----
@@ -64,10 +62,6 @@ If you want to configure options for the client, you create it as follows
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-import io.vertx.ext.web.client.WebClientOptions
-import io.vertx.kotlin.ext.web.client.*
-
 var options = WebClientOptions(
   userAgent = "My-App/1.2.3")
 options.keepAlive = false
@@ -81,8 +75,6 @@ If your already have an HTTP Client in your application you can also reuse it
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-
 var client = WebClient.wrap(httpClient)
 
 ----
@@ -96,8 +88,6 @@ and HEAD requests
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-
 
 var client = WebClient.create(vertx)
 
@@ -138,7 +128,6 @@ Any request URI parameter will pre-populate the request
 
 [source,kotlin]
 ----
-
 var request = client.get(8080, "myserver.mycompany.com", "/some-uri?param1=param1_value&param2=param2_value")
 
 // Add param3
@@ -153,7 +142,6 @@ Setting a request URI discards existing query parameters
 
 [source,kotlin]
 ----
-
 var request = client.get(8080, "myserver.mycompany.com", "/some-uri")
 
 // Add param1
@@ -173,7 +161,6 @@ Use `link:../../apidocs/io/vertx/ext/web/client/HttpRequest.html#sendBuffer-io.v
 
 [source,kotlin]
 ----
-
 // Send a buffer to the server using POST, the content-length header will be set for you
 client.post(8080, "myserver.mycompany.com", "/some-uri").sendBuffer(buffer, { ar ->
   if (ar.succeeded()) {
@@ -200,9 +187,6 @@ When you know the size of the stream, you shall specify before using the `conten
 
 [source,kotlin]
 ----
-import io.vertx.core.file.OpenOptions
-import io.vertx.kotlin.core.file.*
-
 fs.open("content.txt", OpenOptions(), { fileRes ->
   if (fileRes.succeeded()) {
     var fileStream = fileRes.result()
@@ -229,8 +213,6 @@ use the `link:../../apidocs/io/vertx/ext/web/client/HttpRequest.html#sendJsonObj
 
 [source,kotlin]
 ----
-import io.vertx.kotlin.core.json.*
-
 client.post(8080, "myserver.mycompany.com", "/some-uri").sendJsonObject(json {
   obj(
     "firstName" to "Dale",
@@ -250,7 +232,6 @@ method
 
 [source,kotlin]
 ----
-
 client.post(8080, "myserver.mycompany.com", "/some-uri").sendJson(examples.WebClientExamples.User("Dale", "Cooper"), { ar ->
   if (ar.succeeded()) {
     // Ok
@@ -269,8 +250,6 @@ variant.
 
 [source,kotlin]
 ----
-import io.vertx.core.MultiMap
-
 var form = MultiMap.caseInsensitiveMultiMap()
 form.set("firstName", "Dale")
 form.set("lastName", "Cooper")
@@ -289,8 +268,6 @@ the `content-type` header to `multipart/form-data` instead
 
 [source,kotlin]
 ----
-import io.vertx.core.MultiMap
-
 var form = MultiMap.caseInsensitiveMultiMap()
 form.set("firstName", "Dale")
 form.set("lastName", "Cooper")
@@ -313,7 +290,6 @@ You can write headers to a request using the headers multi-map as follows:
 
 [source,kotlin]
 ----
-
 var request = client.get(8080, "myserver.mycompany.com", "/some-uri")
 var headers = request.headers()
 headers.set("content-type", "application/json")
@@ -328,7 +304,6 @@ You can also write headers using putHeader
 
 [source,kotlin]
 ----
-
 var request = client.get(8080, "myserver.mycompany.com", "/some-uri")
 request.putHeader("content-type", "application/json")
 request.putHeader("other-header", "foo")
@@ -342,7 +317,6 @@ safely, making it very easy to configure and reuse `link:../../apidocs/io/vertx/
 
 [source,kotlin]
 ----
-
 var get = client.get(8080, "myserver.mycompany.com", "/some-uri")
 get.send({ ar ->
   if (ar.succeeded()) {
@@ -364,7 +338,6 @@ request
 
 [source,kotlin]
 ----
-
 var get = client.get(8080, "myserver.mycompany.com", "/some-uri")
 get.send({ ar ->
   if (ar.succeeded()) {
@@ -387,7 +360,6 @@ You can set a timeout for a specific http request using `link:../../apidocs/io/v
 
 [source,kotlin]
 ----
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").timeout(5000).send({ ar ->
   if (ar.succeeded()) {
     // Ok
@@ -409,7 +381,6 @@ On a success result the callback happens after the response has been received
 
 [source,kotlin]
 ----
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").send({ ar ->
   if (ar.succeeded()) {
 
@@ -445,8 +416,6 @@ Use `link:../../apidocs/io/vertx/ext/web/codec/BodyCodec.html#jsonObject--[BodyC
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.codec.BodyCodec
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.jsonObject()).send({ ar ->
   if (ar.succeeded()) {
     var response = ar.result()
@@ -465,8 +434,6 @@ In Java, Groovy or Kotlin, custom Json mapped POJO can be decoded
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.codec.BodyCodec
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.json(examples.WebClientExamples.User.`class`)).send({ ar ->
   if (ar.succeeded()) {
     var response = ar.result()
@@ -487,8 +454,6 @@ and signals the success or the failure of the operation in the async result resp
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.codec.BodyCodec
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.pipe(writeStream)).send({ ar ->
   if (ar.succeeded()) {
 
@@ -507,8 +472,6 @@ simply discards the entire response body
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.codec.BodyCodec
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").as(BodyCodec.none()).send({ ar ->
   if (ar.succeeded()) {
 
@@ -527,7 +490,6 @@ that decode the response to a specific type
 
 [source,kotlin]
 ----
-
 client.get(8080, "myserver.mycompany.com", "/some-uri").send({ ar ->
   if (ar.succeeded()) {
 
@@ -552,10 +514,6 @@ By default the client follows redirections, you can configure the default behavi
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-import io.vertx.ext.web.client.WebClientOptions
-import io.vertx.kotlin.ext.web.client.*
-
 
 // Change the default behavior to not follow redirects
 var client = WebClient.create(vertx, WebClientOptions(
@@ -567,10 +525,6 @@ The client will follow at most `16` requests redirections, it can be changed in 
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.client.WebClient
-import io.vertx.ext.web.client.WebClientOptions
-import io.vertx.kotlin.ext.web.client.*
-
 
 // Follow at most 5 redirections
 var client = WebClient.create(vertx, WebClientOptions(
@@ -586,7 +540,6 @@ You can specify the behavior per request
 
 [source,kotlin]
 ----
-
 
 client.get(443, "myserver.mycompany.com", "/some-uri").ssl(true).send({ ar ->
   if (ar.succeeded()) {
@@ -605,7 +558,6 @@ Or using create methods with absolute URI argument
 
 [source,kotlin]
 ----
-
 
 client.getAbs("https://myserver.mycompany.com:4043/some-uri").send({ ar ->
   if (ar.succeeded()) {

--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -142,7 +142,6 @@ Here's a simple router example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
 def server = vertx.createHttpServer()
 
 def router = Router.router(vertx)
@@ -368,7 +367,6 @@ Here's an example
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
 
 def route = router.route(HttpMethod.POST, "/catalogue/products/:producttype/:productid/")
 
@@ -467,7 +465,6 @@ If you want a route to only match for a specific HTTP method you can use `link:.
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
 
 def route = router.route().method(HttpMethod.POST)
 
@@ -484,7 +481,6 @@ Or you can specify this with a path when creating the route:
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
 
 def route = router.route(HttpMethod.POST, "/some/path/")
 
@@ -534,7 +530,6 @@ multiple times:
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
 
 def route = router.route().method(HttpMethod.POST).method(HttpMethod.PUT)
 
@@ -825,7 +820,6 @@ You can combine all the above routing criteria in many different ways, for examp
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
 
 def route = router.route(HttpMethod.PUT, "myapi/orders").consumes("application/json").produces("application/json")
 
@@ -953,7 +947,6 @@ Here's the sub-router:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
 
 def restAPI = Router.router(vertx)
 
@@ -987,7 +980,6 @@ However, let's say we already have a web-site as described by another router:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
 def mainRouter = Router.router(vertx)
 
 // Handle static resources
@@ -1134,7 +1126,6 @@ to install handlers to consume the HTTP request body and this must be done befor
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.BodyHandler
 
 // This body handler will be called for all routes
 router.route().handler(BodyHandler.create())
@@ -1177,7 +1168,6 @@ Here's an example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.BodyHandler
 
 router.route().handler(BodyHandler.create())
 
@@ -1201,7 +1191,6 @@ You should make sure a cookie handler is on a matching route for any requests th
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
 
 // This cookie handler will be called for all routes
 router.route().handler(CookieHandler.create())
@@ -1228,8 +1217,6 @@ Here's an example of querying and adding cookies:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.Cookie
 
 // This cookie handler will be called for all routes
 router.route().handler(CookieHandler.create())
@@ -1310,7 +1297,6 @@ Here are some examples of creating a `link:../../apidocs/io/vertx/ext/web/sstore
 
 [source,groovy]
 ----
-import io.vertx.ext.web.sstore.LocalSessionStore
 
 // Create a local session store using defaults
 def store1 = LocalSessionStore.create(vertx)
@@ -1342,8 +1328,6 @@ Here are some examples of creating a `link:../../apidocs/io/vertx/ext/web/sstore
 
 [source,groovy]
 ----
-import io.vertx.ext.web.sstore.ClusteredSessionStore
-import io.vertx.core.Vertx
 
 // a clustered Vert.x
 Vertx.clusteredVertx([
@@ -1376,10 +1360,6 @@ Here's an example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.sstore.ClusteredSessionStore
-import io.vertx.ext.web.handler.SessionHandler
 
 def router = Router.router(vertx)
 
@@ -1425,7 +1405,6 @@ Here's an example of manipulating session data:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
 
 router.route().handler(CookieHandler.create())
 router.route().handler(sessionHandler)
@@ -1482,10 +1461,6 @@ Here's a simple example of creating a basic auth handler given an auth provider.
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.BasicAuthHandler
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1501,11 +1476,6 @@ your auth handler is before your application handlers on those paths:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.UserSessionHandler
-import io.vertx.ext.web.handler.BasicAuthHandler
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1587,13 +1557,6 @@ Here's an example of a simple app, using a redirect auth handler on the default 
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.UserSessionHandler
-import io.vertx.ext.web.handler.RedirectAuthHandler
-import io.vertx.ext.web.handler.FormLoginHandler
-import io.vertx.ext.web.handler.StaticHandler
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1643,8 +1606,6 @@ Here's an example on how to issue tokens:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.auth.jwt.JWTAuth
 
 def router = Router.router(vertx)
 
@@ -1676,9 +1637,6 @@ Now that your client has a token all it is required is that for *all* consequent
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.auth.jwt.JWTAuth
-import io.vertx.ext.web.handler.JWTAuthHandler
 
 def router = Router.router(vertx)
 
@@ -1706,7 +1664,6 @@ token, during the creation of the token just add data to the JsonObject paramete
 
 [source,groovy]
 ----
-import io.vertx.ext.auth.jwt.JWTAuth
 
 def authConfig = [
   keyStore:[
@@ -1750,7 +1707,6 @@ may support a role/permission based model but others might use another model.
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.RedirectAuthHandler
 
 def listProductsAuthHandler = RedirectAuthHandler.create(authProvider)
 listProductsAuthHandler.addAuthority("list_products")
@@ -1782,7 +1738,6 @@ In the following example all requests to paths starting with `/static/` will get
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.StaticHandler
 
 router.route("/static/*").handler(StaticHandler.create())
 
@@ -1884,8 +1839,6 @@ Here's an example:
 
 [source,groovy]
 ----
-import io.vertx.core.http.HttpMethod
-import io.vertx.ext.web.handler.CorsHandler
 
 // Will only accept GET requests from origin "vertx.io"
 router.route().handler(CorsHandler.create("vertx\\.io").allowedMethod(HttpMethod.GET))
@@ -2022,7 +1975,6 @@ add it the context data in a handler before the template handler. For example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.TemplateHandler
 
 def handler = TemplateHandler.create(engine)
 
@@ -2135,7 +2087,6 @@ seconds:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.TimeoutHandler
 
 router.route("/foo/").handler(TimeoutHandler.create(5000))
 
@@ -2172,8 +2123,6 @@ an instance of `link:../../apidocs/io/vertx/ext/web/handler/sockjs/SockJSHandler
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
 
 def router = Router.router(vertx)
 
@@ -2201,8 +2150,6 @@ Here's an example of a simple SockJS handler that simply echoes back any back an
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
 
 def router = Router.router(vertx)
 
@@ -2304,8 +2251,6 @@ SockJS handler.
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
 
 def router = Router.router(vertx)
 
@@ -2434,8 +2379,6 @@ Here's an example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
 
 def router = Router.router(vertx)
 
@@ -2534,12 +2477,6 @@ To handle the login and actually auth you can configure the normal Vert.x auth h
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.BasicAuthHandler
 
 def router = Router.router(vertx)
 
@@ -2616,9 +2553,6 @@ Here's an example where we reject all messages flowing through the bridge if the
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.handler.sockjs.BridgeEventType
 
 def router = Router.router(vertx)
 
@@ -2712,9 +2646,6 @@ also add headers to the message, here's an example:
 
 [source,groovy]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.handler.sockjs.BridgeEventType
 
 def router = Router.router(vertx)
 
@@ -2777,8 +2708,6 @@ or the header name they have chosen during the instantiation of the `CSRFHandler
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.CSRFHandler
 
 router.route().handler(CookieHandler.create())
 router.route().handler(CSRFHandler.create("abracadabra"))
@@ -2798,7 +2727,6 @@ example `*.vertx.io` or fully domain names as `www.vertx.io`.
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.VirtualHostHandler
 router.route().handler(VirtualHostHandler.create("*.vertx.io", { routingContext ->
   // do something if the request is for *.vertx.io
 }))
@@ -2812,8 +2740,6 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,groovy]
 ----
-import io.vertx.ext.auth.oauth2.providers.GithubAuth
-import io.vertx.ext.web.handler.OAuth2AuthHandler
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to github
 def authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET")
@@ -2873,9 +2799,6 @@ However if you're using an unlisted provider you can still do it using the base 
 
 [source,groovy]
 ----
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.ext.auth.oauth2.OAuth2Auth
-import io.vertx.ext.web.handler.OAuth2AuthHandler
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to Google
 def authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, [
@@ -2922,7 +2845,6 @@ mandatory for the default values, 80 for http, 443 for https.
 
 [source,groovy]
 ----
-import io.vertx.ext.web.handler.OAuth2AuthHandler
 // create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
 def oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback")
 // now allow the handler to setup the callback url for you

--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2100,6 +2100,65 @@ to when the response headers were written, in ms., e.g.:
 
  x-response-time: 1456ms
 
+== Content type handler
+
+The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+
+[source,groovy]
+----
+router.get("/api/books").produces("application/json").handler({ rc ->
+  this.findBooks({ ar ->
+    if (ar.succeeded()) {
+      rc.response().putHeader("Content-Type", "application/json").end(this.toJson(ar.result()))
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
+If the API surface becomes pretty large, setting the content type can become cumbersome.
+To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+
+[source,groovy]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create())
+router.get("/api/books").produces("application/json").handler({ rc ->
+  this.findBooks({ ar ->
+    if (ar.succeeded()) {
+      rc.response().end(this.toJson(ar.result()))
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
+The handler gets the approriate content type from `link:../../apidocs/io/vertx/ext/web/RoutingContext.html#getAcceptableContentType--[getAcceptableContentType]`.
+As a consequence, you can easily share the same handler to produce data of different types:
+
+[source,groovy]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create())
+router.get("/api/books").produces("text/xml").produces("application/json").handler({ rc ->
+  this.findBooks({ ar ->
+    if (ar.succeeded()) {
+      if (rc.getAcceptableContentType() == "text/xml") {
+        rc.response().end(this.toXML(ar.result()))
+      } else {
+        rc.response().end(this.toJson(ar.result()))
+      }
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
 == SockJS
 
 SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1946,6 +1946,62 @@ to when the response headers were written, in ms., e.g.:
 
  x-response-time: 1456ms
 
+== Content type handler
+
+The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+
+[source,java]
+----
+router.get("/api/books").produces("application/json").handler(rc -> {
+  findBooks(ar -> {
+    if (ar.succeeded()) {
+      rc.response().putHeader("Content-Type", "application/json").end(toJson(ar.result()));
+    } else {
+      rc.fail(ar.cause());
+    }
+  });
+});
+----
+
+If the API surface becomes pretty large, setting the content type can become cumbersome.
+To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+
+[source,java]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create());
+router.get("/api/books").produces("application/json").handler(rc -> {
+  findBooks(ar -> {
+    if (ar.succeeded()) {
+      rc.response().end(toJson(ar.result()));
+    } else {
+      rc.fail(ar.cause());
+    }
+  });
+});
+----
+
+The handler gets the approriate content type from `link:../../apidocs/io/vertx/ext/web/RoutingContext.html#getAcceptableContentType--[getAcceptableContentType]`.
+As a consequence, you can easily share the same handler to produce data of different types:
+
+[source,java]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create());
+router.get("/api/books").produces("text/xml").produces("application/json").handler(rc -> {
+  findBooks(ar -> {
+    if (ar.succeeded()) {
+      if (rc.getAcceptableContentType().equals("text/xml")) {
+        rc.response().end(toXML(ar.result()));
+      } else {
+        rc.response().end(toJson(ar.result()));
+      }
+    } else {
+      rc.fail(ar.cause());
+    }
+  });
+});
+----
+
 == SockJS
 
 SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2145,6 +2145,67 @@ to when the response headers were written, in ms., e.g.:
 
  x-response-time: 1456ms
 
+== Content type handler
+
+The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+
+[source,js]
+----
+router.get("/api/books").produces("application/json").handler(function (rc) {
+  findBooks(function (ar, ar_err) {
+    if (ar_err == null) {
+      rc.response().putHeader("Content-Type", "application/json").end(toJson(ar));
+    } else {
+      rc.fail(ar_err);
+    }
+  });
+});
+
+----
+
+If the API surface becomes pretty large, setting the content type can become cumbersome.
+To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+
+[source,js]
+----
+var ResponseContentTypeHandler = require("vertx-web-js/response_content_type_handler");
+router.route("/api/*").handler(ResponseContentTypeHandler.create().handle);
+router.get("/api/books").produces("application/json").handler(function (rc) {
+  findBooks(function (ar, ar_err) {
+    if (ar_err == null) {
+      rc.response().end(toJson(ar));
+    } else {
+      rc.fail(ar_err);
+    }
+  });
+});
+
+----
+
+The handler gets the approriate content type from `link:../../jsdoc/module-vertx-web-js_routing_context-RoutingContext.html#getAcceptableContentType[getAcceptableContentType]`.
+As a consequence, you can easily share the same handler to produce data of different types:
+
+[source,js]
+----
+var ResponseContentTypeHandler = require("vertx-web-js/response_content_type_handler");
+router.route("/api/*").handler(ResponseContentTypeHandler.create().handle);
+router.get("/api/books").produces("text/xml").produces("application/json").handler(function (rc) {
+  findBooks(function (ar, ar_err) {
+    if (ar_err == null) {
+      if (rc.getAcceptableContentType() == "text/xml") {
+        rc.response().end(toXML(ar));
+      } else {
+        rc.response().end(toJson(ar));
+      }
+    } else {
+      rc.fail(ar_err);
+    }
+  });
+});
+
+----
+
 == SockJS
 
 SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-web/src/main/asciidoc/kotlin/index.adoc
@@ -2086,6 +2086,65 @@ to when the response headers were written, in ms., e.g.:
 
  x-response-time: 1456ms
 
+== Content type handler
+
+The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+
+[source,kotlin]
+----
+router.get("/api/books").produces("application/json").handler({ rc ->
+  findBooks({ ar ->
+    if (ar.succeeded()) {
+      rc.response().putHeader("Content-Type", "application/json").end(toJson(ar.result()))
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
+If the API surface becomes pretty large, setting the content type can become cumbersome.
+To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+
+[source,kotlin]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create())
+router.get("/api/books").produces("application/json").handler({ rc ->
+  findBooks({ ar ->
+    if (ar.succeeded()) {
+      rc.response().end(toJson(ar.result()))
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
+The handler gets the approriate content type from `link:../../apidocs/io/vertx/ext/web/RoutingContext.html#getAcceptableContentType--[getAcceptableContentType]`.
+As a consequence, you can easily share the same handler to produce data of different types:
+
+[source,kotlin]
+----
+router.route("/api/*").handler(ResponseContentTypeHandler.create())
+router.get("/api/books").produces("text/xml").produces("application/json").handler({ rc ->
+  findBooks({ ar ->
+    if (ar.succeeded()) {
+      if (rc.getAcceptableContentType() == "text/xml") {
+        rc.response().end(toXML(ar.result()))
+      } else {
+        rc.response().end(toJson(ar.result()))
+      }
+    } else {
+      rc.fail(ar.cause())
+    }
+  })
+})
+
+----
+
 == SockJS
 
 SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-web/src/main/asciidoc/kotlin/index.adoc
@@ -100,7 +100,6 @@ Here's a hello world web server written using Vert.x core. At this point there i
 
 [source,java]
 ----
-
 var server = vertx.createHttpServer()
 
 server.requestHandler({ request ->
@@ -143,8 +142,6 @@ Here's a simple router example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-
 var server = vertx.createHttpServer()
 
 var router = Router.router(vertx)
@@ -197,7 +194,6 @@ You can do this some time later, if you want:
 
 [source,kotlin]
 ----
-
 
 var route1 = router.route("/some/path/").handler({ routingContext ->
 
@@ -259,7 +255,6 @@ Here's an example:
 [source,kotlin]
 ----
 
-
 router.route().blockingHandler({ routingContext ->
 
   // Do something that might take some time synchronously
@@ -282,7 +277,6 @@ Note, if you need to process multipart form data from a blocking handler, you MU
 
 [source,kotlin]
 ----
-
 router.post("/some/endpoint").handler({ ctx ->
   ctx.request().setExpectMultipart(true)
   ctx.next()
@@ -302,7 +296,6 @@ so it will be called for paths `/some/path` and `/some/path//` too:
 
 [source,kotlin]
 ----
-
 
 var route = router.route().path("/some/path/")
 
@@ -333,7 +326,6 @@ For example `/some/path/foo.html` and `/some/path/otherdir/blah.css` would both 
 [source,kotlin]
 ----
 
-
 var route = router.route().path("/some/path/*")
 
 route.handler({ routingContext ->
@@ -357,7 +349,6 @@ With any path it can also be specified when creating the route:
 [source,kotlin]
 ----
 
-
 var route = router.route("/some/path/*")
 
 route.handler({ routingContext ->
@@ -376,8 +367,6 @@ Here's an example
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-
 
 var route = router.route(HttpMethod.POST, "/catalogue/products/:producttype/:productid/")
 
@@ -405,7 +394,6 @@ Regular expressions can also be used to match URI paths in routes.
 [source,kotlin]
 ----
 
-
 // Matches any path ending with 'foo'
 var route = router.route().pathRegex(".*foo")
 
@@ -430,7 +418,6 @@ Alternatively the regex can be specified when creating the route:
 [source,kotlin]
 ----
 
-
 var route = router.routeWithRegex(".*foo")
 
 route.handler({ routingContext ->
@@ -448,7 +435,6 @@ You can also capture path parameters when using regular expressions, here's an e
 
 [source,kotlin]
 ----
-
 
 var route = router.routeWithRegex(".*foo")
 
@@ -479,8 +465,6 @@ If you want a route to only match for a specific HTTP method you can use `link:.
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-
 
 var route = router.route().method(HttpMethod.POST)
 
@@ -497,8 +481,6 @@ Or you can specify this with a path when creating the route:
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-
 
 var route = router.route(HttpMethod.POST, "/some/path/")
 
@@ -517,7 +499,6 @@ method name. For example:
 
 [source,kotlin]
 ----
-
 
 router.get().handler({ routingContext ->
 
@@ -549,8 +530,6 @@ multiple times:
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-
 
 var route = router.route().method(HttpMethod.POST).method(HttpMethod.PUT)
 
@@ -577,7 +556,6 @@ Here's an example to illustrate this:
 
 [source,kotlin]
 ----
-
 
 var route1 = router.route("/some/path/").handler({ routingContext ->
 
@@ -637,7 +615,6 @@ Let's change the ordering of route2 so it runs before route1:
 
 [source,kotlin]
 ----
-
 
 var route1 = router.route("/some/path/").handler({ routingContext ->
 
@@ -702,7 +679,6 @@ Matching can be done on exact MIME type matches:
 [source,kotlin]
 ----
 
-
 // Exact match
 router.route().consumes("text/html").handler({ routingContext ->
 
@@ -717,7 +693,6 @@ Multiple exact matches can also be specified:
 
 [source,kotlin]
 ----
-
 
 // Multiple exact matches
 router.route().consumes("text/html").consumes("text/plain").handler({ routingContext ->
@@ -734,7 +709,6 @@ Matching on wildcards for the sub-type is supported:
 [source,kotlin]
 ----
 
-
 // Sub-type wildcard match
 router.route().consumes("text/*").handler({ routingContext ->
 
@@ -749,7 +723,6 @@ And you can also match on the top level type
 
 [source,kotlin]
 ----
-
 
 // Top level type wildcard match
 router.route().consumes("*/json").handler({ routingContext ->
@@ -794,7 +767,6 @@ following handler produces a response with MIME type `application/json`.
 [source,java]
 ----
 
-
 router.route().produces("application/json").handler({ routingContext ->
 
   var response = routingContext.response()
@@ -820,7 +792,6 @@ was accepted.
 
 [source,kotlin]
 ----
-
 
 // This route can produce two different MIME types
 router.route().produces("application/json").produces("text/html").handler({ routingContext ->
@@ -849,8 +820,6 @@ You can combine all the above routing criteria in many different ways, for examp
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-
 
 var route = router.route(HttpMethod.PUT, "myapi/orders").consumes("application/json").produces("application/json")
 
@@ -886,7 +855,6 @@ A request sent to path `/some/path/other` will match both routes.
 [source,kotlin]
 ----
 
-
 router.get("/some/path").handler({ routingContext ->
 
   routingContext.put("foo", "bar")
@@ -916,7 +884,6 @@ Router.
 
 [source,kotlin]
 ----
-
 
 router.get("/some/path").handler({ routingContext ->
 
@@ -949,7 +916,6 @@ for example:
 [source,kotlin]
 ----
 
-
 router.get("/my-pretty-notfound-handler").handler({ ctx ->
   ctx.response().setStatusCode(404).end("NOT FOUND fancy html here!!!")
 })
@@ -981,8 +947,6 @@ Here's the sub-router:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-
 
 var restAPI = Router.router(vertx)
 
@@ -1016,8 +980,6 @@ However, let's say we already have a web-site as described by another router:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-
 var mainRouter = Router.router(vertx)
 
 // Handle static resources
@@ -1031,7 +993,6 @@ We can now mount the sub router on the main router, against a mount point, in th
 
 [source,kotlin]
 ----
-
 
 mainRouter.mountSubRouter("/productsAPI", restAPI)
 
@@ -1047,7 +1008,6 @@ locale for a client or the sorted list of preferred locales by quality.
 
 [source,kotlin]
 ----
-
 
 var route = router.get("/localized").handler({ rc ->
   // although it might seem strange by running a loop with a switch we
@@ -1090,7 +1050,6 @@ to paths that start with `/somepath/`:
 [source,kotlin]
 ----
 
-
 var route = router.get("/somepath/*")
 
 route.failureHandler({ frc ->
@@ -1113,7 +1072,6 @@ to be retrieved so the failure handler can use that to generate a failure respon
 
 [source,kotlin]
 ----
-
 
 var route1 = router.get("/somepath/path1/")
 
@@ -1168,8 +1126,6 @@ to install handlers to consume the HTTP request body and this must be done befor
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.BodyHandler
-
 
 // This body handler will be called for all routes
 router.route().handler(BodyHandler.create())
@@ -1212,8 +1168,6 @@ Here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.BodyHandler
-
 
 router.route().handler(BodyHandler.create())
 
@@ -1237,8 +1191,6 @@ You should make sure a cookie handler is on a matching route for any requests th
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-
 
 // This cookie handler will be called for all routes
 router.route().handler(CookieHandler.create())
@@ -1265,9 +1217,6 @@ Here's an example of querying and adding cookies:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Cookie
-import io.vertx.ext.web.handler.CookieHandler
-
 
 // This cookie handler will be called for all routes
 router.route().handler(CookieHandler.create())
@@ -1348,8 +1297,6 @@ Here are some examples of creating a `link:../../apidocs/io/vertx/ext/web/sstore
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.sstore.LocalSessionStore
-
 
 // Create a local session store using defaults
 var store1 = LocalSessionStore.create(vertx)
@@ -1381,11 +1328,6 @@ Here are some examples of creating a `link:../../apidocs/io/vertx/ext/web/sstore
 
 [source,kotlin]
 ----
-import io.vertx.core.Vertx
-import io.vertx.core.VertxOptions
-import io.vertx.ext.web.sstore.ClusteredSessionStore
-import io.vertx.kotlin.core.*
-
 
 // a clustered Vert.x
 Vertx.clusteredVertx(VertxOptions(
@@ -1417,11 +1359,6 @@ Here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.sstore.ClusteredSessionStore
-
 
 var router = Router.router(vertx)
 
@@ -1467,8 +1404,6 @@ Here's an example of manipulating session data:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-
 
 router.route().handler(CookieHandler.create())
 router.route().handler(sessionHandler)
@@ -1525,11 +1460,6 @@ Here's a simple example of creating a basic auth handler given an auth provider.
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.BasicAuthHandler
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1545,12 +1475,6 @@ your auth handler is before your application handlers on those paths:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.BasicAuthHandler
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.UserSessionHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1632,14 +1556,6 @@ Here's an example of a simple app, using a redirect auth handler on the default 
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.FormLoginHandler
-import io.vertx.ext.web.handler.RedirectAuthHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.StaticHandler
-import io.vertx.ext.web.handler.UserSessionHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-
 
 router.route().handler(CookieHandler.create())
 router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)))
@@ -1689,12 +1605,6 @@ Here's an example on how to issue tokens:
 
 [source,kotlin]
 ----
-import io.vertx.ext.auth.jwt.JWTAuth
-import io.vertx.ext.auth.jwt.JWTOptions
-import io.vertx.ext.web.Router
-import io.vertx.kotlin.core.json.*
-import io.vertx.kotlin.ext.auth.jwt.*
-
 
 var router = Router.router(vertx)
 
@@ -1726,11 +1636,6 @@ Now that your client has a token all it is required is that for *all* consequent
 
 [source,kotlin]
 ----
-import io.vertx.ext.auth.jwt.JWTAuth
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.JWTAuthHandler
-import io.vertx.kotlin.core.json.*
-
 
 var router = Router.router(vertx)
 
@@ -1758,11 +1663,6 @@ token, during the creation of the token just add data to the JsonObject paramete
 
 [source,kotlin]
 ----
-import io.vertx.ext.auth.jwt.JWTAuth
-import io.vertx.ext.auth.jwt.JWTOptions
-import io.vertx.kotlin.core.json.*
-import io.vertx.kotlin.ext.auth.jwt.*
-
 
 var authConfig = json {
   obj("keyStore" to obj(
@@ -1788,7 +1688,6 @@ And the same when consuming:
 [source,kotlin]
 ----
 
-
 var handler = { rc ->
   var theSubject = rc.user().principal().getString("sub")
   var someKey = rc.user().principal().getString("someKey")
@@ -1809,8 +1708,6 @@ may support a role/permission based model but others might use another model.
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.RedirectAuthHandler
-
 
 var listProductsAuthHandler = RedirectAuthHandler.create(authProvider)
 listProductsAuthHandler.addAuthority("list_products")
@@ -1842,8 +1739,6 @@ In the following example all requests to paths starting with `/static/` will get
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.StaticHandler
-
 
 router.route("/static/*").handler(StaticHandler.create())
 
@@ -1945,9 +1840,6 @@ Here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.core.http.HttpMethod
-import io.vertx.ext.web.handler.CorsHandler
-
 
 // Will only accept GET requests from origin "vertx.io"
 router.route().handler(CorsHandler.create("vertx\\.io").allowedMethod(HttpMethod.GET))
@@ -2069,8 +1961,6 @@ add it the context data in a handler before the template handler. For example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.TemplateHandler
-
 
 var handler = TemplateHandler.create(engine)
 
@@ -2183,8 +2073,6 @@ seconds:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.TimeoutHandler
-
 
 router.route("/foo/").handler(TimeoutHandler.create(5000))
 
@@ -2221,11 +2109,6 @@ an instance of `link:../../apidocs/io/vertx/ext/web/handler/sockjs/SockJSHandler
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2252,11 +2135,6 @@ Here's an example of a simple SockJS handler that simply echoes back any back an
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2357,11 +2235,6 @@ SockJS handler.
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2490,13 +2363,6 @@ Here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.PermittedOptions
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.kotlin.core.json.*
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2561,10 +2427,6 @@ Here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.PermittedOptions
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 // Let through any messages sent to 'demo.orderService' from the client
 var inboundPermitted = PermittedOptions(
@@ -2584,16 +2446,6 @@ To handle the login and actually auth you can configure the normal Vert.x auth h
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.BasicAuthHandler
-import io.vertx.ext.web.handler.CookieHandler
-import io.vertx.ext.web.handler.SessionHandler
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.PermittedOptions
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.ext.web.sstore.LocalSessionStore
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2666,13 +2518,6 @@ Here's an example where we reject all messages flowing through the bridge if the
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.BridgeEventType
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.PermittedOptions
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2762,14 +2607,6 @@ also add headers to the message, here's an example:
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.sockjs.BridgeEventType
-import io.vertx.ext.web.handler.sockjs.BridgeOptions
-import io.vertx.ext.web.handler.sockjs.PermittedOptions
-import io.vertx.ext.web.handler.sockjs.SockJSHandler
-import io.vertx.kotlin.core.json.*
-import io.vertx.kotlin.ext.web.handler.sockjs.*
-
 
 var router = Router.router(vertx)
 
@@ -2830,9 +2667,6 @@ or the header name they have chosen during the instantiation of the `CSRFHandler
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.CSRFHandler
-import io.vertx.ext.web.handler.CookieHandler
-
 
 router.route().handler(CookieHandler.create())
 router.route().handler(CSRFHandler.create("abracadabra"))
@@ -2852,8 +2686,6 @@ example `*.vertx.io` or fully domain names as `www.vertx.io`.
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.VirtualHostHandler
-
 router.route().handler(VirtualHostHandler.create("*.vertx.io", { routingContext ->
   // do something if the request is for *.vertx.io
 }))
@@ -2867,9 +2699,6 @@ authCode flow. An example of using it to protect some resource and authenticate 
 
 [source,kotlin]
 ----
-import io.vertx.ext.auth.oauth2.providers.GithubAuth
-import io.vertx.ext.web.handler.OAuth2AuthHandler
-
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to github
 var authProvider = GithubAuth.create(vertx, "CLIENT_ID", "CLIENT_SECRET")
@@ -2929,12 +2758,6 @@ However if you're using an unlisted provider you can still do it using the base 
 
 [source,kotlin]
 ----
-import io.vertx.ext.auth.oauth2.OAuth2Auth
-import io.vertx.ext.auth.oauth2.OAuth2ClientOptions
-import io.vertx.ext.auth.oauth2.OAuth2FlowType
-import io.vertx.ext.web.handler.OAuth2AuthHandler
-import io.vertx.kotlin.ext.auth.oauth2.*
-
 
 // create an OAuth2 provider, clientID and clientSecret should be requested to Google
 var authProvider = OAuth2Auth.create(vertx, OAuth2FlowType.AUTH_CODE, OAuth2ClientOptions(
@@ -2980,8 +2803,6 @@ mandatory for the default values, 80 for http, 443 for https.
 
 [source,kotlin]
 ----
-import io.vertx.ext.web.handler.OAuth2AuthHandler
-
 // create a oauth2 handler pinned to myserver.com: "https://myserver.com:8447/callback"
 var oauth2 = OAuth2AuthHandler.create(provider, "https://myserver.com:8447/callback")
 // now allow the handler to setup the callback url for you

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -2145,6 +2145,67 @@ to when the response headers were written, in ms., e.g.:
 
  x-response-time: 1456ms
 
+== Content type handler
+
+The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+
+[source,ruby]
+----
+router.get("/api/books").produces("application/json").handler() { |rc|
+  find_books() { |ar_err,ar|
+    if (ar_err == nil)
+      rc.response().put_header("Content-Type", "application/json").end(to_json(ar))
+    else
+      rc.fail(ar_err)
+    end
+  }
+}
+
+----
+
+If the API surface becomes pretty large, setting the content type can become cumbersome.
+To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+
+[source,ruby]
+----
+require 'vertx-web/response_content_type_handler'
+router.route("/api/*").handler(&VertxWeb::ResponseContentTypeHandler.create().method(:handle))
+router.get("/api/books").produces("application/json").handler() { |rc|
+  find_books() { |ar_err,ar|
+    if (ar_err == nil)
+      rc.response().end(to_json(ar))
+    else
+      rc.fail(ar_err)
+    end
+  }
+}
+
+----
+
+The handler gets the approriate content type from `link:../../yardoc/VertxWeb/RoutingContext.html#get_acceptable_content_type-instance_method[getAcceptableContentType]`.
+As a consequence, you can easily share the same handler to produce data of different types:
+
+[source,ruby]
+----
+require 'vertx-web/response_content_type_handler'
+router.route("/api/*").handler(&VertxWeb::ResponseContentTypeHandler.create().method(:handle))
+router.get("/api/books").produces("text/xml").produces("application/json").handler() { |rc|
+  find_books() { |ar_err,ar|
+    if (ar_err == nil)
+      if (rc.get_acceptable_content_type().==("text/xml"))
+        rc.response().end(to_xml(ar))
+      else
+        rc.response().end(to_json(ar))
+      end
+    else
+      rc.fail(ar_err)
+    end
+  }
+}
+
+----
+
 == SockJS
 
 SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -1,8 +1,10 @@
 package examples;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerResponse;
@@ -14,14 +16,42 @@ import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
 import io.vertx.ext.auth.oauth2.providers.GithubAuth;
-import io.vertx.ext.web.*;
-import io.vertx.ext.web.handler.*;
-import io.vertx.ext.web.handler.sockjs.*;
+import io.vertx.ext.web.Cookie;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.LanguageHeader;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
+import io.vertx.ext.web.handler.AuthHandler;
+import io.vertx.ext.web.handler.BasicAuthHandler;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.CSRFHandler;
+import io.vertx.ext.web.handler.CookieHandler;
+import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.handler.ErrorHandler;
+import io.vertx.ext.web.handler.FormLoginHandler;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+import io.vertx.ext.web.handler.OAuth2AuthHandler;
+import io.vertx.ext.web.handler.RedirectAuthHandler;
+import io.vertx.ext.web.handler.ResponseContentTypeHandler;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.handler.StaticHandler;
+import io.vertx.ext.web.handler.TemplateHandler;
+import io.vertx.ext.web.handler.TimeoutHandler;
+import io.vertx.ext.web.handler.UserSessionHandler;
+import io.vertx.ext.web.handler.VirtualHostHandler;
+import io.vertx.ext.web.handler.sockjs.BridgeEventType;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.PermittedOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.sstore.ClusteredSessionStore;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.ext.web.templ.TemplateEngine;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -1231,5 +1261,63 @@ public class WebExamples {
       ctx.response().putHeader("content-type", "text/html").end("Hello<br><a href=\"/protected/somepage\">Protected by LinkedIn</a>");
     });
   }
+
+  public void manualContentType(Router router) {
+    router.get("/api/books").produces("application/json").handler(rc -> {
+      findBooks(ar -> {
+        if (ar.succeeded()) {
+          rc.response().putHeader("Content-Type", "application/json").end(toJson(ar.result()));
+        } else {
+          rc.fail(ar.cause());
+        }
+      });
+    });
+  }
+
+  public void contentTypeHandler(Router router) {
+    router.route("/api/*").handler(ResponseContentTypeHandler.create());
+    router.get("/api/books").produces("application/json").handler(rc -> {
+      findBooks(ar -> {
+        if (ar.succeeded()) {
+          rc.response().end(toJson(ar.result()));
+        } else {
+          rc.fail(ar.cause());
+        }
+      });
+    });
+  }
+
+  private void findBooks(Handler<AsyncResult<List<Book>>> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  class Book {
+  }
+
+  Buffer toJson(List<Book> books) {
+    throw new UnsupportedOperationException();
+  }
+
+  Buffer toXML(List<Book> books) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void mostAcceptableContentTypeHandler(Router router) {
+    router.route("/api/*").handler(ResponseContentTypeHandler.create());
+    router.get("/api/books").produces("text/xml").produces("application/json").handler(rc -> {
+      findBooks(ar -> {
+        if (ar.succeeded()) {
+          if (rc.getAcceptableContentType().equals("text/xml")) {
+            rc.response().end(toXML(ar.result()));
+          } else {
+            rc.response().end(toJson(ar.result()));
+          }
+        } else {
+          rc.fail(ar.cause());
+        }
+      });
+    });
+  }
+
 }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/ResponseContentTypeHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/ResponseContentTypeHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.ResponseContentTypeHandlerImpl;
+
+/**
+ * A handler which sets the response content type automatically according to the best {@code Accept} header match.
+ *
+ * The header is set only if:
+ * <ul>
+ * <li>no object is stored in the routing context under the name {@link #DEFAULT_DISABLE_FLAG}</li>
+ * <li>a match is found</li>
+ * <li>the header is not present already</li>
+ * <li>content length header is absent or set to something different than zero</li>
+ * </ul>
+ *
+ * @author Thomas Segismont
+ * @see RoutingContext#getAcceptableContentType()
+ */
+@VertxGen
+public interface ResponseContentTypeHandler extends Handler<RoutingContext> {
+
+  String DEFAULT_DISABLE_FLAG = "__vertx.autoContenType.disable";
+
+  /**
+   * Create a response content type handler.
+   *
+   * @return the response content type handler
+   */
+  static ResponseContentTypeHandler create() {
+    return new ResponseContentTypeHandlerImpl(DEFAULT_DISABLE_FLAG);
+  }
+
+  /**
+   * Create a response content type handler with a custom disable flag.
+   *
+   * @return the response content type handler
+   */
+  static ResponseContentTypeHandler create(String disableFlag) {
+    return new ResponseContentTypeHandlerImpl(disableFlag);
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseContentTypeHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseContentTypeHandlerImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.impl;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.ResponseContentTypeHandler;
+
+import static io.vertx.core.http.HttpHeaders.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ResponseContentTypeHandlerImpl implements ResponseContentTypeHandler {
+
+  private final String disableFlag;
+
+  public ResponseContentTypeHandlerImpl(String disableFlag) {
+    this.disableFlag = disableFlag;
+  }
+
+  @Override
+  public void handle(RoutingContext rc) {
+    HttpServerResponse response = rc.response();
+    response.headersEndHandler(v -> {
+      if (rc.get(disableFlag) != null) {
+        return;
+      }
+      String acceptableContentType = rc.getAcceptableContentType();
+      if (acceptableContentType == null) {
+        return;
+      }
+      MultiMap headers = rc.response().headers();
+      if (headers.contains(CONTENT_TYPE)) {
+        return;
+      }
+      if (!"0".equals(headers.get(CONTENT_LENGTH))) {
+        headers.add(CONTENT_TYPE, acceptableContentType);
+      }
+    });
+    rc.next();
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1404,6 +1404,32 @@
  *
  *  x-response-time: 1456ms
  *
+ * == Content type handler
+ *
+ * The `ResponseContentTypeHandler` can set the `Content-Type` header automatically.
+ * Suppose we are building a RESTful web application. We need to set the content type in all our handlers:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.WebExamples#manualContentType(io.vertx.ext.web.Router)}
+ * ----
+ *
+ * If the API surface becomes pretty large, setting the content type can become cumbersome.
+ * To avoid this situation, add the `ResponseContentTypeHandler` to the corresponding routes:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.WebExamples#contentTypeHandler(io.vertx.ext.web.Router)}
+ * ----
+ *
+ * The handler gets the approriate content type from {@link io.vertx.ext.web.RoutingContext#getAcceptableContentType()}.
+ * As a consequence, you can easily share the same handler to produce data of different types:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.WebExamples#mostAcceptableContentTypeHandler(io.vertx.ext.web.Router)}
+ * ----
+ *
  * == SockJS
  *
  * SockJS is a client side JavaScript library and protocol which provides a simple WebSocket-like interface allowing you

--- a/vertx-web/src/main/resources/vertx-web-js/response_content_type_handler.js
+++ b/vertx-web/src/main/resources/vertx-web-js/response_content_type_handler.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module vertx-web-js/response_content_type_handler */
+var utils = require('vertx-js/util/utils');
+var RoutingContext = require('vertx-web-js/routing_context');
+
+var io = Packages.io;
+var JsonObject = io.vertx.core.json.JsonObject;
+var JResponseContentTypeHandler = Java.type('io.vertx.ext.web.handler.ResponseContentTypeHandler');
+
+/**
+
+ @class
+*/
+var ResponseContentTypeHandler = function(j_val) {
+
+  var j_responseContentTypeHandler = j_val;
+  var that = this;
+
+  /**
+
+   @public
+   @param arg0 {RoutingContext} 
+   */
+  this.handle = function(arg0) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'object' && __args[0]._jdel) {
+      j_responseContentTypeHandler["handle(io.vertx.ext.web.RoutingContext)"](arg0._jdel);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  // A reference to the underlying Java delegate
+  // NOTE! This is an internal API and must not be used in user code.
+  // If you rely on this property your code is likely to break if we change it / remove it without warning.
+  this._jdel = j_responseContentTypeHandler;
+};
+
+ResponseContentTypeHandler._jclass = utils.getJavaClass("io.vertx.ext.web.handler.ResponseContentTypeHandler");
+ResponseContentTypeHandler._jtype = {
+  accept: function(obj) {
+    return ResponseContentTypeHandler._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    var obj = Object.create(ResponseContentTypeHandler.prototype, {});
+    ResponseContentTypeHandler.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
+ResponseContentTypeHandler._create = function(jdel) {
+  var obj = Object.create(ResponseContentTypeHandler.prototype, {});
+  ResponseContentTypeHandler.apply(obj, arguments);
+  return obj;
+}
+/**
+ Create a response content type handler with a custom disable flag.
+
+ @memberof module:vertx-web-js/response_content_type_handler
+ @param disableFlag {string} 
+ @return {ResponseContentTypeHandler} the response content type handler
+ */
+ResponseContentTypeHandler.create = function() {
+  var __args = arguments;
+  if (__args.length === 0) {
+    return utils.convReturnVertxGen(ResponseContentTypeHandler, JResponseContentTypeHandler["create()"]());
+  }else if (__args.length === 1 && typeof __args[0] === 'string') {
+    return utils.convReturnVertxGen(ResponseContentTypeHandler, JResponseContentTypeHandler["create(java.lang.String)"](__args[0]));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+module.exports = ResponseContentTypeHandler;

--- a/vertx-web/src/main/resources/vertx-web/response_content_type_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/response_content_type_handler.rb
@@ -1,0 +1,61 @@
+require 'vertx-web/routing_context'
+require 'vertx/util/utils.rb'
+# Generated from io.vertx.ext.web.handler.ResponseContentTypeHandler
+module VertxWeb
+  #  A handler which sets the response content type automatically according to the best <code>Accept</code> header match.
+  # 
+  #  The header is set only if:
+  #  <ul>
+  #    <li>no object is stored in the routing context under the name DEFAULT_DISABLE_FLAG</li>
+  #  <li>a match is found</li>
+  #  <li>the header is not present already</li>
+  #  <li>content length header is absent or set to something different than zero</li>
+  #  </ul>
+  class ResponseContentTypeHandler
+    # @private
+    # @param j_del [::VertxWeb::ResponseContentTypeHandler] the java delegate
+    def initialize(j_del)
+      @j_del = j_del
+    end
+    # @private
+    # @return [::VertxWeb::ResponseContentTypeHandler] the underlying java delegate
+    def j_del
+      @j_del
+    end
+    @@j_api_type = Object.new
+    def @@j_api_type.accept?(obj)
+      obj.class == ResponseContentTypeHandler
+    end
+    def @@j_api_type.wrap(obj)
+      ResponseContentTypeHandler.new(obj)
+    end
+    def @@j_api_type.unwrap(obj)
+      obj.j_del
+    end
+    def self.j_api_type
+      @@j_api_type
+    end
+    def self.j_class
+      Java::IoVertxExtWebHandler::ResponseContentTypeHandler.java_class
+    end
+    # @param [::VertxWeb::RoutingContext] arg0 
+    # @return [void]
+    def handle(arg0=nil)
+      if arg0.class.method_defined?(:j_del) && !block_given?
+        return @j_del.java_method(:handle, [Java::IoVertxExtWeb::RoutingContext.java_class]).call(arg0.j_del)
+      end
+      raise ArgumentError, "Invalid arguments when calling handle(#{arg0})"
+    end
+    #  Create a response content type handler with a custom disable flag.
+    # @param [String] disableFlag 
+    # @return [::VertxWeb::ResponseContentTypeHandler] the response content type handler
+    def self.create(disableFlag=nil)
+      if !block_given? && disableFlag == nil
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtWebHandler::ResponseContentTypeHandler.java_method(:create, []).call(),::VertxWeb::ResponseContentTypeHandler)
+      elsif disableFlag.class == String && !block_given?
+        return ::Vertx::Util::Utils.safe_create(Java::IoVertxExtWebHandler::ResponseContentTypeHandler.java_method(:create, [Java::java.lang.String.java_class]).call(disableFlag),::VertxWeb::ResponseContentTypeHandler)
+      end
+      raise ArgumentError, "Invalid arguments when calling create(#{disableFlag})"
+    end
+  end
+end

--- a/vertx-web/src/main/resources/vertx-web/response_content_type_handler.rb
+++ b/vertx-web/src/main/resources/vertx-web/response_content_type_handler.rb
@@ -6,7 +6,7 @@ module VertxWeb
   # 
   #  The header is set only if:
   #  <ul>
-  #    <li>no object is stored in the routing context under the name DEFAULT_DISABLE_FLAG</li>
+  #  <li>no object is stored in the routing context under the name DEFAULT_DISABLE_FLAG</li>
   #  <li>a match is found</li>
   #  <li>the header is not present already</li>
   #  <li>content length header is absent or set to something different than zero</li>

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.WebTestBase;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static io.vertx.core.http.HttpHeaders.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ResponseContentTypeHandlerTest extends WebTestBase {
+
+  private Route testRoute;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    router.route().handler(ResponseContentTypeHandler.create());
+    testRoute = router.route("/test");
+  }
+
+  @Test
+  public void testNoMatch() {
+    testRoute.handler(rc -> rc.response().end());
+    client.get(testRoute.getPath(), resp -> {
+      assertNull(contentType(resp));
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  @Test
+  public void testExistingHeader() {
+    testRoute.produces("application/json").handler(rc -> rc.response().putHeader(CONTENT_TYPE, "text/plain").end());
+    client.get(testRoute.getPath(), resp -> {
+      assertEquals("text/plain", contentType(resp));
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  @Test
+  public void testFixedContent() {
+    Buffer buffer = Buffer.buffer(new JsonObject().put("toto", "titi").encode().getBytes());
+    testRoute.produces("application/json").handler(rc -> {
+      rc.response().end(buffer);
+    });
+    client.get(testRoute.getPath(), resp -> {
+      assertEquals("application/json", contentType(resp));
+      assertEquals(Integer.valueOf(buffer.length()), contentLength(resp));
+      resp.bodyHandler(buf -> {
+        assertEquals(buffer, buf);
+      });
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  @Test
+  public void testChunkedContent() {
+    Buffer buffer = Buffer.buffer(new JsonObject().put("toto", "titi").encode().getBytes());
+    testRoute.produces("application/json").handler(rc -> {
+      rc.response().setChunked(true).end(buffer);
+    });
+    client.get(testRoute.getPath(), resp -> {
+      assertEquals("application/json", contentType(resp));
+      assertNull(contentLength(resp));
+      resp.bodyHandler(buf -> {
+        assertEquals(buffer, buf);
+      });
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  @Test
+  public void testNoContent() {
+    testRoute.produces("application/json").handler(rc -> {
+      rc.response().end();
+    });
+    client.get(testRoute.getPath(), resp -> {
+      assertNull(contentType(resp));
+      assertEquals(Integer.valueOf(0), contentLength(resp));
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  @Test
+  public void testDisableFlag() {
+    Random random = new Random();
+    byte[] bytes = new byte[128];
+    random.nextBytes(bytes);
+    Buffer buffer = Buffer.buffer(bytes);
+    testRoute.produces("application/json").handler(rc -> {
+      rc.put(ResponseContentTypeHandler.DEFAULT_DISABLE_FLAG, true);
+      rc.response().end(buffer);
+    });
+    client.get(testRoute.getPath(), resp -> {
+      assertNull(contentType(resp));
+      assertEquals(Integer.valueOf(buffer.length()), contentLength(resp));
+      resp.bodyHandler(buf -> {
+        assertEquals(buffer, buf);
+      });
+      testComplete();
+    }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
+    await();
+  }
+
+  private String contentType(HttpClientResponse resp) {
+    return resp.getHeader(CONTENT_TYPE);
+  }
+
+  private Integer contentLength(HttpClientResponse resp) {
+    String header = resp.getHeader(CONTENT_LENGTH);
+    return header == null ? null : Integer.parseInt(header);
+  }
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
@@ -73,8 +73,8 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
       assertEquals(Integer.valueOf(buffer.length()), contentLength(resp));
       resp.bodyHandler(buf -> {
         assertEquals(buffer, buf);
+        testComplete();
       });
-      testComplete();
     }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
     await();
   }
@@ -90,8 +90,8 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
       assertNull(contentLength(resp));
       resp.bodyHandler(buf -> {
         assertEquals(buffer, buf);
+        testComplete();
       });
-      testComplete();
     }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
     await();
   }
@@ -124,8 +124,8 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
       assertEquals(Integer.valueOf(buffer.length()), contentLength(resp));
       resp.bodyHandler(buf -> {
         assertEquals(buffer, buf);
+        testComplete();
       });
-      testComplete();
     }).putHeader(HttpHeaders.ACCEPT, "application/json").end();
     await();
   }


### PR DESCRIPTION
Currently when you say that a route produces content of some type, the response header is not set automatically.

With this change, the most acceptable type would be set (but the user can still disable the future at the route level).