### PR TITLE
Fix inheritance for HandlebarsTemplateEngine

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/impl/HandlebarsTemplateEngineImpl.java
@@ -70,8 +70,13 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
       Template template = cache.get(templateFileName);
       if (template == null) {
         synchronized (this) {
+          // Prepare templateDirectory for partials every request, in case of multiple associated directories
+          loader.setPrefix(templateFileName.substring(0,
+            // preserve '/' as Utils#normalizePath guarantees a leading slash
+            templateFileName.length() - Utils.pathOffset(context.normalisedPath(), context).length() + 1
+          ));
           loader.setVertx(context.vertx());
-          template = handlebars.compile(templateFileName);
+          template = handlebars.compile(templateFileName.substring(loader.getPrefix().length()));
           cache.put(templateFileName, template);
         }
       }
@@ -99,8 +104,8 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
   }
 
   private class Loader implements TemplateLoader {
-
     private Vertx vertx;
+    private String templateDirectory;
 
     void setVertx(Vertx vertx) {
       this.vertx = vertx;
@@ -108,8 +113,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
     @Override
     public TemplateSource sourceAt(String location) throws IOException {
-
-      String loc = adjustLocation(location);
+      String loc = resolve(location);
       String templ = Utils.readFileToString(vertx, loc);
 
       if (templ == null) {
@@ -139,12 +143,12 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
     @Override
     public String resolve(String location) {
-      return location;
+      return templateDirectory + adjustLocation(location);
     }
 
     @Override
     public String getPrefix() {
-      return null;
+      return templateDirectory;
     }
 
     @Override
@@ -154,7 +158,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
     @Override
     public void setPrefix(String prefix) {
-      // does nothing since TemplateLoader handles the prefix
+      templateDirectory = prefix;
     }
 
     @Override
@@ -162,6 +166,4 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
       extension = suffix;
     }
   }
-
-
 }

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template7.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template7.hbs
@@ -1,0 +1,4 @@
+{{#partial "partialtext"}}
+text from template7
+{{/partial}}
+{{> test-handlebars-template8 }}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template8.hbs
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/filesystemtemplates/test-handlebars-template8.hbs
@@ -1,0 +1,2 @@
+text from template8
+{{#block "partialtext"}}{{/block}}

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
@@ -130,6 +130,12 @@ public class HandlebarsTemplateTest extends WebTestBase {
   }
 
   @Test
+  public void testTemplateWithPartial() throws Exception {
+    TemplateEngine engine = HandlebarsTemplateEngine.create();
+    testTemplateHandler(engine, "src/test/filesystemtemplates", "test-handlebars-template7", "\ntext from template8\n\ntext from template7\n\n\n");
+  }
+
+  @Test
   public void testTemplateNoExtension() throws Exception {
     TemplateEngine engine = HandlebarsTemplateEngine.create();
     testTemplateHandler(engine, "somedir", "test-handlebars-template2", "Hello badger and fox");

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -39,7 +39,6 @@ public class TemplateHandlerImpl implements TemplateHandler {
 
   @Override
   public void handle(RoutingContext context) {
-
     String file = templateDirectory + Utils.pathOffset(context.normalisedPath(), context);
     engine.render(context, file, res -> {
       if (res.succeeded()) {


### PR DESCRIPTION
Passes templateDirectory in TemplateHandlerImpl to the Handlebars Loader implementation, allowing for inheritance that matches the official handlebars.java behavior ([which was a bit of a pain to research](https://github.com/jknack/handlebars.java/blob/83e8400da8dfc1820ec1f4523f51505e85abc0c1/handlebars/src/main/java/com/github/jknack/handlebars/io/AbstractTemplateLoader.java#L60)). 

The path prefix is only for the root template directory like the official implementation, NOT the directory for the currently rendered template. Additionally, this supports a specific nested directory edge case (e.g. templates/templates/templates/main.hbs) that will break with the startsWith check proposed earlier. However, this change will break existing templates that specify the whole path (which are very easy to fix) in order to match upstream behavior. Alternatively, we can break the edge case but retain support for existing templates. I think the former is more desirable as this is correcting broken behavior.

Fixes https://github.com/vert-x3/vertx-web/issues/514.

Continuation of #544, as I accidentally deleted the branch during a rebase.