### PR TITLE
Async handler before SockJS handler breaks XhrTransport

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSAsyncHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSAsyncHandlerTest.java
@@ -1,0 +1,40 @@
+package io.vertx.ext.web.handler.sockjs;
+
+import org.junit.Test;
+
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class SockJSAsyncHandlerTest extends SockJSTestBase {
+
+  @Override
+  protected void addHandlersBeforeSockJSHandler(Router router) {
+    router.route().handler(BodyHandler.create());
+    // simulate an async handler
+    router.route().handler(rtx -> rtx.vertx().executeBlocking(f -> f.complete(true), r -> rtx.next()));
+  }
+
+  @Test
+  public void testHandleMessageFromXhrTransportWithAsyncHandler() {
+    sockJSHandler.socketHandler(socket -> {
+      socket.handler(buf -> {
+        assertEquals("Hello World", buf.toString());
+        testComplete();
+      });
+    });
+
+    client.post("/test/400/8ne8e94a/xhr", resp -> {
+      assertEquals(200, resp.statusCode());
+
+      client.post("/test/400/8ne8e94a/xhr_send", respSend -> {
+        assertEquals(204, respSend.statusCode());
+      })
+      .putHeader("content-length", "13")
+      .write("\"Hello World\"")
+      .end();
+    })
+    .end();
+
+    await();
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -14,7 +14,7 @@
  *  You may elect to redistribute this code under either of these licenses.
  */
 
-package io.vertx.ext.web.handler;
+package io.vertx.ext.web.handler.sockjs;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
@@ -22,7 +22,6 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.WebTestBase;
-import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
@@ -13,12 +13,12 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-package io.vertx.ext.web.handler;
+package io.vertx.ext.web.handler.sockjs;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.WebTestBase;
-import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+
 import org.junit.Test;
 
 import java.io.BufferedReader;

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
@@ -38,31 +38,7 @@ import java.util.concurrent.locks.LockSupport;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class SockJSSessionTest extends VertxTestBase {
-
-  private HttpClient client;
-  private HttpServer server;
-  private Router router;
-  private SockJSHandler sockJSHandler;
-
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8080));
-    router = Router.router(vertx);
-    router.route().handler(CookieHandler.create());
-    router.route()
-      .handler(SessionHandler.create(LocalSessionStore.create(vertx))
-        .setNagHttps(false)
-        .setSessionTimeout(60 * 60 * 1000));
-    SockJSHandlerOptions options = new SockJSHandlerOptions().setHeartbeatInterval(2000);
-    sockJSHandler = SockJSHandler.create(vertx, options);
-    router.route("/test/*").handler(sockJSHandler);
-    server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"));
-    CountDownLatch latch = new CountDownLatch(1);
-    server.requestHandler(router::accept).listen(ar -> latch.countDown());
-    awaitLatch(latch);
-  }
+public class SockJSSessionTest extends SockJSTestBase {
 
   @Test
   public void testNoDeadlockWhenWritingFromAnotherThreadWithSseTransport() {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
@@ -13,7 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-package io.vertx.ext.web.handler;
+package io.vertx.ext.web.handler.sockjs;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -21,6 +21,8 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.CookieHandler;
+import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.sstore.LocalSessionStore;

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
@@ -1,0 +1,45 @@
+package io.vertx.ext.web.handler.sockjs;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.CookieHandler;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.LocalSessionStore;
+import io.vertx.test.core.VertxTestBase;
+
+public abstract class SockJSTestBase extends VertxTestBase {
+
+  protected HttpClient client;
+  protected HttpServer server;
+  protected Router router;
+  protected SockJSHandler sockJSHandler;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8080));
+    router = Router.router(vertx);
+    router.route().handler(CookieHandler.create());
+    router.route()
+        .handler(SessionHandler.create(LocalSessionStore.create(vertx))
+            .setNagHttps(false)
+            .setSessionTimeout(60 * 60 * 1000));
+    addHandlersBeforeSockJSHandler(router);
+    SockJSHandlerOptions options = new SockJSHandlerOptions().setHeartbeatInterval(2000);
+    sockJSHandler = SockJSHandler.create(vertx, options);
+    router.route("/test/*").handler(sockJSHandler);
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"));
+    CountDownLatch latch = new CountDownLatch(1);
+    server.requestHandler(router::accept).listen(ar -> latch.countDown());
+    awaitLatch(latch);
+  }
+
+  protected void addHandlersBeforeSockJSHandler(Router router) {
+    // no additional routing handlers by default
+  }
+}


### PR DESCRIPTION
SockJS XHR transport tries to register a body handler
(rc.request().bodyHandler(buff -> {})). This doesn't work when using an async
handler before the SockJS handler.

Fixes #654