### PR TITLE
Add shortcut for rendering directly to context in TemplateEngine

### DIFF
--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/impl/ThymeleafTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/impl/ThymeleafTemplateEngineImpl.java
@@ -47,7 +47,7 @@ import static io.vertx.ext.web.templ.impl.CachingTemplateEngine.DISABLE_TEMPL_CA
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="http://matty.io">Matty Southall</a>
  */
-public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
+public class ThymeleafTemplateEngineImpl extends AbstractTemplateEngine implements ThymeleafTemplateEngine {
 
   // should not be static, so at at creation time the value is evaluated
   private final boolean enableCache = !Boolean.getBoolean(DISABLE_TEMPL_CACHING_PROP_NAME);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/TemplateHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/TemplateHandler.java
@@ -39,7 +39,8 @@ public interface TemplateHandler extends Handler<RoutingContext> {
   /**
    * The default content type header to be used in the response
    */
-  String DEFAULT_CONTENT_TYPE = "text/html";
+  @Deprecated
+  String DEFAULT_CONTENT_TYPE = TemplateEngine.DEFAULT_CONTENT_TYPE;
 
   /**
    * Create a handler
@@ -48,7 +49,7 @@ public interface TemplateHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static TemplateHandler create(TemplateEngine engine) {
-    return new TemplateHandlerImpl(engine, DEFAULT_TEMPLATE_DIRECTORY, DEFAULT_CONTENT_TYPE);
+    return new TemplateHandlerImpl(engine, DEFAULT_TEMPLATE_DIRECTORY);
   }
 
   /**
@@ -56,11 +57,25 @@ public interface TemplateHandler extends Handler<RoutingContext> {
    *
    * @param engine  the template engine
    * @param templateDirectory  the template directory where templates will be looked for
+   * @return the handler
+   */
+  static TemplateHandler create(TemplateEngine engine, String templateDirectory) {
+    return new TemplateHandlerImpl(engine, templateDirectory);
+  }
+
+  /**
+   * Create a handler
+   * Deprecated, use {@link TemplateEngine#setContentType(String)} instead
+   *
+   * @param engine  the template engine
+   * @param templateDirectory  the template directory where templates will be looked for
    * @param contentType  the content type header to be used in the response
    * @return the handler
    */
+  @Deprecated
   static TemplateHandler create(TemplateEngine engine, String templateDirectory, String contentType) {
-    return new TemplateHandlerImpl(engine, templateDirectory, contentType);
+    engine.setContentType(contentType);
+    return new TemplateHandlerImpl(engine, templateDirectory);
   }
 
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -29,23 +29,14 @@ public class TemplateHandlerImpl implements TemplateHandler {
 
   private final TemplateEngine engine;
   private final String templateDirectory;
-  private final String contentType;
 
-  public TemplateHandlerImpl(TemplateEngine engine, String templateDirectory, String contentType) {
+  public TemplateHandlerImpl(TemplateEngine engine, String templateDirectory) {
     this.engine = engine;
     this.templateDirectory = templateDirectory;
-    this.contentType = contentType;
   }
 
   @Override
   public void handle(RoutingContext context) {
-    String file = templateDirectory + Utils.pathOffset(context.normalisedPath(), context);
-    engine.render(context, file, res -> {
-      if (res.succeeded()) {
-        context.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType).end(res.result());
-      } else {
-        context.fail(res.cause());
-      }
-    });
+    engine.render(context, templateDirectory + Utils.pathOffset(context.normalisedPath(), context));
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/TemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/TemplateEngine.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -31,6 +32,10 @@ import io.vertx.ext.web.RoutingContext;
  */
 @VertxGen
 public interface TemplateEngine {
+  /**
+   * The default content type header to be used in the response
+   */
+  String DEFAULT_CONTENT_TYPE = "text/html";
 
   /**
    * Render
@@ -39,6 +44,35 @@ public interface TemplateEngine {
    * @param handler  the handler that will be called with a result containing the buffer or a failure.
    */
   void render(RoutingContext context, String templateFileName, Handler<AsyncResult<Buffer>> handler);
+
+  /**
+   * Renders directly to the given context with the provided filename
+   *
+   * @param context  the routing context to render to
+   * @param templateFileName  the template file to use
+   */
+  default void render(RoutingContext context, String templateFileName) {
+    render(context, templateFileName, (res) -> {
+      if (res.succeeded()) {
+        context.response().putHeader(HttpHeaders.CONTENT_TYPE, getContentType()).end(res.result());
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+  /**
+   * Gets the content type header to use when rendering, defaults to text/html
+   *
+   * @return the content type
+   */
+  String getContentType();
+
+  /**
+   * Sets the content type header to use when rendering
+   * @param contentType the content type
+   */
+  void setContentType(String contentType);
 
   /**
    * Returns true if the template engine caches template files. If false, then template files are freshly loaded each

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/AbstractTemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/AbstractTemplateEngine.java
@@ -1,0 +1,17 @@
+package io.vertx.ext.web.templ.impl;
+
+import io.vertx.ext.web.templ.TemplateEngine;
+
+public abstract class AbstractTemplateEngine implements TemplateEngine {
+  private String contentType = DEFAULT_CONTENT_TYPE;
+
+  @Override
+  public String getContentType() {
+    return contentType;
+  }
+
+  @Override
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/templ/impl/CachingTemplateEngine.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public abstract class CachingTemplateEngine<T> implements TemplateEngine {
+public abstract class CachingTemplateEngine<T> extends AbstractTemplateEngine {
 
   public static final String DISABLE_TEMPL_CACHING_PROP_NAME = "io.vertx.ext.web.TemplateEngine.disableCache";
   // should not be static, so at at creation time the value is evaluated


### PR DESCRIPTION
Fixes #568. Implemented as a default method for compatibility reasons.