### PR TITLE
Throw IllegalStateException instead of just warning when setting Route handlers more than once

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -135,7 +135,7 @@ public class RouteImpl implements Route {
   @Override
   public synchronized Route handler(Handler<RoutingContext> contextHandler) {
     if (this.contextHandler != null) {
-      log.warn("Setting handler for a route more than once!");
+      throw new IllegalStateException("Setting handler for a route more than once!");
     }
     this.contextHandler = contextHandler;
     checkAdd();
@@ -155,7 +155,7 @@ public class RouteImpl implements Route {
   @Override
   public synchronized Route failureHandler(Handler<RoutingContext> exceptionHandler) {
     if (this.failureHandler != null) {
-      log.warn("Setting failureHandler for a route more than once!");
+      throw new IllegalStateException("Setting failureHandler for a route more than once!");
     }
     this.failureHandler = exceptionHandler;
     checkAdd();

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2014,4 +2014,24 @@ public class RouterTest extends WebTestBase {
     });
     testRequest(HttpMethod.GET, "/some+path?q1=some+query", 200, "foo");
   }
+
+  @Test
+  public void testMultipleSetHandler() throws Exception {
+    try {
+      router.route().handler(context -> {}).handler(context -> {});
+      fail();
+    } catch (IllegalStateException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void testMultipleSetFailureHandler() throws Exception {
+    try {
+      router.route().failureHandler(context -> {}).failureHandler(context -> {});
+      fail();
+    } catch (IllegalStateException e) {
+      // OK
+    }
+  }
 }


### PR DESCRIPTION
Fixes #434. This will cause already broken applications to break in a more obvious manner, which I think is a good thing.