### PR TITLE
Update docs for TemplateHandler

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -1894,7 +1894,7 @@ def engine = HandlebarsTemplateEngine.create()
 def handler = TemplateHandler.create(engine)
 
 // This will route all GET requests starting with /dynamic/ to the template handler
-// E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+// E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
 router.get("/dynamic/*").handler(handler)
 
 // Route all GET requests for resource ending in .hbs to the template handler

--- a/vertx-web/src/main/asciidoc/java/index.adoc
+++ b/vertx-web/src/main/asciidoc/java/index.adoc
@@ -1744,7 +1744,7 @@ TemplateEngine engine = HandlebarsTemplateEngine.create();
 TemplateHandler handler = TemplateHandler.create(engine);
 
 // This will route all GET requests starting with /dynamic/ to the template handler
-// E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+// E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
 router.get("/dynamic/*").handler(handler);
 
 // Route all GET requests for resource ending in .hbs to the template handler

--- a/vertx-web/src/main/asciidoc/js/index.adoc
+++ b/vertx-web/src/main/asciidoc/js/index.adoc
@@ -1941,7 +1941,7 @@ var engine = HandlebarsTemplateEngine.create();
 var handler = TemplateHandler.create(engine);
 
 // This will route all GET requests starting with /dynamic/ to the template handler
-// E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+// E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
 router.get("/dynamic/*").handler(handler.handle);
 
 // Route all GET requests for resource ending in .hbs to the template handler

--- a/vertx-web/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web/src/main/asciidoc/ruby/index.adoc
@@ -1939,7 +1939,7 @@ engine = VertxWeb::HandlebarsTemplateEngine.create()
 handler = VertxWeb::TemplateHandler.create(engine)
 
 # This will route all GET requests starting with /dynamic/ to the template handler
-# E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+# E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
 router.get("/dynamic/*").handler(&handler.method(:handle))
 
 # Route all GET requests for resource ending in .hbs to the template handler

--- a/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/package-info.java
@@ -1160,7 +1160,7 @@
  * TemplateHandler handler = TemplateHandler.create(engine);
  *
  * // This will route all GET requests starting with /dynamic/ to the template handler
- * // E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+ * // E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
  * router.get("/dynamic/*").handler(handler);
  *
  * // Route all GET requests for resource ending in .hbs to the template handler
@@ -1179,7 +1179,7 @@
  * def handler = TemplateHandler.create(engine)
  *
  * // This will route all GET requests starting with /dynamic/ to the template handler
- * // E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+ * // E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
  * router.get("/dynamic/*").handler(handler)
  *
  * // Route all GET requests for resource ending in .hbs to the template handler
@@ -1198,7 +1198,7 @@
  * handler = VertxWeb::TemplateHandler.create(engine)
  *
  * # This will route all GET requests starting with /dynamic/ to the template handler
- * # E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+ * # E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
  * router.get("/dynamic/*").handler(&handler.method(:handle))
  *
  * # Route all GET requests for resource ending in .hbs to the template handler
@@ -1217,7 +1217,7 @@
  * var handler = TemplateHandler.create(engine);
  *
  * // This will route all GET requests starting with /dynamic/ to the template handler
- * // E.g. /dynamic/graph.hbs will look for a template in /templates/dynamic/graph.hbs
+ * // E.g. /dynamic/graph.hbs will look for a template in /templates/graph.hbs
  * router.get("/dynamic/*").handler(handler.handle);
  *
  * // Route all GET requests for resource ending in .hbs to the template handler


### PR DESCRIPTION
The documentation of Serving template resources is misleading, If the template handler is configured as router.route("/dynamic/*").handler(TemplateHandler.create(HandlebarsTemplateEngine.create())) it will serve the dynamic content from templates directory, instead of templates/dynamic as stated in the docs.

and following are related issues:
https://github.com/vert-x3/vertx-web-site/issues/192
https://github.com/vert-x3/vertx-web/issues/419
https://github.com/vert-x3/vertx-web/pull/618

Signed-off-by: Chengen Zhao <chengen.zhao@mail.mcgill.ca>