### PR TITLE
update docs for StaticHandler

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1025,9 +1025,9 @@
  * ----
  *
  * For example, if there was a request with path `/static/css/mystyles.css` the static serve will look for a file in the
- * directory `webroot/static/css/mystyle.css`.
+ * directory `webroot/css/mystyle.css`.
  *
- * It will also look for a file on the classpath called `webroot/static/css/mystyle.css`. This means you can package up all your
+ * It will also look for a file on the classpath called `webroot/css/mystyle.css`. This means you can package up all your
  * static resources into a jar file (or fatjar) and distribute them like that.
  *
  * When Vert.x finds a resource on the classpath for the first time it extracts it and caches it in a temporary directory


### PR DESCRIPTION
The documentation of `Serving static resources` is misleading, If the static handler is configured as `router.route("/static/*").handler(StaticHandler.create())` it will serve the static content from `webroot` directory, instead of `webroot/static` as stated in the docs.

please refer to the ![screenshot](https://cloud.githubusercontent.com/assets/5792205/25609978/014537d4-2f54-11e7-97fc-c378c50f4d88.png)

related issue on `vertx-web`  [here](https://github.com/vert-x3/vertx-web/issues/419)

and the actual code which remove the `prefix` for static resources [here](https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java#L361)
