### PR TITLE
WebClientOptions.toJson() method

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
@@ -99,6 +99,17 @@ public class WebClientOptions extends HttpClientOptions {
   }
 
   /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    WebClientOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
    * @return true if the Web Client should send a user agent header, false otherwise
    */
   public boolean isUserAgentEnabled() {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientOptionsTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientOptionsTest.java
@@ -30,12 +30,25 @@ public class WebClientOptionsTest {
   @Test
   public void testFromJson() {
     JsonObject json = new JsonObject()
+      .put("defaultPort", 4848)
       .put("userAgentEnabled", false)
       .put("maxPoolSize", 50);
     WebClientOptions options = new WebClientOptions(json);
+    assertEquals(4848, options.getDefaultPort());
     assertFalse(options.isUserAgentEnabled());
     assertEquals("Vert.x-WebClient/" + VersionCommand.getVersion(), options.getUserAgent());
     assertEquals(50, options.getMaxPoolSize());
   }
 
+  @Test
+  public void testToJson() {
+    WebClientOptions options = new WebClientOptions()
+      .setDefaultPort(4848)
+      .setMaxPoolSize(50)
+      .setUserAgentEnabled(false);
+    JsonObject json = options.toJson();
+    assertEquals(4848, (int) json.getInteger("defaultPort"));
+    assertEquals(50, (int) json.getInteger("maxPoolSize"));
+    assertEquals(false, json.getBoolean("userAgentEnabled"));
+  }
 }


### PR DESCRIPTION
this method is necessary for properly `WebClientOptions` serialization
see vert-x3/vertx-consul-client/issues/19