### PR TITLE
Added multiple handlers support inside route object

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -49,8 +49,10 @@ public class RouteImpl implements Route {
   private String path;
   private int order;
   private boolean enabled = true;
-  private Handler<RoutingContext> contextHandler;
-  private Handler<RoutingContext> failureHandler;
+  private List<Handler<RoutingContext>> contextHandlers;
+  private int actualHandlerIndex;
+  private List<Handler<RoutingContext>> failureHandlers;
+  private int actualFailureHandlerIndex;
   private boolean added;
   private Pattern pattern;
   private List<String> groups;
@@ -59,6 +61,9 @@ public class RouteImpl implements Route {
   RouteImpl(RouterImpl router, int order) {
     this.router = router;
     this.order = order;
+    this.contextHandlers = new ArrayList<>();
+    this.failureHandlers = new ArrayList<>();
+    resetIndexes();
   }
 
   RouteImpl(RouterImpl router, int order, HttpMethod method, String path) {
@@ -134,10 +139,7 @@ public class RouteImpl implements Route {
 
   @Override
   public synchronized Route handler(Handler<RoutingContext> contextHandler) {
-    if (this.contextHandler != null) {
-      throw new IllegalStateException("Setting handler for a route more than once!");
-    }
-    this.contextHandler = contextHandler;
+    this.contextHandlers.add(contextHandler);
     checkAdd();
     return this;
   }
@@ -154,10 +156,7 @@ public class RouteImpl implements Route {
 
   @Override
   public synchronized Route failureHandler(Handler<RoutingContext> exceptionHandler) {
-    if (this.failureHandler != null) {
-      throw new IllegalStateException("Setting failureHandler for a route more than once!");
-    }
-    this.failureHandler = exceptionHandler;
+    this.failureHandlers.add(exceptionHandler);
     checkAdd();
     return this;
   }
@@ -196,8 +195,8 @@ public class RouteImpl implements Route {
     StringBuilder sb = new StringBuilder("Route[ ");
     sb.append("path:").append(path);
     sb.append(" pattern:").append(pattern);
-    sb.append(" handler:").append(contextHandler);
-    sb.append(" failureHandler:").append(failureHandler);
+    sb.append(" handlers:").append(contextHandlers);
+    sb.append(" failureHandlers:").append(failureHandlers);
     sb.append(" order:").append(order);
     sb.append(" methods:[");
     int cnt = 0;
@@ -213,20 +212,22 @@ public class RouteImpl implements Route {
   }
 
   synchronized void handleContext(RoutingContext context) {
-    if (contextHandler != null) {
-      contextHandler.handle(context);
+    if (this.hasNextContextHandler()) {
+      actualHandlerIndex++;
+      contextHandlers.get(actualHandlerIndex - 1).handle(context);
     }
   }
 
   synchronized void handleFailure(RoutingContext context) {
-    if (failureHandler != null) {
-      failureHandler.handle(context);
+    if (this.hasNextFailureHandler()) {
+      actualFailureHandlerIndex++;
+      failureHandlers.get(actualFailureHandlerIndex - 1).handle(context);
     }
   }
 
   synchronized boolean matches(RoutingContext context, String mountPoint, boolean failure) {
 
-    if (failure && failureHandler == null || !failure && contextHandler == null) {
+    if (failure && !hasNextFailureHandler() || !failure && !hasNextContextHandler()) {
       return false;
     }
     if (!enabled) {
@@ -416,4 +417,18 @@ public class RouteImpl implements Route {
     }
   }
 
+  synchronized protected boolean hasNextContextHandler() {
+    if (actualHandlerIndex < contextHandlers.size()) return true;
+    else return false;
+  }
+
+  synchronized protected boolean hasNextFailureHandler() {
+    if (actualFailureHandlerIndex < failureHandlers.size()) return true;
+    else return false;
+  }
+
+  synchronized protected void resetIndexes() {
+    actualFailureHandlerIndex = 0;
+    actualHandlerIndex = 0;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -417,6 +417,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private void doFail() {
     this.iter = router.iterator();
+    currentRoute = null;
     next();
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
 import org.junit.Test;
 
 import java.util.List;
@@ -2002,21 +2003,91 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testMultipleSetHandler() throws Exception {
-    try {
-      router.route().handler(context -> {}).handler(context -> {});
-      fail();
-    } catch (IllegalStateException e) {
-      // OK
-    }
+    router.get("/path").handler(routingContext -> {
+      routingContext.put("response", "handler1");
+      routingContext.next();
+    }).handler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "handler2");
+      routingContext.next();
+    }).handler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.end(routingContext.get("response") + "handler3");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "OK", "handler1handler2handler3");
   }
 
   @Test
   public void testMultipleSetFailureHandler() throws Exception {
-    try {
-      router.route().failureHandler(context -> {}).failureHandler(context -> {});
-      fail();
-    } catch (IllegalStateException e) {
-      // OK
-    }
+    router.get("/path").handler(routingContext -> {
+      routingContext.fail(500);
+    }).failureHandler(routingContext -> {
+      routingContext.put("response", "handler1");
+      routingContext.next();
+    }).failureHandler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "handler2");
+      routingContext.next();
+    }).failureHandler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.setStatusMessage("ERROR");
+      response.setStatusCode(500);
+      response.end(routingContext.get("response") + "handler3");
+    });
+    testRequest(HttpMethod.GET, "/path", 500, "ERROR", "handler1handler2handler3");
+  }
+
+  @Test
+  public void testMultipleSetFailureHandlerCorrectOrder() throws Exception {
+    router.route().failureHandler(routingContext -> {
+      routingContext.put("response", "handler1");
+      routingContext.next();
+    });
+
+    router.get("/path").handler(routingContext -> {
+      routingContext.fail(500);
+    }).failureHandler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "handler2");
+      routingContext.next();
+    }).failureHandler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.setStatusMessage("ERROR");
+      response.setStatusCode(500);
+      response.end(routingContext.get("response") + "handler3");
+    });
+    testRequest(HttpMethod.GET, "/path", 500, "ERROR", "handler1handler2handler3");
+  }
+
+  @Test
+  public void testMultipleHandlersMixed() throws Exception {
+    router.route().failureHandler(routingContext -> {
+      routingContext.put("response", "fhandler1");
+      routingContext.next();
+    });
+
+    router.get("/:param").handler(routingContext -> {
+      if (routingContext.pathParam("param").equals("fail")) routingContext.fail(500);
+      routingContext.put("response", "handler1");
+      routingContext.next();
+    }).handler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "handler2");
+      routingContext.next();
+    }).handler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.end(routingContext.get("response") + "handler3");
+    }).failureHandler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "fhandler2");
+      routingContext.next();
+    }).failureHandler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.setStatusMessage("ERROR");
+      response.setStatusCode(500);
+      response.end(routingContext.get("response") + "fhandler3");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "OK", "handler1handler2handler3");
+    testRequest(HttpMethod.GET, "/fail", 500, "ERROR", "fhandler1fhandler2fhandler3");
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2090,4 +2090,21 @@ public class RouterTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/path", 200, "OK", "handler1handler2handler3");
     testRequest(HttpMethod.GET, "/fail", 500, "ERROR", "fhandler1fhandler2fhandler3");
   }
+
+  @Test
+  public void testMultipleSetHandlerMultipleRouteObject() throws Exception {
+    router.get("/path").handler(routingContext -> {
+      routingContext.put("response", "handler1");
+      routingContext.next();
+    });
+    router.get("/path").handler(routingContext -> {
+      routingContext.put("response", routingContext.get("response") + "handler2");
+      routingContext.next();
+    }).handler(routingContext -> {
+      HttpServerResponse response = routingContext.response();
+      response.setChunked(true);
+      response.end(routingContext.get("response") + "handler3");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "OK", "handler1handler2handler3");
+  }
 }


### PR DESCRIPTION
Following this [google groups post](https://groups.google.com/forum/?fromgroups=#!topic/vertx-dev/jBCuyzb8Yls), I implemented the multiple handlers support:
```java
router.get("/path").handler(routingContext -> {
      routingContext.put("response", "handler1");
      routingContext.next();
    }).handler(routingContext -> {
      routingContext.put("response", routingContext.get("response") + "handler2");
      routingContext.next();
    }).handler(routingContext -> {
      HttpServerResponse response = routingContext.response();
      response.setChunked(true);
      response.end(routingContext.get("response") + "handler3");
    });
```
There is only one downside. In the code above, you will use the same Route object, while in the code below you create 3 different Route objects:

```java
router.get("/path").handler(routingContext -> {
      routingContext.put("response", "handler1");
      routingContext.next();
    });
router.get("/path").handler(routingContext -> {
      routingContext.put("response", routingContext.get("response") + "handler2");
      routingContext.next();
    });
router.get("/path").handler(routingContext -> {
      HttpServerResponse response = routingContext.response();
      response.setChunked(true);
      response.end(routingContext.get("response") + "handler3");
    });
```
However both this cases are handled (see the unit tests added)