### PR TITLE
Support executing blocking handlers on a shared worker pool

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.HttpMethod;
 
 /**
@@ -130,6 +131,19 @@ public interface Route {
    */
   @Fluent
   Route blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered);
+
+  /**
+   * Lilke {@link #blockingHandler(Handler, WorkerExecutor, boolean)} called with ordered = true
+   */
+  @Fluent
+  Route blockingHandler(Handler<RoutingContext> requestHandler, WorkerExecutor workerExecutor);
+
+  /**
+   * Like {@link #blockingHandler(Handler, boolean)}, except it will use a separate worker pool rather than the
+   * default Vert.x one.
+   */
+  @Fluent
+  Route blockingHandler(Handler<RoutingContext> requestHandler, WorkerExecutor workerExecutor, boolean ordered);
 
   /**
    * Specify a failure handler for the route. The router routes failures to failurehandlers depending on whether the various

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/BlockingHandlerDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/BlockingHandlerDecorator.java
@@ -15,7 +15,11 @@
  */
 package io.vertx.ext.web.impl;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
@@ -23,36 +27,54 @@ import java.util.Objects;
 
 /**
  * Wraps a handler that would normally block and turn it into a non-blocking handler.
- * This is done by calling {@link io.vertx.core.Vertx#executeBlocking(Handler, Handler)} 
+ * This is done by calling {@link io.vertx.core.Vertx#executeBlocking(Handler, Handler)}
  * and wrapping the context to overload {@link RoutingContext#next()} so that
  * the next handler is run on the original event loop
- * 
+ *
  * @author <a href="mailto:stephane.bastian.dev@gmail.com>Stéphane Bastian</a>
  *
  */
 public class BlockingHandlerDecorator implements Handler<RoutingContext> {
 
-  private boolean ordered;
   private final Handler<RoutingContext> decoratedHandler;
-  
+  private final WorkerExecutor workerExecutor;
+  private final boolean ordered;
+
   public BlockingHandlerDecorator(Handler<RoutingContext> decoratedHandler, boolean ordered) {
-    Objects.requireNonNull(decoratedHandler);
+    Objects.requireNonNull(decoratedHandler, "decoratedHandler");
     this.decoratedHandler = decoratedHandler;
     this.ordered = ordered;
+    workerExecutor = null;
   }
-  
+
+  public BlockingHandlerDecorator(Handler<RoutingContext> decoratedHandler, WorkerExecutor workerExecutor, boolean ordered) {
+    Objects.requireNonNull(decoratedHandler, "decoratedHandler");
+    Objects.requireNonNull(workerExecutor, "workerExecutor");
+    this.decoratedHandler = decoratedHandler;
+    this.workerExecutor = workerExecutor;
+    this.ordered = ordered;
+  }
+
   @Override
   public void handle(RoutingContext context) {
     Route currentRoute = context.currentRoute();
-    context.vertx().executeBlocking(fut -> {
-      decoratedHandler.handle(new RoutingContextDecorator(currentRoute, context));
-      fut.complete();
-    }, ordered, res -> {
-      if (res.failed()) {
-        // This means an exception was thrown from the blocking handler
-        context.fail(res.cause());
-      }
-    });
+    if (workerExecutor == null) {
+      Vertx vertx = context.vertx();
+      vertx.<Void>executeBlocking(fut -> invokeBlockingHandler(fut, context, currentRoute), ordered, res -> handleResult(context, res));
+    } else {
+      workerExecutor.<Void>executeBlocking(fut -> invokeBlockingHandler(fut, context, currentRoute), ordered, res -> handleResult(context, res));
+    }
   }
 
+  private void invokeBlockingHandler(Future<Void> fut, RoutingContext context, Route currentRoute) {
+    decoratedHandler.handle(new RoutingContextDecorator(currentRoute, context));
+    fut.complete();
+  }
+
+  private void handleResult(RoutingContext context, AsyncResult<Void> res) {
+    if (res.failed()) {
+      // This means an exception was thrown from the blocking handler
+      context.fail(res.cause());
+    }
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.impl;
 
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.logging.Logger;
@@ -25,7 +26,13 @@ import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -150,6 +157,16 @@ public class RouteImpl implements Route {
   @Override
   public synchronized Route blockingHandler(Handler<RoutingContext> contextHandler, boolean ordered) {
     return handler(new BlockingHandlerDecorator(contextHandler, ordered));
+  }
+
+  @Override
+  public Route blockingHandler(Handler<RoutingContext> requestHandler, WorkerExecutor workerExecutor) {
+    return blockingHandler(requestHandler, workerExecutor, true);
+  }
+
+  @Override
+  public Route blockingHandler(Handler<RoutingContext> requestHandler, WorkerExecutor workerExecutor, boolean ordered) {
+    return handler(new BlockingHandlerDecorator(requestHandler, workerExecutor, ordered));
   }
 
   @Override


### PR DESCRIPTION
Added methods in Route to define a blocking handler providing a WorkerExecutor.

Depends on eclipse/vert.x#1887