### PR TITLE
Fix inheritance for HandlebarsTemplateEngine

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template7.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template7.hbs
@@ -1,0 +1,4 @@
+{{#partial "partialtext"}}
+text from template7
+{{/partial}}
+{{> test-handlebars-template8 }}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template8.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template8.hbs
@@ -1,0 +1,2 @@
+text from template8
+{{#block "partialtext"}}{{/block}}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
@@ -130,6 +130,12 @@ public class HandlebarsTemplateTest extends WebTestBase {
   }
 
   @Test
+  public void testTemplateWithPartial() throws Exception {
+    TemplateEngine engine = HandlebarsTemplateEngine.create();
+    testTemplateHandler(engine, "src/test/filesystemtemplates", "test-handlebars-template7", "\ntext from template8\n\ntext from template7\n\n\n");
+  }
+
+  @Test
   public void testTemplateNoExtension() throws Exception {
     TemplateEngine engine = HandlebarsTemplateEngine.create();
     testTemplateHandler(engine, "somedir", "test-handlebars-template2", "Hello badger and fox");

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -39,7 +39,6 @@ public class TemplateHandlerImpl implements TemplateHandler {
 
   @Override
   public void handle(RoutingContext context) {
-
     String file = templateDirectory + Utils.pathOffset(context.normalisedPath(), context);
     engine.render(context, file, res -> {
       if (res.succeeded()) {


### PR DESCRIPTION
Passes templateDirectory in TemplateHandlerImpl to the Handlebars Loader implementation, allowing for inheritance that matches the official handlebars.java behavior ([which was a bit of a pain to research](https://github.com/jknack/handlebars.java/blob/83e8400da8dfc1820ec1f4523f51505e85abc0c1/handlebars/src/main/java/com/github/jknack/handlebars/io/AbstractTemplateLoader.java#L60)). 

The path prefix is only for the root template directory like the official implementation, NOT the directory for the currently rendered template. Additionally, this supports a specific nested directory edge case (e.g. templates/templates/templates/main.hbs) that will break with the startsWith check proposed earlier. However, this change will break existing templates that specify the whole path (which are very easy to fix) in order to match upstream behavior. Alternatively, we can break the edge case but retain support for existing templates. I think the former is more desirable as this is correcting broken behavior.

Fixes https://github.com/vert-x3/vertx-web/issues/514.