### PR TITLE
Catch IllegalArgumentException and return false while matching path

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -323,25 +323,27 @@ public class RouteImpl implements Route {
   private boolean pathMatches(String mountPoint, RoutingContext ctx) {
     String thePath = mountPoint == null ? path : mountPoint + path;
     String requestPath;
-
-    if (useNormalisedPath) {
-      // never null
-      requestPath = Utils.normalizePath(ctx.request().path());
-    } else {
-      requestPath = ctx.request().path();
-      // can be null
-      if (requestPath == null) {
-        requestPath = "/";
+    try {
+      if (useNormalisedPath) {
+        // never null
+        requestPath = Utils.normalizePath(ctx.request().path());
+      } else {
+        requestPath = ctx.request().path();
+        // can be null
+        if (requestPath == null) {
+          requestPath = "/";
+        }
       }
-    }
-
-    if (exactPath) {
-      return pathMatchesExact(requestPath, thePath);
-    } else {
-      if (thePath.endsWith("/") && requestPath.equals(removeTrailing(thePath))) {
-        return true;
+      if (exactPath) {
+        return pathMatchesExact(requestPath, thePath);
+      } else {
+        if (thePath.endsWith("/") && requestPath.equals(removeTrailing(thePath))) {
+          return true;
+        }
+        return requestPath.startsWith(thePath);
       }
-      return requestPath.startsWith(thePath);
+    } catch (IllegalArgumentException e) {
+      return false;
     }
   }
 


### PR DESCRIPTION
There is an unhandled `IllegalArgumentException` exception for routes having invalid url encoding like `localhost:8080/%`. 
This exception is being thrown but not handled anywhere. 
https://github.com/vert-x3/vertx-web/blob/17613119fb2c7a0106f79b6751643e76771cc3e8/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java#L107
In this commit, the `pathMatches` function catches it and returns false to the upstream function.