### PR TITLE
Support fragmented WS messages

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -94,9 +94,8 @@ class WebSocketTransport extends BaseTransport {
     WebSocketListener(ServerWebSocket ws, SockJSSession session) {
       this.ws = ws;
       this.session = session;
-      ws.handler(data -> {
+      ws.textMessageHandler(msgs -> {
         if (!session.isClosed()) {
-          String msgs = data.toString();
           if (msgs.equals("")) {
             //Ignore empty frames
           } else if ((msgs.startsWith("[\"") && msgs.endsWith("\"]")) ||

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SockJSSessionTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SockJSSessionTest.java
@@ -123,4 +123,20 @@ public class SockJSSessionTest extends VertxTestBase {
     });
     await();
   }
+
+  @Test
+  public void testCombineMultipleFramesIntoASingleMessage() {
+    sockJSHandler.socketHandler(socket -> {
+      socket.handler(buf -> {
+        assertEquals("Hello World", buf.toString());
+        testComplete();
+      });
+    });
+    client.websocket("/test/400/8ne8e94a/websocket", ws -> {
+      ws.writeFrame(io.vertx.core.http.WebSocketFrame.textFrame("[\"Hello", false));
+      ws.writeFrame(io.vertx.core.http.WebSocketFrame.continuationFrame(Buffer.buffer(" World\"]"), true));
+      ws.close();
+    });
+    await();
+  }
 }


### PR DESCRIPTION
SockJS currently listens to data which maps to WebSocket frames. Frames
are a low-level WebSocket transport mechanism which will quite
frequently map to fragmented WebSocket messages.

The following screenshot shows what a fragmented message looks like on the wire. Notice that the `FIN` flag is not set (see https://tools.ietf.org/html/rfc6455#section-5.2 for reference).

<img width="1969" alt="screen shot 2017-07-06 at 10 45 04" src="https://user-images.githubusercontent.com/596443/27903044-383a4060-6238-11e7-9fff-b6fba7ce7729.png">

 Luckily, vertx-core already supports a `textMessageHandler` which does the heavy lifting of stitching together fragmented frames into messages.

Fixes https://github.com/eclipse/vert.x/issues/1751