### PR TITLE
Improve caching strategy for Jade template engine

### DIFF
--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/JadeTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/JadeTemplateEngine.java
@@ -65,6 +65,14 @@ public interface JadeTemplateEngine extends TemplateEngine {
   JadeTemplateEngine setMaxCacheSize(int maxCacheSize);
 
   /**
+   * Set caching option for templates
+   *
+   * @param flag
+   * @return
+   */
+  JadeTemplateEngine setCaching(boolean flag);
+
+  /**
    * Get a reference to the internal JadeConfiguration object so it
    * can be configured.
    *

--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/impl/JadeTemplateEngineImpl.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
+ * @author <a href="https://github.com/mystdeim">Roman Novikov</a>
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -57,7 +58,15 @@ public class JadeTemplateEngineImpl extends CachingTemplateEngine<JadeTemplate> 
   @Override
   public JadeTemplateEngine setMaxCacheSize(int maxCacheSize) {
     this.cache.setMaxSize(maxCacheSize);
+    this.config.setCaching(maxCacheSize <= 0);
     return this;
+  }
+
+  @Override
+  public JadeTemplateEngine setCaching(boolean flag) {
+      this.config.setCaching(flag);
+      this.cache.setMaxSize(flag ? DEFAULT_MAX_CACHE_SIZE : 0);
+      return this;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-jade/src/test/java/io/vertx/ext/web/templ/JadeTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/test/java/io/vertx/ext/web/templ/JadeTemplateTest.java
@@ -73,4 +73,11 @@ public class JadeTemplateTest extends WebTestBase {
     assertNotNull(engine.getJadeConfiguration());
   }
 
+  @Test
+  public void testSetCachingDefault() throws Exception {
+    JadeTemplateEngine engine = JadeTemplateEngine.create();
+    engine.setCaching(false);
+    assertFalse(engine.getJadeConfiguration().isCaching());
+  }
+
 }


### PR DESCRIPTION
Look at example:
```java
JadeTemplateEngine engine = JadeTemplateEngine.create();
engine.setMaxCacheSize(0);
```
It isn't work for Jade, because jade engine has his own cache. So I added extra method and some logic for turn on/off caching.

To turn off cache, you can simply do:
```java
JadeTemplateEngine engine = JadeTemplateEngine.create();
engine.setCaching(false);  
```
Also setMaxCacheSize(0) works right.

P.S. I can help to add this comment to official documentation.