### PR TITLE
Replaced Usage of handler() with textMessageHandler()

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -94,20 +94,8 @@ class WebSocketTransport extends BaseTransport {
     WebSocketListener(ServerWebSocket ws, SockJSSession session) {
       this.ws = ws;
       this.session = session;
-      ws.handler(data -> {
-        if (!session.isClosed()) {
-          String msgs = data.toString();
-          if (msgs.equals("")) {
-            //Ignore empty frames
-          } else if ((msgs.startsWith("[\"") && msgs.endsWith("\"]")) ||
-                     (msgs.startsWith("\"") && msgs.endsWith("\""))) {
-            session.handleMessages(msgs);
-          } else {
-            //Invalid JSON - we close the connection
-            close();
-          }
-        }
-      });
+      ws.textMessageHandler(this::handleMessage);
+      ws.binaryMessageHandler((buffer) -> this.handleMessage(buffer.toString()));
       ws.closeHandler(v -> {
         closed = true;
         session.shutdown();
@@ -117,6 +105,21 @@ class WebSocketTransport extends BaseTransport {
         session.shutdown();
         session.handleException(t);
       });
+    }
+
+    private void handleMessage(String msgs) {
+      if (!session.isClosed()) {
+        if (msgs.equals("")) {
+          //Ignore empty frames
+        } else if ((msgs.startsWith("[\"") && msgs.endsWith("\"]")) ||
+          (msgs.startsWith("\"") && msgs.endsWith("\""))) {
+          session.handleMessages(msgs);
+        } else {
+          //Invalid JSON - we close the connection
+          log.warn("Invalid sockJS packet received - closing connection");
+          close();
+        }
+      }
     }
 
     public void sendFrame(final String body) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -94,8 +94,8 @@ class WebSocketTransport extends BaseTransport {
     WebSocketListener(ServerWebSocket ws, SockJSSession session) {
       this.ws = ws;
       this.session = session;
-      ws.textMessageHandler(this::handleMessage);
       ws.binaryMessageHandler((buffer) -> this.handleMessage(buffer.toString()));
+      ws.textMessageHandler(this::handleMessage);
       ws.closeHandler(v -> {
         closed = true;
         session.shutdown();


### PR DESCRIPTION
The ServerWebSocket now provides fragmentation-safe textMessageHandler() and binaryMessageHandler() - the existing handler() call was replaced.