### PR TITLE
Add automatic responses for OPTIONS, invalid methods, and failed content negotiation

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -21,8 +21,8 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.Utils;
 
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -60,42 +60,42 @@ public class CorsHandlerImpl implements CorsHandler {
   @Override
   public CorsHandler allowedMethod(HttpMethod method) {
     allowedMethods.add(method);
-    allowedMethodsString = join(allowedMethods);
+    allowedMethodsString = Utils.join(allowedMethods);
     return this;
   }
 
   @Override
   public CorsHandler allowedMethods(Set<HttpMethod> methods) {
     allowedMethods.addAll(methods);
-    allowedMethodsString = join(allowedMethods);
+    allowedMethodsString = Utils.join(allowedMethods);
     return this;
   }
 
   @Override
   public CorsHandler allowedHeader(String headerName) {
     allowedHeaders.add(headerName);
-    allowedHeadersString = join(allowedHeaders);
+    allowedHeadersString = Utils.join(allowedHeaders);
     return this;
   }
 
   @Override
   public CorsHandler allowedHeaders(Set<String> headerNames) {
     allowedHeaders.addAll(headerNames);
-    allowedHeadersString = join(allowedHeaders);
+    allowedHeadersString = Utils.join(allowedHeaders);
     return this;
   }
 
   @Override
   public CorsHandler exposedHeader(String headerName) {
     exposedHeaders.add(headerName);
-    exposedHeadersString = join(exposedHeaders);
+    exposedHeadersString = Utils.join(exposedHeaders);
     return this;
   }
 
   @Override
   public CorsHandler exposedHeaders(Set<String> headerNames) {
     exposedHeaders.addAll(headerNames);
-    exposedHeadersString = join(exposedHeaders);
+    exposedHeadersString = Utils.join(exposedHeaders);
     return this;
   }
 
@@ -175,22 +175,6 @@ public class CorsHandlerImpl implements CorsHandler {
 
   private String getAllowedOrigin(String origin) {
     return allowedOrigin == null ? "*" : origin;
-  }
-
-  private String join(Collection<?> ss) {
-    if (ss == null || ss.isEmpty()) {
-      return null;
-    }
-    StringBuilder sb = new StringBuilder();
-    boolean first = true;
-    for (Object s : ss) {
-      if (!first) {
-        sb.append(',');
-      }
-      sb.append(s);
-      first = false;
-    }
-    return sb.toString();
   }
 
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandler.java
@@ -9,15 +9,15 @@ import java.util.function.Function;
  * @author <a href="mailto:y.lin@vanderbilt.edu">Yunyu Lin</a>
  */
 public class AutomaticHandler {
-  private Function<RoutingContext, AutomaticHandlerResult> resultFunction;
+  private Function<RoutingContext, MatchResult> resultFunction;
   private Handler<RoutingContext> contextHandler;
 
-  public AutomaticHandler(Function<RoutingContext, AutomaticHandlerResult> resultFunction, Handler<RoutingContext> contextHandler) {
+  public AutomaticHandler(Function<RoutingContext, MatchResult> resultFunction, Handler<RoutingContext> contextHandler) {
     this.resultFunction = resultFunction;
     this.contextHandler = contextHandler;
   }
 
-  public AutomaticHandlerResult shouldHandle(RoutingContext context) {
+  public MatchResult matches(RoutingContext context) {
     return resultFunction.apply(context);
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandler.java
@@ -1,0 +1,27 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:y.lin@vanderbilt.edu">Yunyu Lin</a>
+ */
+public class AutomaticHandler {
+  private Function<RoutingContext, AutomaticHandlerResult> resultFunction;
+  private Handler<RoutingContext> contextHandler;
+
+  public AutomaticHandler(Function<RoutingContext, AutomaticHandlerResult> resultFunction, Handler<RoutingContext> contextHandler) {
+    this.resultFunction = resultFunction;
+    this.contextHandler = contextHandler;
+  }
+
+  public AutomaticHandlerResult shouldHandle(RoutingContext context) {
+    return resultFunction.apply(context);
+  }
+
+  public void handle(RoutingContext context) {
+    contextHandler.handle(context);
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandlerResult.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/AutomaticHandlerResult.java
@@ -1,0 +1,11 @@
+package io.vertx.ext.web.impl;
+
+/**
+ * @author <a href="mailto:y.lin@vanderbilt.edu">Yunyu Lin</a>
+ */
+public enum AutomaticHandlerResult {
+  METHOD,
+  PATH,
+  CONTENT_TYPE,
+  ACCEPTABLE_CONTENT_TYPES
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/MatchResult.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/MatchResult.java
@@ -3,9 +3,8 @@ package io.vertx.ext.web.impl;
 /**
  * @author <a href="mailto:y.lin@vanderbilt.edu">Yunyu Lin</a>
  */
-public enum AutomaticHandlerResult {
-  METHOD,
-  PATH,
-  CONTENT_TYPE,
-  ACCEPTABLE_CONTENT_TYPES
+public enum MatchResult {
+  TRUE,
+  FALSE,
+  SKIP
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -59,7 +59,10 @@ public abstract class RoutingContextImplBase implements RoutingContext {
 
   protected void restart() {
     this.iter = routes.iterator();
-    currentRoute = null;
+    if (currentRoute != null) {
+      currentRoute.clearAutomaticHandler();
+      currentRoute = null;
+    }
     next();
   }
 
@@ -87,6 +90,8 @@ public abstract class RoutingContextImplBase implements RoutingContext {
             if (log.isTraceEnabled()) log.trace("Failure in handling failure");
             unhandledFailure(-1, t, route.router());
           }
+        } finally {
+          route.clearAutomaticHandler();
         }
         return true;
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -407,5 +408,21 @@ public class Utils extends io.vertx.core.impl.Utils {
 
   public static long secondsFactor(long millis) {
     return millis - (millis % 1000);
+  }
+
+  public static String join(Collection<?> ss) {
+    if (ss == null || ss.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (Object s : ss) {
+      if (!first) {
+        sb.append(',');
+      }
+      sb.append(s);
+      first = false;
+    }
+    return sb.toString();
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/AutomaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/AutomaticHandlerTest.java
@@ -1,0 +1,88 @@
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.WebTestBase;
+import org.junit.Test;
+
+public class AutomaticHandlerTest extends WebTestBase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void testOptionsAllMethodsAllowed() throws Exception {
+    router.route("/allmethods").handler(ctx -> ctx.response().end());
+    testRequest(HttpMethod.OPTIONS, "/allmethods", null, resp -> {
+      assertEquals("OPTIONS,GET,HEAD,POST,PUT,DELETE,TRACE,CONNECT,PATCH,OTHER", resp.getHeader("Allow"));
+    }, 204, "No Content", null);
+  }
+
+  @Test
+  public void testOptionsGetPostAllowed() throws Exception {
+    router.route("/getpost").method(HttpMethod.GET).method(HttpMethod.POST).handler(ctx -> ctx.response().end());
+    testRequest(HttpMethod.OPTIONS, "/getpost", null, resp -> {
+      assertEquals("POST,GET", resp.getHeader("Allow"));
+    }, 204, "No Content", null);
+  }
+
+  @Test
+  public void testOptionsAlreadyDeclared() throws Exception {
+    router.route("/optionspath").method(HttpMethod.OPTIONS).handler(ctx -> {
+      ctx.response().putHeader("Allow", "CUSTOM");
+      ctx.response().setStatusCode(204).end();
+    });
+    testRequest(HttpMethod.OPTIONS, "/optionspath", null, resp -> {
+      assertEquals("CUSTOM", resp.getHeader("Allow"));
+    }, 204, "No Content", null);
+  }
+
+  @Test
+  public void testIncorrectVerb() throws Exception {
+    router.post("/posthandler").handler(ctx -> ctx.response().end("Hello World!"));
+    testRequest(HttpMethod.PUT, "/posthandler", null, resp -> {
+      assertEquals("POST", resp.getHeader("Allow"));
+    }, 405, "Method Not Allowed", null);
+  }
+
+  @Test
+  public void testIncorrectVerbRequired() throws Exception {
+    router.post("/posthandler2").handler(ctx -> ctx.response().end("Hello World!"));
+    testRequest(HttpMethod.GET, "/posthandler2", null, null,
+      404, "Not Found", null);
+    testRequest(HttpMethod.HEAD, "/posthandler2", null, null,
+      404, "Not Found", null);
+  }
+
+  @Test
+  public void testFailedContentNegotiation() throws Exception {
+    router.post("/xmlhandler").consumes("application/xml").handler((ctx) -> ctx.response().end("XML"));
+    testRequest(HttpMethod.POST, "/xmlhandler", req -> {
+      req.putHeader("Content-Type", "application/json");
+    }, null, 415, "Unsupported Media Type", null);
+  }
+
+  @Test
+  public void testSuccessfulContentNegotiation() throws Exception {
+    router.post("/xmlhandler2").consumes("application/xml").handler((ctx) -> ctx.response().end("XML"));
+    testRequest(HttpMethod.POST, "/xmlhandler2", req -> {
+      req.putHeader("Content-Type", "application/xml");
+    }, null, 200, "OK", "XML");
+  }
+
+  @Test
+  public void testFailedAcceptFulfill() throws Exception {
+    router.get("/xmlproducer").produces("application/xml").handler((ctx) -> ctx.response().end("XML"));
+    testRequest(HttpMethod.GET, "/xmlproducer", req -> {
+      req.putHeader("Accept", "application/json");
+    }, null, 406, "Not Acceptable", null);
+  }
+
+  @Test
+  public void testSuccessfulAcceptFulfill() throws Exception {
+    router.get("/xmlproducer2").produces("application/xml").handler((ctx) -> ctx.response().end("XML"));
+    testRequest(HttpMethod.GET, "/xmlproducer2", req -> {
+      req.putHeader("Accept", "application/xml");
+    }, null, 200, "OK", null);
+  }
+}


### PR DESCRIPTION
Also implements a internal framework for adding other automatic responses.

* Does nothing if a CorsHandler an OPTIONS method is added. 
* 405 if request specifies a wrong verb
* 415 if consumed content negotiation fails
* 406 if produced content negotiation fails

Fixes #594 and #456.

I don't like the instanceof check, but it's a bit too late to force users to declare `.method(HttpMethod.OPTIONS)` when adding a CorsHandler. The only other solution is to do a massive refactor of response handling to allow replacing the response after it's written (which is unlikely to happen).

This will break response handling for the very small (probably 0) minority of users who handle OPTIONS without declaring the method in the route or using CorsHandler, as well as for people who expect non-compliant behavior for the other fixes.
