### PR TITLE
typo on multiple lines fixed

### DIFF
--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -2740,7 +2740,7 @@ sockJSHandler.bridge(options, function (be) {
   be.complete(true);
 });
 
-router.route("/eventbus").handler(sockJSHandler.handle);
+router.route("/eventbus/*").handler(sockJSHandler.handle);
 
 
 
@@ -2765,7 +2765,7 @@ sockJSHandler.bridge(options, be -> {
  be.complete(true);
 });
 
-router.route("/eventbus").handler(sockJSHandler);
+router.route("/eventbus/*").handler(sockJSHandler);
 ----
 
 In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send and receive messages:
@@ -2838,7 +2838,7 @@ sockJSHandler.bridge(options, function (be) {
   be.complete(true);
 });
 
-router.route("/eventbus").handler(sockJSHandler.handle);
+router.route("/eventbus/*").handler(sockJSHandler.handle);
 
 
 

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -1001,7 +1001,7 @@ public class WebExamples {
       be.complete(true);
     });
 
-    router.route("/eventbus").handler(sockJSHandler);
+    router.route("/eventbus/*").handler(sockJSHandler);
 
 
   }
@@ -1027,7 +1027,7 @@ public class WebExamples {
       be.complete(true);
     });
 
-    router.route("/eventbus").handler(sockJSHandler);
+    router.route("/eventbus/*").handler(sockJSHandler);
 
 
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1807,7 +1807,7 @@
  *  be.complete(true);
  * });
  *
- * router.route("/eventbus").handler(sockJSHandler);
+ * router.route("/eventbus/*").handler(sockJSHandler);
  * ----
  *
  * In client side JavaScript you use the 'vertx-eventbus.js` library to create connections to the event bus and to send and receive messages:


### PR DESCRIPTION
was: 

router.route("/eventbus").handler...

changed to:

router.route("/eventbus/*").handler...
