### PR TITLE
Make PebbleTemplateEngine properly evaluate variables

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/impl/PebbleTemplateEngineImpl.java
@@ -82,6 +82,8 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
               .orElseGet(Locale::getDefault);
       final Map<String, Object> variables = new HashMap<>(1);
       variables.put("context", context);
+      // Pass defined variables in context to engine
+      variables.putAll(context.data());
       final StringWriter stringWriter = new StringWriter();
       template.evaluate(stringWriter, variables, locale);
       handler.handle(Future.succeededFuture(Buffer.buffer(stringWriter.toString())));


### PR DESCRIPTION
The [Pebble documentation](http://www.mitchellbosecke.com/pebble/documentation/guide/basic-usage) states that when you evaluate a template, you can assign values to variables (e.g. `{{ foo }}`) by providing a context object.

The context object referred to in the documentation is "just a map of variables", however the context object passed here is a RoutingContext meaning that in order to access the value for key `foo`, you'd have to do `{{ context.get("foo") }}` instead of the documented `{{ foo }}`.

A simple fix for this would be to add the items defined in `context.data()` to `variables` so that they can be properly evaluated.

See [#698](https://github.com/vert-x3/vertx-web/issues/698)