### PR TITLE
Ignore whitespace around comma separated header values

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -19,7 +19,6 @@ package io.vertx.ext.web;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -1173,6 +1172,25 @@ public class RouterTest extends WebTestBase {
     });
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html,application/*,text/plain", 200, "application/json");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;a,application/*,text/plain", 200, "application/json");
+  }
+
+  @Test
+  public void testAcceptsWithSpaces() throws Exception {
+    router.route("/json").produces("application/json").handler(rc -> {
+      rc.response().setStatusMessage(rc.getAcceptableContentType());
+      rc.response().end();
+    });
+    testRequestWithAccepts(HttpMethod.GET, "/json", "    text/html    , application/*    , text/plain; q= 0.9  ", 200, "application/json");
+    router.route("/html").produces("text/html").handler(rc -> {
+      rc.response().setStatusMessage(rc.getAcceptableContentType());
+      rc.response().end();
+    });
+    testRequestWithAccepts(HttpMethod.GET, "/html", "    text/html    , application/*    , text/plain; q= 0.9  ", 200, "text/html");
+    router.route("/text").produces("text/plain").handler(rc -> {
+      rc.response().setStatusMessage(rc.getAcceptableContentType());
+      rc.response().end();
+    });
+    testRequestWithAccepts(HttpMethod.GET, "/text", "    text/html    , application/*    , text/plain; q= 0.9  ", 200, "text/plain");
   }
 
   @Test


### PR DESCRIPTION
See:
Accept header: https://tools.ietf.org/html/rfc7231#section-5.3.2
Comma separated values: https://tools.ietf.org/html/rfc7230#section-7
Whitespace: https://tools.ietf.org/html/rfc7230#section-3.2.3