### PR TITLE
Doc fix: FormLoginHandler expects POST requests

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -1568,7 +1568,8 @@ def redirectAuthHandler = RedirectAuthHandler.create(authProvider)
 router.route("/private/*").handler(redirectAuthHandler)
 
 // Handle the actual login
-router.route("/login").handler(FormLoginHandler.create(authProvider))
+// One of your pages must POST form login data
+router.post("/login").handler(FormLoginHandler.create(authProvider))
 
 // Set a static server to serve static resources, e.g. the login page
 router.route().handler(StaticHandler.create())

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1456,7 +1456,8 @@ AuthHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
 router.route("/private/*").handler(redirectAuthHandler);
 
 // Handle the actual login
-router.route("/login").handler(FormLoginHandler.create(authProvider));
+// One of your pages must POST form login data
+router.post("/login").handler(FormLoginHandler.create(authProvider));
 
 // Set a static server to serve static resources, e.g. the login page
 router.route().handler(StaticHandler.create());

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -1600,7 +1600,8 @@ var redirectAuthHandler = RedirectAuthHandler.create(authProvider);
 router.route("/private/*").handler(redirectAuthHandler.handle);
 
 // Handle the actual login
-router.route("/login").handler(FormLoginHandler.create(authProvider).handle);
+// One of your pages must POST form login data
+router.post("/login").handler(FormLoginHandler.create(authProvider).handle);
 
 // Set a static server to serve static resources, e.g. the login page
 router.route().handler(StaticHandler.create().handle);

--- a/vertx-web/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-web/src/main/asciidoc/kotlin/index.adoc
@@ -1567,7 +1567,8 @@ var redirectAuthHandler = RedirectAuthHandler.create(authProvider)
 router.route("/private/*").handler(redirectAuthHandler)
 
 // Handle the actual login
-router.route("/login").handler(FormLoginHandler.create(authProvider))
+// One of your pages must POST form login data
+router.post("/login").handler(FormLoginHandler.create(authProvider))
 
 // Set a static server to serve static resources, e.g. the login page
 router.route().handler(StaticHandler.create())

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -1600,7 +1600,8 @@ redirectAuthHandler = VertxWeb::RedirectAuthHandler.create(authProvider)
 router.route("/private/*").handler(&redirectAuthHandler.method(:handle))
 
 # Handle the actual login
-router.route("/login").handler(&VertxWeb::FormLoginHandler.create(authProvider).method(:handle))
+# One of your pages must POST form login data
+router.post("/login").handler(&VertxWeb::FormLoginHandler.create(authProvider).method(:handle))
 
 # Set a static server to serve static resources, e.g. the login page
 router.route().handler(&VertxWeb::StaticHandler.create().method(:handle))

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -777,7 +777,8 @@ public class WebExamples {
     router.route("/private/*").handler(redirectAuthHandler);
 
     // Handle the actual login
-    router.route("/login").handler(FormLoginHandler.create(authProvider));
+    // One of your pages must POST form login data
+    router.post("/login").handler(FormLoginHandler.create(authProvider));
 
     // Set a static server to serve static resources, e.g. the login page
     router.route().handler(StaticHandler.create());


### PR DESCRIPTION
To avoid confusion, use #post method in the documentation to bind the form login handler.