### PR TITLE
Add useNormalisedPathByDefault to Router

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -168,7 +168,7 @@ public interface Route {
 
   /**
    * If true then the normalised request path will be used when routing (e.g. removing duplicate /)
-   * Default is true
+   * Defaults to {@link io.vertx.ext.web.Router#useNormalisedPathByDefault(boolean)} in the router
    *
    * @param useNormalisedPath  use normalised path for routing?
    * @return a reference to this, so the API can be used fluently

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -361,6 +361,18 @@ public interface Router {
   Router exceptionHandler(@Nullable Handler<Throwable> exceptionHandler);
 
   /**
+   * If true then the normalised request path will be used when routing (e.g. removing duplicate /)
+   * by default for all top-level routes on this router, unless explicitly set.
+   * Sub-routers will override this option.
+   * Default is true
+   *
+   * @param useNormalisedPathByDefault  use normalised path by default for all routes on this router?
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Router useNormalisedPathByDefault(boolean useNormalisedPathByDefault);
+
+  /**
    * Used to route a context to the router. Used for sub-routers. You wouldn't normally call this method directly.
    *
    * @param context  the routing context

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -71,6 +71,7 @@ public class RouterImpl implements Router {
 
   private final AtomicInteger orderSequence = new AtomicInteger();
   private Handler<Throwable> exceptionHandler;
+  private boolean useNormalisedPathByDefault = true;
 
   @Override
   public void accept(HttpServerRequest request) {
@@ -268,13 +269,19 @@ public class RouterImpl implements Router {
     if (mountPoint.contains(":")) {
       throw new IllegalArgumentException("Can't use patterns in subrouter mounts");
     }
-    route(mountPoint + "*").handler(subRouter::handleContext).failureHandler(subRouter::handleFailure);
+    new RouteImpl(this, orderSequence.getAndIncrement(), mountPoint, subRouter);
     return this;
   }
 
   @Override
   public synchronized Router exceptionHandler(Handler<Throwable> exceptionHandler) {
     this.exceptionHandler = exceptionHandler;
+    return this;
+  }
+
+  @Override
+  public Router useNormalisedPathByDefault(boolean useNormalisedPathByDefault) {
+    this.useNormalisedPathByDefault = useNormalisedPathByDefault;
     return this;
   }
 
@@ -296,6 +303,10 @@ public class RouterImpl implements Router {
 
   Handler<Throwable> exceptionHandler() {
     return exceptionHandler;
+  }
+
+  public boolean useNormalisedPathByDefault() {
+    return useNormalisedPathByDefault;
   }
 
   private String getAndCheckRoutePath(RoutingContext ctx) {


### PR DESCRIPTION
This lets users disable normalised paths on a router without applying it to every single route. Fixes #469. Needs tests.
