### PR TITLE
Make SessionStore put, clear, delete take in AsyncResult<Void> instead

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/SessionStore.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/SessionStore.java
@@ -76,24 +76,24 @@ public interface SessionStore {
    * Delete the session with the specified ID
    *
    * @param id  the unique ID of the session
-   * @param resultHandler  will be called with a result true/false, or a failure
+   * @param resultHandler  will be called with a success or a failure
    */
-  void delete(String id, Handler<AsyncResult<Boolean>> resultHandler);
+  void delete(String id, Handler<AsyncResult<Void>> resultHandler);
 
   /**
    * Add a session with the specified ID
    *
    * @param session  the session
-   * @param resultHandler  will be called with a result true/false, or a failure
+   * @param resultHandler  will be called with a success or a failure
    */
-  void put(Session session, Handler<AsyncResult<Boolean>> resultHandler);
+  void put(Session session, Handler<AsyncResult<Void>> resultHandler);
 
   /**
    * Remove all sessions from the store
    *
-   * @param resultHandler  will be called with a result true/false, or a failure
+   * @param resultHandler  will be called with a success or a failure
    */
-  void clear(Handler<AsyncResult<Boolean>> resultHandler);
+  void clear(Handler<AsyncResult<Void>> resultHandler);
 
   /**
    * Get the number of sessions in the store

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/ClusteredSessionStoreImpl.java
@@ -78,12 +78,12 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
   }
 
   @Override
-  public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) {
+  public void delete(String id, Handler<AsyncResult<Void>> resultHandler) {
     getMap(res -> {
       if (res.succeeded()) {
         res.result().remove(id, res2 -> {
           if (res2.succeeded()) {
-            resultHandler.handle(Future.succeededFuture(res2.result() != null));
+            resultHandler.handle(Future.succeededFuture());
           } else {
             resultHandler.handle(Future.failedFuture(res2.cause()));
           }
@@ -95,7 +95,7 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
   }
 
   @Override
-  public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) {
+  public void put(Session session, Handler<AsyncResult<Void>> resultHandler) {
     getMap(res -> {
       if (res.succeeded()) {
         // we need to take care of the transactionality of session data
@@ -123,7 +123,7 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
 
           res.result().put(session.id(), session, session.timeout(), res2 -> {
             if (res2.succeeded()) {
-              resultHandler.handle(Future.succeededFuture(res2.result() != null));
+              resultHandler.handle(Future.succeededFuture());
             } else {
               resultHandler.handle(Future.failedFuture(res2.cause()));
             }
@@ -136,12 +136,12 @@ public class ClusteredSessionStoreImpl implements ClusteredSessionStore {
   }
 
   @Override
-  public void clear(Handler<AsyncResult<Boolean>> resultHandler) {
+  public void clear(Handler<AsyncResult<Void>> resultHandler) {
     getMap(res -> {
       if (res.succeeded()) {
         res.result().clear(res2 -> {
           if (res2.succeeded()) {
-            resultHandler.handle(Future.succeededFuture(res2.result() != null));
+            resultHandler.handle(Future.succeededFuture());
           } else {
             resultHandler.handle(Future.failedFuture(res2.cause()));
           }

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/LocalSessionStoreImpl.java
@@ -72,13 +72,13 @@ public class LocalSessionStoreImpl implements LocalSessionStore, Handler<Long> {
   }
 
   @Override
-  public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) {
+  public void delete(String id, Handler<AsyncResult<Void>> resultHandler) {
     localMap.remove(id);
-    resultHandler.handle(Future.succeededFuture(true));
+    resultHandler.handle(Future.succeededFuture());
   }
 
   @Override
-  public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) {
+  public void put(Session session, Handler<AsyncResult<Void>> resultHandler) {
     final SessionImpl oldSession = (SessionImpl) localMap.get(session.id());
     final SessionImpl newSession = (SessionImpl) session;
 
@@ -92,13 +92,13 @@ public class LocalSessionStoreImpl implements LocalSessionStore, Handler<Long> {
 
     newSession.incrementVersion();
     localMap.put(session.id(), session);
-    resultHandler.handle(Future.succeededFuture(true));
+    resultHandler.handle(Future.succeededFuture());
   }
 
   @Override
-  public void clear(Handler<AsyncResult<Boolean>> resultHandler) {
+  public void clear(Handler<AsyncResult<Void>> resultHandler) {
     localMap.clear();
-    resultHandler.handle(Future.succeededFuture(true));
+    resultHandler.handle(Future.succeededFuture());
   }
 
   @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -240,24 +240,24 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
     }
 
     @Override
-    public void delete(String id, Handler<AsyncResult<Boolean>> resultHandler) {
-      boolean deleted = sessions.remove(id) != null;
-      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture(deleted)));
+    public void delete(String id, Handler<AsyncResult<Void>> resultHandler) {
+      sessions.remove(id);
+      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture()));
     }
 
     @Override
-    public void put(Session session, Handler<AsyncResult<Boolean>> resultHandler) {
+    public void put(Session session, Handler<AsyncResult<Void>> resultHandler) {
       ClusterSerializable cs = (ClusterSerializable)session;
       Buffer buff = Buffer.buffer();
       cs.writeToBuffer(buff);
       sessions.put(session.id(), buff);
-      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture(true)));
+      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture()));
     }
 
     @Override
-    public void clear(Handler<AsyncResult<Boolean>> resultHandler) {
+    public void clear(Handler<AsyncResult<Void>> resultHandler) {
       sessions.clear();
-      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture(true)));
+      vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture()));
     }
 
     @Override


### PR DESCRIPTION
The current AsyncResult<Boolean> is confusing, and the result doesn't provide any information that's not present in succeeded()/failed().

Fixes #388. This may cause an API breakage if applications use result() (which they shouldn't be doing), as mentioned in the linked issue. The cluster implementation result always returns false while the local implementation result always returns true, and developers should be using succeeded()/failed() instead.