### PR TITLE
Make FreeMarker and Pebble template loaders use Utils#readFileToString

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateLoader.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/impl/FreeMarkerTemplateLoader.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.templ.impl;
 import freemarker.cache.TemplateLoader;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.impl.Utils;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -39,8 +40,8 @@ class FreeMarkerTemplateLoader implements TemplateLoader {
     try {
       // check if exists on file system
       if (vertx.fileSystem().existsBlocking(name)) {
-        Buffer buff = vertx.fileSystem().readFileBlocking(name);
-        return new StringTemplateSource(name, buff.toString(), System.currentTimeMillis());
+        String templ = Utils.readFileToString(vertx, name);
+        return new StringTemplateSource(name, templ, System.currentTimeMillis());
       } else {
         return null;
       }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleVertxLoader.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.templ.impl;
 import com.mitchellbosecke.pebble.error.LoaderException;
 import com.mitchellbosecke.pebble.loader.Loader;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.impl.Utils;
 
 import java.io.File;
 import java.io.Reader;
@@ -33,7 +34,7 @@ public class PebbleVertxLoader implements Loader<String> {
 
   private final Vertx vertx;
 
-  private String charset = Charset.defaultCharset().toString();
+  private Charset charset = Charset.defaultCharset();
 
   public PebbleVertxLoader(Vertx vertx) {
     this.vertx = vertx;
@@ -42,7 +43,7 @@ public class PebbleVertxLoader implements Loader<String> {
   @Override
   public Reader getReader(String s) throws LoaderException {
     try {
-      final String buffer = vertx.fileSystem().readFileBlocking(s).toString(charset);
+      final String buffer = Utils.readFileToString(vertx, s, charset);
       return new StringReader(buffer);
     } catch (RuntimeException e) {
       throw new LoaderException(e, e.getMessage());
@@ -51,7 +52,7 @@ public class PebbleVertxLoader implements Loader<String> {
 
   @Override
   public void setCharset(String s) {
-    this.charset = s;
+    this.charset = Charset.forName(s);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -24,6 +24,8 @@ import io.vertx.ext.web.RoutingContext;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
@@ -332,12 +334,19 @@ public class Utils extends io.vertx.core.impl.Utils {
   }
 
   /*
-  Reads from file or classpath
+  Reads from file or classpath using UTF-8
    */
   public static String readFileToString(Vertx vertx, String resource) {
+    return readFileToString(vertx, resource, StandardCharsets.UTF_8);
+  }
+
+  /*
+  Reads from file or classpath using the provided charset
+   */
+  public static String readFileToString(Vertx vertx, String resource, Charset charset) {
     try {
       Buffer buff = vertx.fileSystem().readFileBlocking(resource);
-      return buff.toString();
+      return buff.toString(charset);
     } catch (Exception e) {
       throw new VertxException(e);
     }


### PR DESCRIPTION
Also add an optional charset argument to Utils#readFileToString, defaulting to the original UTF-8.

All of the other template engine loaders (Handlebars, Jade, MVEL, Thymeleaf) use this method, so it makes sense to convert the remaining 2 for consistency reasons.