### PR TITLE
Fix issue #593: Allow custom CSRF 403 response body

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
@@ -23,6 +23,8 @@ public interface CSRFHandler extends Handler<RoutingContext> {
 
   String DEFAULT_HEADER_NAME = "X-XSRF-TOKEN";
 
+  String DEFAULT_RESPONSE_BODY = null;
+
   /**
    * Instantiate a new CSRFHandlerImpl with a secret
    * <p>
@@ -64,6 +66,15 @@ public interface CSRFHandler extends Handler<RoutingContext> {
    */
   @Fluent
   CSRFHandler setNagHttps(boolean nag);
+
+  /**
+   * Set the body returned by the handler when the XSRF token is missing or invalid.
+   *
+   * @param responseBody the body of the response. If null, no response body will be returned.
+   * @return fluent
+   */
+  @Fluent
+  CSRFHandler setResponseBody(String responseBody);
 
 
   /**

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CSRFHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CSRFHandlerTest.java
@@ -172,4 +172,18 @@ public class CSRFHandlerTest extends WebTestBase {
       req.write(buffer);
     }, null, 200, "OK", null);
   }
+
+  @Test
+  public void testPostWithCustomResponseBody() throws Exception {
+    final String expectedResponseBody = "Expected response body";
+
+    router.route().handler(CookieHandler.create());
+    router.route().handler(CSRFHandler.create("Abracadabra").setTimeout(1).setResponseBody(expectedResponseBody));
+    router.route().handler(rc -> rc.response().end());
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME,
+        "4CYp9vQsr2VSQEsi/oVsMu35Ho9TlR0EovcYovlbiBw=.1437037602082.41jwU0FPl/n7ZNZAZEA07GyIUnpKSTKQ8Eju7Nicb34=");
+    }, null, 403, "Forbidden", expectedResponseBody);
+  }
 }


### PR DESCRIPTION
I ended up doing both suggestions. Let me know what you think.

Also, I'm by no means a vert.x expert, so I'd like your confirmation that what the new `forbidden` method does is correct.