### PR TITLE
Fix newline behavior for template rendering on Windows, including tests

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateLoader.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateLoader.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.templ.impl;
 import freemarker.cache.TemplateLoader;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.impl.Utils;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -39,8 +40,7 @@ class FreeMarkerTemplateLoader implements TemplateLoader {
     try {
       // check if exists on file system
       if (vertx.fileSystem().existsBlocking(name)) {
-        Buffer buff = vertx.fileSystem().readFileBlocking(name);
-        return new StringTemplateSource(name, buff.toString(), System.currentTimeMillis());
+        return new StringTemplateSource(name, Utils.readFileToString(vertx, name), System.currentTimeMillis());
       } else {
         return null;
       }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.templ.impl;
 import com.mitchellbosecke.pebble.error.LoaderException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.impl.Utils;
 
 import java.io.File;
 import java.io.Reader;
@@ -33,7 +34,7 @@ public class PebbleVertxLoader implements Loader<String> {
 
   private final Vertx vertx;
 
-  private String charset = Charset.defaultCharset().toString();
+  private Charset charset = Charset.defaultCharset();
 
   public PebbleVertxLoader(Vertx vertx) {
     this.vertx = vertx;
@@ -42,7 +43,7 @@ public class PebbleVertxLoader implements Loader<String> {
   @Override
   public Reader getReader(String s) throws LoaderException {
     try {
-      final String buffer = vertx.fileSystem().readFileBlocking(s).toString(charset);
+      final String buffer = Utils.readFileToString(vertx, s, charset);
       return new StringReader(buffer);
     } catch (RuntimeException e) {
       throw new LoaderException(e, e.getMessage());
@@ -51,7 +52,7 @@ public class PebbleVertxLoader implements Loader<String> {
 
   @Override
   public void setCharset(String s) {
-    this.charset = s;
+    this.charset = Charset.forName(s);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -344,12 +344,17 @@ public class Utils extends io.vertx.core.impl.Utils {
     return readFileToString(vertx, resource, DEFAULT_CHARSET);
   }
 
+  private static final boolean convertLineEndings = System.lineSeparator().equals("\r\n");
+
   /*
   Reads from file or classpath using the given charset, replacing CRLF line endings with LF ones
    */
   public static String readFileToString(Vertx vertx, String resource, Charset charset) {
     try {
       Buffer buff = vertx.fileSystem().readFileBlocking(resource);
+      if (!convertLineEndings) {
+        return buff.toString(charset);
+      }
       int buffLen = buff.length();
       ByteBuf byteBuf = buff.getByteBuf();
       ByteBuf convertedBuf = Unpooled.buffer(buffLen, buffLen);


### PR DESCRIPTION
Several users in the IRC (@ivanovdns, @alexlehm) reported that all vertx-template-engines tests with newlines were failing on Windows. 

![](https://i.imgur.com/6YpnfP2.png)

This is because Git on Windows checks out as CRLF by default, and the template engines in question just use the provided line endings. The fact that Windows line endings are ever returned is an issue in the implementation, as usage of '\n' is extremely prevalent throughout the Vert.x codebase, including the tests. We can't just use System.getProperty("line.separator") in the tests, as the behavior isn't reliable and some developers may disabled autocrlf. 

These commits fix this behavior by introducing a performant CRLF-to-LF converter adapted from Netty's ByteBufInputStream in Utils#readFileToString, and has the side effect of fixing all the template tests on Windows. For the latter reason, no additional tests should be needed.

If the behavior shouldn't be changed, a form of line ending detection should be done in the tests.