### PR TITLE
Make CORS headers optional for SockJS handlers

### DIFF
--- a/vertx-web/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web/src/main/asciidoc/dataobjects.adoc
@@ -69,6 +69,7 @@ Declare a specific authority that user must have in order to allow messages
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[corsHeadersEnabled]]`corsHeadersEnabled`|`Boolean`|-
 |[[disabledTransports]]`disabledTransports`|`Array of String`|-
 |[[heartbeatInterval]]`heartbeatInterval`|`Number (long)`|-
 |[[insertJSESSIONID]]`insertJSESSIONID`|`Boolean`|-

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerOptions.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerOptions.java
@@ -35,6 +35,7 @@ public class SockJSHandlerOptions {
   public static final long DEFAULT_HEARTBEAT_INTERVAL = 25l * 1000;
   public static final int DEFAULT_MAX_BYTES_STREAMING = 128 * 1024;
   public static final String DEFAULT_LIBRARY_URL = "//cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js";
+  public static final boolean DEFAULT_CORS_HEADERS_ENABLED = true;
 
   private long sessionTimeout;
   private boolean insertJSESSIONID;
@@ -42,6 +43,7 @@ public class SockJSHandlerOptions {
   private int maxBytesStreaming;
   private String libraryURL;
   private Set<String> disabledTransports = new HashSet<>();
+  private boolean corsHeadersEnabled;
 
   public SockJSHandlerOptions(SockJSHandlerOptions other) {
     throw new UnsupportedOperationException("todo");
@@ -53,6 +55,7 @@ public class SockJSHandlerOptions {
     this.heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     this.maxBytesStreaming = DEFAULT_MAX_BYTES_STREAMING;
     this.libraryURL = DEFAULT_LIBRARY_URL;
+    this.corsHeadersEnabled = DEFAULT_CORS_HEADERS_ENABLED;
   }
 
   public SockJSHandlerOptions(JsonObject json) {
@@ -61,6 +64,7 @@ public class SockJSHandlerOptions {
     this.heartbeatInterval = json.getLong("heartbeatInterval", DEFAULT_HEARTBEAT_INTERVAL);
     this.maxBytesStreaming = json.getInteger("maxBytesStreaming", DEFAULT_MAX_BYTES_STREAMING);
     this.libraryURL = json.getString("libraryURL", DEFAULT_LIBRARY_URL);
+    this.corsHeadersEnabled = json.getBoolean("corsHeadersEnabled", DEFAULT_CORS_HEADERS_ENABLED);
     JsonArray arr = json.getJsonArray("disabledTransports");
     if (arr != null) {
       for (Object str : arr) {
@@ -137,4 +141,12 @@ public class SockJSHandlerOptions {
     return disabledTransports;
   }
 
+  public boolean isCorsHeadersEnabled() {
+    return corsHeadersEnabled;
+  }
+
+  public SockJSHandlerOptions setCorsHeadersEnabled(boolean corsHeadersEnabled) {
+    this.corsHeadersEnabled = corsHeadersEnabled;
+    return this;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
@@ -156,7 +156,11 @@ class BaseTransport {
     }
   }
 
-  static void setCORS(RoutingContext rc) {
+  static void setCORS(SockJSHandlerOptions options, RoutingContext rc) {
+    if (!options.isCorsHeadersEnabled()) {
+      return;
+    }
+
     HttpServerRequest req = rc.request();
     String origin = req.headers().get("origin");
     if (origin == null || "null".equals(origin)) {
@@ -184,7 +188,7 @@ class BaseTransport {
         // Java ints are signed, so we need to use a long and add the offset so
         // the result is not negative
         json.put("entropy", RAND_OFFSET + new Random().nextInt());
-        setCORS(rc);
+        setCORS(options, rc);
         rc.response().end(json.encode());
       }
     };
@@ -204,7 +208,7 @@ class BaseTransport {
       rc.response().putHeader("Expires", expires)
         .putHeader("Access-Control-Allow-Methods", methods)
         .putHeader("Access-Control-Max-Age", String.valueOf(oneYearSeconds));
-      setCORS(rc);
+      setCORS(options, rc);
       setJSESSIONID(options, rc);
       rc.response().setStatusCode(204);
       rc.response().end();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -197,7 +197,7 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
       public void handle(RoutingContext rc) {
         rc.response().headers().set("Content-Type", "application/javascript; charset=UTF-8");
 
-        BaseTransport.setCORS(rc);
+        BaseTransport.setCORS(options, rc);
         rc.response().setChunked(true);
 
         Buffer h = buffer(2);
@@ -342,4 +342,3 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
     server.requestHandler(router::accept).listen(8081);
   }
 }
-

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
@@ -141,7 +141,7 @@ class XhrTransport extends BaseTransport {
       rc.response().putHeader("Content-Type", "text/plain; charset=UTF-8");
       setNoCacheHeaders(rc);
       setJSESSIONID(options, rc);
-      setCORS(rc);
+      setCORS(options, rc);
       rc.response().setStatusCode(204);
       rc.response().end();
     }
@@ -162,7 +162,7 @@ class XhrTransport extends BaseTransport {
         HttpServerResponse resp = rc.response();
         resp.putHeader("Content-Type", "application/javascript; charset=UTF-8");
         setJSESSIONID(options, rc);
-        setCORS(rc);
+        setCORS(options, rc);
         if (rc.request().version() != HttpVersion.HTTP_1_0) {
           resp.setChunked(true);
         } else {

--- a/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSHandlerOptions.kt
+++ b/vertx-web/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSHandlerOptions.kt
@@ -7,6 +7,7 @@ import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions
  *
  * Options for configuring a SockJS handler
  *
+ * @param corsHeadersEnabled 
  * @param disabledTransports 
  * @param heartbeatInterval 
  * @param insertJSESSIONID 
@@ -18,6 +19,7 @@ import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions
  * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions original] using Vert.x codegen.
  */
 fun SockJSHandlerOptions(
+  corsHeadersEnabled: Boolean? = null,
   disabledTransports: Iterable<String>? = null,
   heartbeatInterval: Long? = null,
   insertJSESSIONID: Boolean? = null,
@@ -25,6 +27,9 @@ fun SockJSHandlerOptions(
   maxBytesStreaming: Int? = null,
   sessionTimeout: Long? = null): SockJSHandlerOptions = io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions().apply {
 
+  if (corsHeadersEnabled != null) {
+    this.setCorsHeadersEnabled(corsHeadersEnabled)
+  }
   if (disabledTransports != null) {
     for (item in disabledTransports) {
       this.addDisabledTransport(item)


### PR DESCRIPTION
When using a SockJSHandler as per the docs, then every request will have CORS
headers (Access-Control-*). This is not a desirable behavior when trying to
ensure that the browser same-origin policy mechanism is protecting your
users' credentials.

CORS header addition can now be disabled via
SockJSHandlerOptions#setCorsHeadersEnabled(false).

Fixes #649