### PR TITLE
Allow PASSWORD flow to be processed too

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -32,6 +32,16 @@ import io.vertx.ext.web.handler.impl.OAuth2AuthHandlerImpl;
 public interface OAuth2AuthHandler extends AuthHandler {
 
   /**
+   * Create a OAuth2 auth handler without host pinning, useful not PASSWORD flows
+   *
+   * @param authProvider  the auth provider to use
+   * @return the auth handler
+   */
+  static OAuth2AuthHandler create(OAuth2Auth authProvider) {
+    return new OAuth2AuthHandlerImpl(authProvider, null);
+  }
+
+  /**
    * Create a OAuth2 auth handler with host pinning
    *
    * @param authProvider  the auth provider to use

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -60,19 +60,20 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
 
     switch (flow) {
       case AUTH_CODE:
+        try {
+          final URL url = new URL(callbackURL);
+          this.host = url.getProtocol() + "://" + url.getHost() + (url.getPort() == -1 ? "" : ":" + url.getPort());
+          this.callbackPath = url.getPath();
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+        break;
       case PASSWORD:
-        // good to go, we can handle these
+        this.host = null;
+        this.callbackPath = null;
         break;
       default:
         throw new IllegalStateException(authProvider.getFlowType() + " is not a valid flow for web applications");
-    }
-
-    try {
-      final URL url = new URL(callbackURL);
-      this.host = url.getProtocol() + "://" + url.getHost() + (url.getPort() == -1 ? "" : ":" + url.getPort());
-      this.callbackPath = url.getPath();
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -208,6 +209,10 @@ public class OAuth2AuthHandlerImpl extends AuthHandlerImpl implements OAuth2Auth
 
   @Override
   public OAuth2AuthHandler setupCallback(Route route) {
+
+    if (host == null && callbackPath == null) {
+      throw new IllegalStateException("Cannot set callback with host pinning.");
+    }
 
     callback = route;
 


### PR DESCRIPTION
Currently the OAuth2 handler only supports AUTH_CODE (note that the Provider does support more modes) This PR will allow AUTH_CODE + PASSWORD flows to be handled too.

Fixes #554 

@msavy could you have a look if this is fine?