### PR TITLE
Normalize new lines for MVEL templates

### DIFF
--- a/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/impl/MVELTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/impl/MVELTemplateEngineImpl.java
@@ -65,7 +65,10 @@ public class MVELTemplateEngineImpl extends CachingTemplateEngine<CompiledTempla
         if (templateText == null) {
           throw new IllegalArgumentException("Cannot find template " + loc);
         }
-        template = TemplateCompiler.compileTemplate(templateText);
+        template = TemplateCompiler.compileTemplate(
+          // If replacing the read string is a performance issue, it might be possible to do it when reading the buffer
+          Utils.normalizeNewlines(templateText)
+        );
         cache.put(templateFileName, template);
       }
       Map<String, RoutingContext> variables = new HashMap<>(1);

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -343,6 +343,12 @@ public class Utils extends io.vertx.core.impl.Utils {
     }
   }
 
+  private static Pattern normalizeNewlineRegex = Pattern.compile("\\r\\n?");
+
+  public static String normalizeNewlines(String toNormalize) {
+    return normalizeNewlineRegex.matcher(toNormalize).replaceAll("\n");
+  }
+
   public static DateFormat createRFC1123DateTimeFormatter() {
     DateFormat dtf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
     dtf.setTimeZone(TimeZone.getTimeZone("GMT"));


### PR DESCRIPTION
Git clients on Windows will check out with CRLF endings by default. Additionally, the MVEL template engine will treat line endings as-is, which causes the MVEL tests to fail in Windows (and MVEL deployed application to probably not return consistent line endings on Windows, servers but who uses those anyways):

![](https://i.imgur.com/6YpnfP2.png)

I only noticed the MVEL tests failing on my machine, if more engines are affected, we should optimize this.