### PR TITLE
Allow usage of custom PebbleEngine

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-pebble/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
 	    <groupId>com.mitchellbosecke</groupId>
 	    <artifactId>pebble</artifactId>
-	    <version>2.0.0</version>
+	    <version>2.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/PebbleTemplateEngine.java
@@ -16,6 +16,8 @@
 
 package io.vertx.ext.web.templ;
 
+import com.mitchellbosecke.pebble.PebbleEngine;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.templ.impl.PebbleTemplateEngineImpl;
@@ -46,6 +48,17 @@ public interface PebbleTemplateEngine extends TemplateEngine {
 	static PebbleTemplateEngine create(Vertx vertx) {
 		return new PebbleTemplateEngineImpl(vertx);
 	}
+
+  /**
+   * Create a template engine using a custom Builder, e.g. if
+   * you want use custom Filters or Functions.
+   *
+   * @return the engine
+   */
+  @GenIgnore
+  static PebbleTemplateEngine create(PebbleEngine.Builder builder) {
+    return new PebbleTemplateEngineImpl(builder);
+  }
 
 	/**
 	 * Set the extension for the engine

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/PebbleTemplateEngine.java
@@ -56,8 +56,8 @@ public interface PebbleTemplateEngine extends TemplateEngine {
    * @return the engine
    */
   @GenIgnore
-  static PebbleTemplateEngine create(PebbleEngine.Builder builder) {
-    return new PebbleTemplateEngineImpl(builder);
+  static PebbleTemplateEngine create(PebbleEngine engine) {
+    return new PebbleTemplateEngineImpl(engine);
   }
 
 	/**

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -38,12 +38,12 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
-    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)));
+    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).build());
   }
 
-  public PebbleTemplateEngineImpl(PebbleEngine.Builder builder) {
+  public PebbleTemplateEngineImpl(PebbleEngine engine) {
     super(DEFAULT_TEMPLATE_EXTENSION, DEFAULT_MAX_CACHE_SIZE);
-    this.pebbleEngine = builder.build();
+    this.pebbleEngine = engine;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -38,7 +38,7 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
-    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).build());
+    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).cacheActive(false).build());
   }
 
   public PebbleTemplateEngineImpl(PebbleEngine engine) {

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -16,13 +16,8 @@
 
 package io.vertx.ext.web.templ.impl;
 
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -30,6 +25,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.templ.PebbleTemplateEngine;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Dan Kristensen
@@ -39,8 +38,12 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
+    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)));
+  }
+
+  public PebbleTemplateEngineImpl(PebbleEngine.Builder builder) {
     super(DEFAULT_TEMPLATE_EXTENSION, DEFAULT_MAX_CACHE_SIZE);
-    pebbleEngine = new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).build();
+    this.pebbleEngine = builder.build();
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
  *
  * @author Paulo Lopes
  */
-class PebbleVertxLoader implements Loader<String> {
+public class PebbleVertxLoader implements Loader<String> {
 
   private final Vertx vertx;
 

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template5.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template5.peb
@@ -1,0 +1,3 @@
+Hello {{context.get("foo")}} and {{context.get("bar")}}
+String is {{ createString() }}
+Request path is {{context.request().path()}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
@@ -16,11 +16,13 @@
 
 package io.vertx.ext.web.templ;
 
-import org.junit.Test;
-
+import com.mitchellbosecke.pebble.PebbleEngine;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.TemplateHandler;
+import io.vertx.ext.web.templ.extension.TestExtension;
+import io.vertx.ext.web.templ.impl.PebbleVertxLoader;
+import org.junit.Test;
 
 /**
  * @author Dan Kristensen
@@ -328,4 +330,10 @@ public class PebbleTemplateTest extends WebTestBase {
             "\n" +
             "</body>\n" +
             "</html>";
+
+  @Test
+  public void customBuilderShouldRender() throws Exception {
+    final TemplateEngine engine = PebbleTemplateEngine.create(new PebbleEngine.Builder().extension(new TestExtension()).loader(new PebbleVertxLoader(vertx)));
+    testTemplateHandler(engine, "src/test/filesystemtemplates", "test-pebble-template5.peb","Hello badger and foxString is TESTRequest path is /test-pebble-template5.peb");
+  }
 }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
@@ -333,7 +333,7 @@ public class PebbleTemplateTest extends WebTestBase {
 
   @Test
   public void customBuilderShouldRender() throws Exception {
-    final TemplateEngine engine = PebbleTemplateEngine.create(new PebbleEngine.Builder().extension(new TestExtension()).loader(new PebbleVertxLoader(vertx)));
+    final TemplateEngine engine = PebbleTemplateEngine.create(new PebbleEngine.Builder().extension(new TestExtension()).loader(new PebbleVertxLoader(vertx)).build());
     testTemplateHandler(engine, "src/test/filesystemtemplates", "test-pebble-template5.peb","Hello badger and foxString is TESTRequest path is /test-pebble-template5.peb");
   }
 }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/extension/TestExtension.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/extension/TestExtension.java
@@ -1,0 +1,32 @@
+package io.vertx.ext.web.templ.extension;
+
+import com.mitchellbosecke.pebble.extension.AbstractExtension;
+import com.mitchellbosecke.pebble.extension.Function;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by jensklingsporn on 22.02.17.
+ */
+public class TestExtension extends AbstractExtension{
+
+  @Override
+  public Map<String, Function> getFunctions() {
+    return Collections.singletonMap("createString",new CreateStringFunction());
+  }
+
+  class CreateStringFunction implements Function{
+
+    @Override
+    public Object execute(Map<String, Object> args) {
+      return "TEST";
+    }
+
+    @Override
+    public List<String> getArgumentNames() {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1928,6 +1928,7 @@ Here are some examples:
 
 Please consult the http://www.mitchellbosecke.com/pebble/home/[Pebble documentation] for how to write
 Pebble templates.
+
 == Error handler
 
 You can render your own errors using a template handler or otherwise but Vert.x-Web also includes an out of the boxy

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -47,11 +47,10 @@ Some of the key features of Vert.x-Web include:
 * Favicon handling
 * Template support for server side rendering, including support for the following template engines out of the box:
 ** Handlebars
-** Jade
+** Jade,
 ** MVEL
 ** Thymeleaf
 ** Apache FreeMarker
-** Pebble
 * Response time handler
 * Static file serving, including caching logic and directory listing.
 * Request timeout support
@@ -1900,34 +1899,6 @@ Here are some examples:
 
 Please consult the http://www.freemarker.org/[Apache FreeMarker documentation] for how to write
 Apache FreeMarker templates.
-
-=== Pebble template engine
-
-To use Pebble, you need to add the following _dependency_ to your project:
-`io.vertx:vertx-web-templ-pebble:3.4.0-SNAPSHOT`. Create an instance of the Pebble template engine
-using: `io.vertx.ext.web.templ.PebbleTemplateEngine#create(vertx)`.
-
-When using the Pebble template engine, it will by default look for
-templates with the `.peb` extension if no extension is specified in the file name.
-
-The routing context `link:../../apidocs/io/vertx/ext/web/RoutingContext.html[RoutingContext]` is available
-in the Pebble template as the `context` variable, this means you can render the template based on anything in the context
-including the request, response, session or context data.
-
-Here are some examples:
-
-----
-[snip]
-<p th:text="{{context.foo}}"></p>
-<p th:text="{{context.bar}}"></p>
-<p th:text="{{context.normalisedPath()}}"></p>
-<p th:text="{{context.request().params().param1}}"></p>
-<p th:text="{{context.request().params().param2}}"></p>
-[snip]
-----
-
-Please consult the http://www.mitchellbosecke.com/pebble/home/[Pebble documentation] for how to write
-Pebble templates.
 
 == Error handler
 

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -47,10 +47,11 @@ Some of the key features of Vert.x-Web include:
 * Favicon handling
 * Template support for server side rendering, including support for the following template engines out of the box:
 ** Handlebars
-** Jade,
+** Jade
 ** MVEL
 ** Thymeleaf
 ** Apache FreeMarker
+** Pebble
 * Response time handler
 * Static file serving, including caching logic and directory listing.
 * Request timeout support
@@ -1900,6 +1901,33 @@ Here are some examples:
 Please consult the http://www.freemarker.org/[Apache FreeMarker documentation] for how to write
 Apache FreeMarker templates.
 
+=== Pebble template engine
+
+To use Pebble, you need to add the following _dependency_ to your project:
+`io.vertx:vertx-web-templ-pebble:3.4.0-SNAPSHOT`. Create an instance of the Pebble template engine
+using: `io.vertx.ext.web.templ.PebbleTemplateEngine#create(vertx)`.
+
+When using the Pebble template engine, it will by default look for
+templates with the `.peb` extension if no extension is specified in the file name.
+
+The routing context `link:../../apidocs/io/vertx/ext/web/RoutingContext.html[RoutingContext]` is available
+in the Pebble template as the `context` variable, this means you can render the template based on anything in the context
+including the request, response, session or context data.
+
+Here are some examples:
+
+----
+[snip]
+<p th:text="{{context.foo}}"></p>
+<p th:text="{{context.bar}}"></p>
+<p th:text="{{context.normalisedPath()}}"></p>
+<p th:text="{{context.request().params().param1}}"></p>
+<p th:text="{{context.request().params().param2}}"></p>
+[snip]
+----
+
+Please consult the http://www.mitchellbosecke.com/pebble/home/[Pebble documentation] for how to write
+Pebble templates.
 == Error handler
 
 You can render your own errors using a template handler or otherwise but Vert.x-Web also includes an out of the boxy

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -50,6 +50,7 @@
  * ** MVEL
  * ** Thymeleaf
  * ** Apache FreeMarker
+ * ** Pebble
  * * Response time handler
  * * Static file serving, including caching logic and directory listing.
  * * Request timeout support
@@ -1356,6 +1357,34 @@
  *
  * Please consult the http://www.freemarker.org/[Apache FreeMarker documentation] for how to write
  * Apache FreeMarker templates.
+ *
+ * === Pebble template engine
+ *
+ * To use Pebble, you need to add the following _dependency_ to your project:
+ * `io.vertx:vertx-web-templ-pebble:3.4.0-SNAPSHOT`. Create an instance of the Pebble template engine
+ * using: `io.vertx.ext.web.templ.PebbleTemplateEngine#create(vertx)`.
+ *
+ * When using the Pebble template engine, it will by default look for
+ * templates with the `.peb` extension if no extension is specified in the file name.
+ *
+ * The routing context `link:../../apidocs/io/vertx/ext/web/RoutingContext.html[RoutingContext]` is available
+ * in the Pebble template as the `context` variable, this means you can render the template based on anything in the context
+ * including the request, response, session or context data.
+ *
+ * Here are some examples:
+ *
+ * ----
+ * [snip]
+ * <p th:text="{{context.foo}}"></p>
+ * <p th:text="{{context.bar}}"></p>
+ * <p th:text="{{context.normalisedPath()}}"></p>
+ * <p th:text="{{context.request().params().param1}}"></p>
+ * <p th:text="{{context.request().params().param2}}"></p>
+ * [snip]
+ * ----
+ *
+ * Please consult the http://www.mitchellbosecke.com/pebble/home/[Pebble documentation] for how to write
+ * Pebble templates.
  *
  * == Error handler
  *


### PR DESCRIPTION
When someone is [extending Pebble](http://www.mitchellbosecke.com/pebble/documentation/guide/extending-pebble) by using own Filters or Functions, he has to be able to pass-in a custom PebbleEngine. I added a new constructor and create-method for this. To be able to access the PebbleVertxLoader, I had to increase the visibility of that class to public. Alternatively I though about adding a PebbleEngine.Builder instance instead and force the Loader to VertxLoader in the PebbleTemplateEngineImpl-constructor, but this would prevent the rare usecase when someone actually needs to provide it's own loader.
I also bumped the version of the pebble-dependency to 2.3.0.