### PR TITLE
Removes deprecated BridgeEvent#rawMessage()

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/BridgeEvent.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/BridgeEvent.java
@@ -39,13 +39,6 @@ public interface BridgeEvent extends Future<Boolean> {
   BridgeEventType type();
 
   /**
-   * Use {@link #getRawMessage()} instead, will be removed in 3.3
-   */
-  @Deprecated
-  @CacheReturn
-  JsonObject rawMessage();
-
-  /**
    * Get the raw JSON message for the event. This will be null for SOCKET_CREATED or SOCKET_CLOSED events as there is
    * no message involved. If the returned message is modified, {@link #setRawMessage} should be called with the
    * new message.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BridgeEventImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BridgeEventImpl.java
@@ -45,11 +45,6 @@ class BridgeEventImpl implements BridgeEvent {
   }
 
   @Override
-  public JsonObject rawMessage() {
-    return rawMessage;
-  }
-
-  @Override
   public JsonObject getRawMessage() {
     return rawMessage;
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -61,7 +61,7 @@ public class EventbusBridgeTest extends WebTestBase {
     sockJSHandler.bridge(allAccessOptions, be -> {
       if (be.type() == BridgeEventType.SOCKET_CREATED) {
         assertNotNull(be.socket());
-        assertNull(be.rawMessage());
+        assertNull(be.getRawMessage());
         be.complete(true);
         testComplete();
       } else {


### PR DESCRIPTION
BridgeEvent#rawMessage() should be removed since 3.3

```java
  /**
   * Use {@link #getRawMessage()} instead, will be removed in 3.3
   */
  @Deprecated
  @CacheReturn
  JsonObject rawMessage();
```