### PR TITLE
Fix NPE when no bearer token exists for jwt

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -98,13 +98,8 @@ public class JWTAuthHandlerImpl extends AuthHandlerImpl implements JWTAuthHandle
 
       if (authorization != null) {
         String[] parts = authorization.split(" ");
-        if (parts.length == 2) {
-          final String scheme = parts[0],
-              credentials = parts[1];
-
-          if (BEARER.matcher(scheme).matches()) {
-            token = credentials;
-          }
+        if ((parts.length == 2) && BEARER.matcher(parts[0]).matches()) {
+          token = parts[1];
         } else {
           log.warn("Format is Authorization: Bearer [token]");
           context.fail(401);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
@@ -19,7 +19,6 @@ package io.vertx.ext.web.handler;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTOptions;
 import io.vertx.ext.web.RoutingContext;
@@ -86,6 +85,10 @@ public class JWTAuthHandlerTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/protected/somepage", req -> {
       req.putHeader("Authorization", "Bearer x" + token);
+    }, 401, "Unauthorized", null);
+
+    testRequest(HttpMethod.GET, "/protected/somepage", req -> {
+      req.putHeader("Authorization", "Basic " + token);
     }, 401, "Unauthorized", null);
 
   }


### PR DESCRIPTION
When no bearer token if found but an authorization header is given, the current JWTAuthHandler passes a null to JWTAuth which gives a NPE.

See test for reproduction scenario.