### PR TITLE
Added query parameters getter inside RoutingContext

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -31,6 +31,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -474,15 +475,15 @@ public interface RoutingContext {
   /**
    * Returns a map of all query parameters inside the <a href="https://en.wikipedia.org/wiki/Query_string">query string</a>
    *
-   * @return the map of query parameters
+   * @return the map of query parameters (if a query parameter value is an array, it will be provided as comma separated string, so if you need to extract array from query use {@link #queryParam(String)} queryParam)
    */
-  Map<String, List<String>> queryParams();
+  Map<String, String> queryParams();
 
   /**
    * Gets the value of a single query parameter
    *
    * @param query The name of query parameter
-   * @return The value of query parameter
+   * @return The list of all elements inside query parameter
    */
   @Nullable
   List<String> queryParam(String query);

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -22,6 +22,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -475,9 +476,9 @@ public interface RoutingContext {
   /**
    * Returns a map of all query parameters inside the <a href="https://en.wikipedia.org/wiki/Query_string">query string</a>
    *
-   * @return the map of query parameters (if a query parameter value is an array, it will be provided as comma separated string, so if you need to extract array from query use {@link #queryParam(String)} queryParam)
+   * @return the multimap of query parameters
    */
-  Map<String, String> queryParams();
+  MultiMap queryParams();
 
   /**
    * Gets the value of a single query parameter

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -470,4 +470,20 @@ public interface RoutingContext {
    */
   @Nullable
   String pathParam(String name);
+
+  /**
+   * Returns a map of all query parameters inside the <a href="https://en.wikipedia.org/wiki/Query_string">query string</a>
+   *
+   * @return the map of query parameters
+   */
+  Map<String, List<String>> queryParams();
+
+  /**
+   * Gets the value of a single query parameter
+   *
+   * @param query The name of query parameter
+   * @return The value of query parameter
+   */
+  @Nullable
+  List<String> queryParam(String query);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -285,9 +285,11 @@ public class RouteImpl implements Route {
         return false;
       }
     }
-    // Decode query parameters and put insie context.pathParams
+    // Decode query parameters and put inside context.pathParams
     Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
-    ((RoutingContextImpl)context).setQueryParams(decodedParams);
+
+    for (Map.Entry<String, List<String>> entry : decodedParams.entrySet())
+      context.queryParams().add(entry.getKey(), entry.getValue());
 
     if (!consumes.isEmpty()) {
       // Can this route consume the specified content type

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -286,7 +286,8 @@ public class RouteImpl implements Route {
       }
     }
     // Decode query parameters and put insie context.pathParams
-    context.queryParams().putAll(new QueryStringDecoder(request.uri()).parameters());
+    Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
+    ((RoutingContextImpl)context).setQueryParams(decodedParams);
 
     if (!consumes.isEmpty()) {
       // Can this route consume the specified content type

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -24,6 +24,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
+import io.netty.handler.codec.http.QueryStringDecoder;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -284,6 +285,9 @@ public class RouteImpl implements Route {
         return false;
       }
     }
+    // Decode query parameters and put insie context.pathParams
+    context.queryParams().putAll(new QueryStringDecoder(request.uri()).parameters());
+
     if (!consumes.isEmpty()) {
       // Can this route consume the specified content type
       MIMEHeader contentType = context.parsedHeaders().contentType();

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -285,11 +285,15 @@ public class RouteImpl implements Route {
         return false;
       }
     }
-    // Decode query parameters and put inside context.pathParams
-    Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
 
-    for (Map.Entry<String, List<String>> entry : decodedParams.entrySet())
-      context.queryParams().add(entry.getKey(), entry.getValue());
+    // Check if query params are already parsed
+    if (context.queryParams().size() == 0) {
+      // Decode query parameters and put inside context.queryParams
+      Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
+
+      for (Map.Entry<String, List<String>> entry : decodedParams.entrySet())
+        context.queryParams().add(entry.getKey(), entry.getValue());
+    }
 
     if (!consumes.isEmpty()) {
       // Can this route consume the specified content type

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 /**
  * Decorate a {@link RoutingContext} and simply delegate all method calls to the decorated handler
- * 
+ *
  * @author <a href="mailto:stephane.bastian.dev@gmail.com>Stéphane Bastian</a>
  *
  */
@@ -27,7 +27,7 @@ public class RoutingContextDecorator implements RoutingContext {
 
   private final Route currentRoute;
   private final RoutingContext decoratedContext;
-  
+
   public RoutingContextDecorator(Route currentRoute, RoutingContext decoratedContext) {
     Objects.requireNonNull(currentRoute);
     Objects.requireNonNull(decoratedContext);
@@ -202,7 +202,7 @@ public class RoutingContextDecorator implements RoutingContext {
   public ParsedHeaderValues parsedHeaders() {
     return decoratedContext.parsedHeaders();
   }
-  
+
   @Override
   public void setAcceptableContentType(String contentType) {
     decoratedContext.setAcceptableContentType(contentType);
@@ -226,6 +226,16 @@ public class RoutingContextDecorator implements RoutingContext {
   @Override
   public @Nullable String pathParam(String name) {
     return decoratedContext.pathParam(name);
+  }
+
+  @Override
+  public Map<String, String> queryParams() {
+    return decoratedContext.queryParams();
+  }
+
+  @Override
+  public @Nullable List<String> queryParam(String query) {
+    return decoratedContext.queryParam(query);
   }
 
   @Override
@@ -257,5 +267,5 @@ public class RoutingContextDecorator implements RoutingContext {
   public Vertx vertx() {
     return decoratedContext.vertx();
   }
-  
+
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -2,6 +2,7 @@ package io.vertx.ext.web.impl;
 
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -229,7 +230,7 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
-  public Map<String, String> queryParams() {
+  public MultiMap queryParams() {
     return decoratedContext.queryParams();
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -376,12 +376,6 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     return getQueryParams().getAll(query);
   }
 
-  protected void setQueryParams(Map<String, List<String>> q) {
-    queryParams = MultiMap.caseInsensitiveMultiMap();
-    for (Map.Entry<String, List<String>> entry : q.entrySet())
-      queryParams.add(entry.getKey(), entry.getValue());
-  }
-
   private MultiMap getQueryParams() {
     if (queryParams == null) {
       queryParams = MultiMap.caseInsensitiveMultiMap();

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -41,7 +41,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private final RouterImpl router;
   private Map<String, Object> data;
   private Map<String, String> pathParams;
-  private Map<String, List<String>> queryParams;
+  private Map<String, String> queryParams;
+  private Map<String, List<String>> queryParamsParsed;
   private AtomicInteger handlerSeq = new AtomicInteger();
   private Map<Integer, Handler<Void>> headersEndHandlers;
   private Map<Integer, Handler<Void>> bodyEndHandlers;
@@ -365,32 +366,36 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     return getPathParams().get(name);
   }
 
-  /**
-   * Returns a map of all query parameters inside the <a href="https://en.wikipedia.org/wiki/Query_string">query string</a>
-   *
-   * @return the map of query parameters
-   */
   @Override
-  public Map<String, List<String>> queryParams() {
+  public Map<String, String> queryParams() {
     return getQueryParams();
   }
 
-  /**
-   * Gets the value of a single query parameter
-   *
-   * @param query The name of query parameter
-   * @return The value of query parameter
-   */
   @Override
   public @Nullable List<String> queryParam(String query) {
-    return getQueryParams().get(query);
+    return getQueryParamsParsed().get(query);
   }
 
-  private Map<String, List<String>> getQueryParams() {
+  protected void setQueryParams(Map<String, List<String>> q) {
+    queryParamsParsed = new HashMap<>();
+    queryParamsParsed.putAll(q);
+    queryParams = new HashMap<>();
+    for (Map.Entry<String, List<String>> e : q.entrySet())
+      queryParams.put(e.getKey(), String.join(",", e.getValue()));
+  }
+
+  private Map<String, String> getQueryParams() {
     if (queryParams == null) {
       queryParams = new HashMap<>();
     }
     return queryParams;
+  }
+
+  private Map<String, List<String>> getQueryParamsParsed() {
+    if (queryParamsParsed == null) {
+      queryParamsParsed = new HashMap<>();
+    }
+    return queryParamsParsed;
   }
 
   private Map<String, String> getPathParams() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.impl;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -41,8 +42,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private final RouterImpl router;
   private Map<String, Object> data;
   private Map<String, String> pathParams;
-  private Map<String, String> queryParams;
-  private Map<String, List<String>> queryParamsParsed;
+  private MultiMap queryParams;
   private AtomicInteger handlerSeq = new AtomicInteger();
   private Map<Integer, Handler<Void>> headersEndHandlers;
   private Map<Integer, Handler<Void>> bodyEndHandlers;
@@ -367,35 +367,26 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   }
 
   @Override
-  public Map<String, String> queryParams() {
+  public MultiMap queryParams() {
     return getQueryParams();
   }
 
   @Override
   public @Nullable List<String> queryParam(String query) {
-    return getQueryParamsParsed().get(query);
+    return getQueryParams().getAll(query);
   }
 
   protected void setQueryParams(Map<String, List<String>> q) {
-    queryParamsParsed = new HashMap<>();
-    queryParamsParsed.putAll(q);
-    queryParams = new HashMap<>();
-    for (Map.Entry<String, List<String>> e : q.entrySet())
-      queryParams.put(e.getKey(), String.join(",", e.getValue()));
+    queryParams = MultiMap.caseInsensitiveMultiMap();
+    for (Map.Entry<String, List<String>> entry : q.entrySet())
+      queryParams.add(entry.getKey(), entry.getValue());
   }
 
-  private Map<String, String> getQueryParams() {
+  private MultiMap getQueryParams() {
     if (queryParams == null) {
-      queryParams = new HashMap<>();
+      queryParams = MultiMap.caseInsensitiveMultiMap();
     }
     return queryParams;
-  }
-
-  private Map<String, List<String>> getQueryParamsParsed() {
-    if (queryParamsParsed == null) {
-      queryParamsParsed = new HashMap<>();
-    }
-    return queryParamsParsed;
   }
 
   private Map<String, String> getPathParams() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -41,6 +41,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private final RouterImpl router;
   private Map<String, Object> data;
   private Map<String, String> pathParams;
+  private Map<String, List<String>> queryParams;
   private AtomicInteger handlerSeq = new AtomicInteger();
   private Map<Integer, Handler<Void>> headersEndHandlers;
   private Map<Integer, Handler<Void>> bodyEndHandlers;
@@ -362,6 +363,34 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   @Override
   public @Nullable String pathParam(String name) {
     return getPathParams().get(name);
+  }
+
+  /**
+   * Returns a map of all query parameters inside the <a href="https://en.wikipedia.org/wiki/Query_string">query string</a>
+   *
+   * @return the map of query parameters
+   */
+  @Override
+  public Map<String, List<String>> queryParams() {
+    return getQueryParams();
+  }
+
+  /**
+   * Gets the value of a single query parameter
+   *
+   * @param query The name of query parameter
+   * @return The value of query parameter
+   */
+  @Override
+  public @Nullable List<String> queryParam(String query) {
+    return getQueryParams().get(query);
+  }
+
+  private Map<String, List<String>> getQueryParams() {
+    if (queryParams == null) {
+      queryParams = new HashMap<>();
+    }
+    return queryParams;
   }
 
   private Map<String, String> getPathParams() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -272,4 +272,14 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
     return inner.pathParam(name);
   }
 
+  @Override
+  public Map<String, List<String>> queryParams() {
+    return inner.queryParams();
+  }
+
+  @Override
+  public @Nullable List<String> queryParam(String query) {
+    return inner.queryParam(query);
+  }
+
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -273,7 +273,7 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public Map<String, List<String>> queryParams() {
+  public Map<String, String> queryParams() {
     return inner.queryParams();
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.impl;
 
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -273,9 +274,7 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public Map<String, String> queryParams() {
-    return inner.queryParams();
-  }
+  public MultiMap queryParams() { return inner.queryParams(); }
 
   @Override
   public @Nullable List<String> queryParam(String query) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -810,6 +810,32 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testCorrectQueryParamatersEncapsulation() throws Exception {
+    final String pathParameterName = "pathParameter";
+    final String pathParamValue = "awesomePath";
+    final String qName = "q";
+    final String qValue1 = "a";
+    final String qValue2 = "b";
+    final String sName = "s";
+    final String sValue = "sample_value";
+    final String sep = ",";
+    router.route("/blah/:" + pathParameterName + "/test").handler(rc -> {
+      Map<String, List<String>> params = rc.queryParams();
+      StringBuilder stringBuilder = new StringBuilder();
+      for (List<String> values : params.values())
+        for (String q : values)
+          stringBuilder.append(q + ",");
+        stringBuilder.deleteCharAt(stringBuilder.length() - 1); // Remove last comma
+        stringBuilder.append("/");
+      stringBuilder.deleteCharAt(stringBuilder.length() - 1); // Remove last slash
+      rc.response().setStatusMessage(stringBuilder.toString()).end();
+    });
+    testRequest(HttpMethod.GET,
+      "/blah/" + pathParamValue + "/test?" + qName + "=" + qValue1 + "," + qValue2 + "&" + sName + "=" + sValue, 200,
+      qValue1 + "," + qValue2 + "/" + sValue);
+  }
+
+  @Test
   public void testPathParamsWithReroute() throws Exception {
     String paramName = "param";
     String firstParamValue = "fpv";

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -820,15 +820,10 @@ public class RouterTest extends WebTestBase {
     final String sValue = "sample_value";
     final String sep = ",";
     router.route("/blah/:" + pathParameterName + "/test").handler(rc -> {
-      Map<String, List<String>> params = rc.queryParams();
-      StringBuilder stringBuilder = new StringBuilder();
-      for (List<String> values : params.values())
-        for (String q : values)
-          stringBuilder.append(q + ",");
-        stringBuilder.deleteCharAt(stringBuilder.length() - 1); // Remove last comma
-        stringBuilder.append("/");
-      stringBuilder.deleteCharAt(stringBuilder.length() - 1); // Remove last slash
-      rc.response().setStatusMessage(stringBuilder.toString()).end();
+      Map<String, String> params = rc.queryParams();
+      assertEquals(params.get("q"), String.join(",", rc.queryParam("q")));
+      String statusMessage = String.join("/", params.values());
+      rc.response().setStatusMessage(statusMessage).end();
     });
     testRequest(HttpMethod.GET,
       "/blah/" + pathParamValue + "/test?" + qName + "=" + qValue1 + "," + qValue2 + "&" + sName + "=" + sValue, 200,

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -21,9 +21,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -820,9 +818,9 @@ public class RouterTest extends WebTestBase {
     final String sValue = "sample_value";
     final String sep = ",";
     router.route("/blah/:" + pathParameterName + "/test").handler(rc -> {
-      Map<String, String> params = rc.queryParams();
-      assertEquals(params.get("q"), String.join(",", rc.queryParam("q")));
-      String statusMessage = String.join("/", params.values());
+      MultiMap params = rc.queryParams();
+      String qExpected = String.join(",", params.getAll("q"));
+      String statusMessage = String.join("/", qExpected, params.get("s"));
       rc.response().setStatusMessage(statusMessage).end();
     });
     testRequest(HttpMethod.GET,


### PR DESCRIPTION
To allow users to avoid conflicts between path parameters and query parameters, I created a query parameters getter.
Unfortunately i can't return from `queryParams()` a `Map<String, List<String>>` because of this: https://github.com/vert-x3/vertx-codegen/blob/master/src/main/java/io/vertx/codegen/ClassModel.java#L424
So:
* `queryParams()`returns a `Map<String, String>.` If one query parameter is an array It will return as a comma separated list
* `queryParam(name)` returns a `List<String>`, containing the query parameter value/values

I also wrote a small unit test to test this getter