### PR TITLE
ResponseContentTypeHandler does not work well with other handlers

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseContentTypeHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseContentTypeHandlerImpl.java
@@ -17,7 +17,6 @@
 package io.vertx.ext.web.handler.impl;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.ResponseContentTypeHandler;
 
@@ -36,8 +35,7 @@ public class ResponseContentTypeHandlerImpl implements ResponseContentTypeHandle
 
   @Override
   public void handle(RoutingContext rc) {
-    HttpServerResponse response = rc.response();
-    response.headersEndHandler(v -> {
+    rc.addHeadersEndHandler(v -> {
       if (rc.get(disableFlag) != null) {
         return;
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseTimeHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ResponseTimeHandlerImpl.java
@@ -16,20 +16,25 @@
 
 package io.vertx.ext.web.handler.impl;
 
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.ResponseTimeHandler;
+
+import static java.util.concurrent.TimeUnit.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class ResponseTimeHandlerImpl implements ResponseTimeHandler {
 
+  private static final CharSequence HEADER_NAME = HttpHeaders.createOptimized("x-response-time");
+
   @Override
   public void handle(RoutingContext ctx) {
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     ctx.addHeadersEndHandler(v -> {
-      long duration = System.currentTimeMillis() - start;
-      ctx.response().putHeader("x-response-time", duration + "ms");
+      long duration = MILLISECONDS.convert(System.nanoTime() - start, NANOSECONDS);
+      ctx.response().putHeader(HEADER_NAME, duration + "ms");
     });
     ctx.next();
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ResponseContentTypeHandlerTest.java
@@ -39,6 +39,8 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
   public void setUp() throws Exception {
     super.setUp();
     router.route().handler(ResponseContentTypeHandler.create());
+    // Added to make sure ResponseContentTypeHandler works well with others
+    router.route().handler(ResponseTimeHandler.create());
     testRoute = router.route("/test");
   }
 
@@ -64,7 +66,7 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
 
   @Test
   public void testFixedContent() {
-    Buffer buffer = Buffer.buffer(new JsonObject().put("toto", "titi").encode().getBytes());
+    Buffer buffer = new JsonObject().put("toto", "titi").toBuffer();
     testRoute.produces("application/json").handler(rc -> {
       rc.response().end(buffer);
     });
@@ -81,7 +83,7 @@ public class ResponseContentTypeHandlerTest extends WebTestBase {
 
   @Test
   public void testChunkedContent() {
-    Buffer buffer = Buffer.buffer(new JsonObject().put("toto", "titi").encode().getBytes());
+    Buffer buffer = new JsonObject().put("toto", "titi").toBuffer();
     testRoute.produces("application/json").handler(rc -> {
       rc.response().setChunked(true).end(buffer);
     });


### PR DESCRIPTION
Fixes #669

Use RoutingContext.addHeadersEndHandler instead of HttpServerResponse.headersEndHandler

Also, updated ResponseTimeHandler to use:
- System#nanoTime as a matter of accuracy
- an optimized CharSequence header name instead of String