### PR TITLE
Support i18n for vertx-web-templ-pebble

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -23,16 +23,18 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.LanguageHeader;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.templ.PebbleTemplateEngine;
 
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * @author Dan Kristensen
+ * @author Jens Klingsporn
  */
 public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTemplate> implements PebbleTemplateEngine {
 
@@ -72,10 +74,16 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
           cache.put(templateFileName, template);
         }
       }
+      final Locale locale = context.acceptableLanguages()
+              .stream()
+              .findFirst()
+                .map(LanguageHeader::value)
+                .map(Locale::forLanguageTag)
+              .orElseGet(Locale::getDefault);
       final Map<String, Object> variables = new HashMap<>(1);
       variables.put("context", context);
       final StringWriter stringWriter = new StringWriter();
-      template.evaluate(stringWriter, variables);
+      template.evaluate(stringWriter, variables, locale);
       handler.handle(Future.succeededFuture(Buffer.buffer(stringWriter.toString())));
     } catch (final Exception ex) {
       handler.handle(Future.failedFuture(ex));

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template-i18n.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template-i18n.peb
@@ -1,0 +1,1 @@
+{{ i18n("messages","greeting") }}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/messages_de_DE.properties
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/messages_de_DE.properties
@@ -1,0 +1,1 @@
+greeting=Hallo

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/messages_en_US.properties
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/messages_en_US.properties
@@ -1,0 +1,1 @@
+greeting=Hi


### PR DESCRIPTION
Forward user's preferred locale to `PebbleTemplateEngine` so one can use [Pebble's i18n function](http://www.mitchellbosecke.com/pebble/documentation/function/i18n) for localization by setting the `Accept-Language` header. 