### PR TITLE
produces() ignores Accept: */* when charset is present

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ParsableMIMEValue.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ParsableMIMEValue.java
@@ -6,9 +6,9 @@ public class ParsableMIMEValue extends ParsableHeaderValue implements MIMEHeader
 
   private String component;
   private String subComponent;
-  
+
   private int orderWeight;
-  
+
   public ParsableMIMEValue(String headerContent) {
     super(headerContent);
     component = null;
@@ -19,26 +19,31 @@ public class ParsableMIMEValue extends ParsableHeaderValue implements MIMEHeader
   public String component() {
     return component;
   }
-  
+
   @Override
   public String subComponent() {
     return subComponent;
   }
-  
+
   @Override
   protected boolean isMatchedBy2(ParsableHeaderValue matchTry) {
     ParsableMIMEValue myMatchTry = (ParsableMIMEValue) matchTry;
     ensureHeaderProcessed();
-    
+
     if (!"*".equals(component) && !"*".equals(myMatchTry.component) && !component.equals(myMatchTry.component)) {
       return false;
     }
     if (!"*".equals(subComponent) && !"*".equals(myMatchTry.subComponent) && !subComponent.equals(myMatchTry.subComponent)) {
       return false;
     }
+
+    if ("*".equals(component) && "*".equals(subComponent) && parameters().size() == 0) {
+      return true;
+    }
+
     return super.isMatchedBy2(myMatchTry);
   }
-  
+
   @Override
   protected void ensureHeaderProcessed() {
     super.ensureHeaderProcessed();
@@ -52,20 +57,20 @@ public class ParsableMIMEValue extends ParsableHeaderValue implements MIMEHeader
       orderWeight += "*".equals(subComponent) ? 0 : 2;
     }
   }
-  
+
   public ParsableMIMEValue forceParse(){
     ensureHeaderProcessed();
     return this;
   }
-  
+
   private void setComponent(String component) {
     this.component = "*".equals(component) ? "*" : component;
   }
-  
+
   private void setSubComponent(String subComponent) {
     this.subComponent = "*".equals(subComponent) ? "*" : subComponent;
   }
-    
+
   @Override
   protected int weightedOrderPart2(){
     return orderWeight;

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1054,11 +1054,11 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testProducesWithParameterKey() throws Exception {
     router.route().produces("text/html;boo").handler(rc -> rc.response().end());
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo=ya;itWorks=4real", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo;itWorks", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo=ya", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "*/*", 200, "OK");
   }
 
   @Test
@@ -1087,6 +1087,7 @@ public class RouterTest extends WebTestBase {
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;a", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;q=2", 200, "OK");
     testRequest(HttpMethod.GET, "/foo", 200, "OK");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "*/*", 200, "OK");
   }
 
   @Test


### PR DESCRIPTION
Fixes #639 

Last step before looking at the parameters should be to check if user accepts anything	