### PR TITLE
check for python 2.x in SockJSProtocolTest as the sockjs script does …

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SockJSProtocolTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SockJSProtocolTest.java
@@ -46,8 +46,8 @@ public class SockJSProtocolTest extends WebTestBase {
    */
   @Test
   public void testProtocol() throws Exception {
-    // does this system have python?
-    Process p = Runtime.getRuntime().exec("python --version");
+    // does this system have python 2.x?
+    Process p = Runtime.getRuntime().exec("python pythonversion.py", null, new File("src/test"));
     int res = p.waitFor();
 
     if (res == 0) {

--- a/vertx-web/src/test/pythonversion.py
+++ b/vertx-web/src/test/pythonversion.py
@@ -1,0 +1,5 @@
+# fail for python 3 since sockjs requires python 2.7
+import sys
+
+if (sys.version_info > (3, 0)):
+  raise RuntimeError('you are running python 3.x')


### PR DESCRIPTION
…not support python 3

Signed-off-by: alexlehm <alexlehm@gmail.com>