### PR TITLE
Router support for MQTT messages

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -51,6 +51,9 @@ public interface Route {
   @Fluent
   Route path(String path);
 
+  @Fluent
+  Route topic(String path);
+
   /**
    * Set the path prefix as a regular expression. If set then this route will only match request URI paths, the beginning
    * of which match the regex. Only a single path or path regex can be set for a route.
@@ -107,6 +110,8 @@ public interface Route {
   @Fluent
   Route handler(Handler<RoutingContext> requestHandler);
 
+  @Fluent
+  Route mqttMessageHandler(Handler<MqttPublishMessage> messageHandler);
 
   /**
    * Like {@link io.vertx.ext.web.Route#blockingHandler(Handler, boolean)} called with ordered = true

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -57,6 +57,8 @@ public interface Router {
    */
   void accept(HttpServerRequest request);
 
+  void accept(MqttPublishMessage request);
+
   /**
    * Add a route with no matching criteria, i.e. it matches all requests or failures.
    *

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -70,6 +70,9 @@ public interface RoutingContext {
   @CacheReturn
   HttpServerResponse response();
 
+  @CacheReturn
+  MqttPublishMessage message();
+
   /**
    * Tell the router to route this context to the next matching route (if any).
    * This method, if called, does not need to be called during the execution of the handler, it can be called
@@ -79,6 +82,8 @@ public interface RoutingContext {
    * will be sent.
    */
   void next();
+
+  void nextMqtt();
 
   /**
    * Fail the context with the specified status code.

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -80,6 +80,13 @@ public class RouterImpl implements Router {
   }
 
   @Override
+  public void accept(MqttPublishMessage message) {
+    if (log.isTraceEnabled()) log.trace("MQTT Router: " + System.identityHashCode(this) +
+      " accepting message from topic " + message.topicName() + " with QoS " + message.qosLevel());
+    new RoutingContextImpl(null, this, message, routes).next();
+  }
+
+  @Override
   public Route route() {
     return new RouteImpl(this, orderSequence.getAndIncrement());
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -155,6 +155,12 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
+  public void nextMqtt() {
+    // make sure the next handler run on the correct context
+    vertx().runOnContext(future -> decoratedContext.next());
+  }
+
+  @Override
   public String normalisedPath() {
     return decoratedContext.normalisedPath();
   }
@@ -187,6 +193,11 @@ public class RoutingContextDecorator implements RoutingContext {
   @Override
   public HttpServerResponse response() {
     return decoratedContext.response();
+  }
+
+  @Override
+  public MqttPublishMessage message() {
+    return decoratedContext.message();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -69,6 +69,15 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     }
   }
 
+  public RoutingContextImpl(String mountPoint, RouterImpl router, MqttPublishMessage message, Set<RouteImpl> routes) {
+    super(mountPoint, message, routes);
+    this.router = router;
+
+    if (request.path().charAt(0) == '/') {
+      // throw Error
+    }
+  }
+
   private String ensureNotNull(String string){
     return string == null ? "" : string;
   }
@@ -96,6 +105,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   }
 
   @Override
+  public MqttPublishMessage message() {
+    return message;
+  }
+
+  @Override
   public HttpServerResponse response() {
     return request.response();
   }
@@ -119,6 +133,13 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public void next() {
     if (!iterateNext()) {
       checkHandleNoMatch();
+    }
+  }
+
+  @Override
+  public void nextMqtt() {
+    if (!iterateNextMqtt()) {
+      // Do Smth
     }
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -64,6 +64,11 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
+  public MqttPublishMessage message() {
+    return inner.message();
+  }
+
+  @Override
   public void fail(int statusCode) {
     inner.fail(statusCode);
   }
@@ -146,6 +151,14 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
 
   @Override
   public void next() {
+    if (!super.iterateNext()) {
+      // We didn't route request to anything so go to parent
+      inner.next();
+    }
+  }
+
+  @Override
+  public void nextMqtt() {
     if (!super.iterateNext()) {
       // We didn't route request to anything so go to parent
       inner.next();

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -149,6 +149,23 @@ public class Utils extends io.vertx.core.impl.Utils {
     return removeDots(ibuf);
   }
 
+  public static String normalizeTopic(String pathname) {
+
+    StringBuilder ibuf = new StringBuilder(pathname.length() + 1);
+
+    ibuf.append(pathname);
+
+    // Not standard!!!
+    if (ibuf.charAt(0) == '/') {
+      ibuf.deleteCharAt(0);
+    }
+
+    // remove dots as described in
+    // http://tools.ietf.org/html/rfc3986#section-5.2.4
+    return removeDots(ibuf);
+  }
+
+
   /**
    * Removed dots as per <a href="http://tools.ietf.org/html/rfc3986#section-5.2.4>rfc3986</a>.
    *


### PR DESCRIPTION
Related to https://github.com/vert-x3/vertx-mqtt/issues/55

This PR is just to inform about changes to support MQTT messages.

As it was mentioned in the issue, the router needs a separate package (with the new changes).
Other option is to copy the relevant router code (with the new changes) to vertx-mqtt.
Thus, leaving vertx-web code unchanged.

Waiting for a decision on this from: @vietj @pmlopes @ppatierno 

Test file: https://gist.github.com/AGutan/6f171403a778f33771f5307e03a3aabf



