### PR TITLE
use ctx.next instead of fail 404

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -200,8 +200,8 @@ public class StaticHandlerImpl implements StaticHandler {
         }
       } else {
         if (res.cause() instanceof NoSuchFileException || (res.cause().getCause() != null && res.cause().getCause() instanceof NoSuchFileException)) {
-          // this is a special case, we cannot detect that a file does not exist normally, but we by an exception
-          context.fail(NOT_FOUND.code());
+          // this is a special case, we can't handle it as an error
+          context.next();
         } else {
           context.fail(res.cause());
         }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -135,8 +135,8 @@ public class StaticHandlerImpl implements StaticHandler {
       String path = Utils.removeDots(Utils.urlDecode(context.normalisedPath(), false));
       // if the normalized path is null it cannot be resolved
       if (path == null) {
-        log.warn("Invalid path: " + context.request().path() + " so returning 404");
-        context.fail(NOT_FOUND.code());
+        log.warn("Invalid path: " + context.request().path());
+        context.next();
         return;
       }
 
@@ -160,7 +160,8 @@ public class StaticHandlerImpl implements StaticHandler {
       int idx = file.lastIndexOf('/');
       String name = file.substring(idx + 1);
       if (name.length() > 0 && name.charAt(0) == '.') {
-        context.fail(NOT_FOUND.code());
+        // skip
+        context.next();
         return;
       }
     }
@@ -190,7 +191,7 @@ public class StaticHandlerImpl implements StaticHandler {
         FileProps fprops = res.result();
         if (fprops == null) {
           // File does not exist
-          context.fail(NOT_FOUND.code());
+          context.next();
         } else if (fprops.isDirectory()) {
           sendDirectory(context, path, sfile);
         } else {
@@ -199,6 +200,7 @@ public class StaticHandlerImpl implements StaticHandler {
         }
       } else {
         if (res.cause() instanceof NoSuchFileException || (res.cause().getCause() != null && res.cause().getCause() instanceof NoSuchFileException)) {
+          // this is a special case, we cannot detect that a file does not exist normally, but we by an exception
           context.fail(NOT_FOUND.code());
         } else {
           context.fail(res.cause());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -621,28 +621,6 @@ public class StaticHandlerTest extends WebTestBase {
   }
 
   @Test
-  public void testDoubleException() throws Exception {
-    router.clear();
-
-    final AtomicInteger cnt = new AtomicInteger(0);
-
-    router.route("/static/*")
-        .handler(stat)
-        .failureHandler(ctx -> {
-          if (cnt.incrementAndGet() == 1) {
-            vertx.setTimer(100, v -> {
-              ctx.response().end();
-            });
-          }
-
-          System.out.println("HERE!");
-        });
-
-    testRequest(HttpMethod.GET, "/static/non-existent-file.txt", 200, "OK");
-    assertEquals(1, cnt.get());
-  }
-
-  @Test
   public void testLastModifiedInGMT() throws Exception {
     testRequest(HttpMethod.GET, "/otherpage.html", null, res -> {
       String lastModified = res.headers().get("last-modified");
@@ -659,6 +637,15 @@ public class StaticHandlerTest extends WebTestBase {
       assertEquals("text/html;charset=ISO-8859-1", contentType);
     }, 200, "OK", "<html><body>Other page</body></html>");
   }
+
+  @Test
+  public void testHandlerAfter() throws Exception {
+    router.get().handler(ctx -> {
+      ctx.response().end("Howdy!");
+    });
+    testRequest(HttpMethod.GET, "/not-existing-file.html", 200, "OK", "Howdy!");
+  }
+
 
   // TODO
   // 1.Test all the params including invalid values


### PR DESCRIPTION
This does not introduce any breaking change, all the tests are still valid and untouched. The need for this change if for the cases where you want to have a handler **after** the static handler, say a catch all.

These kind of handlers are required for many SPA frameworks which use url paths to perform internal navigation.