### PR TITLE
Content-type should be case insensitive.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.handler.impl;
 
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.FileSystem;
@@ -117,8 +118,14 @@ public class BodyHandlerImpl implements BodyHandler {
       Set<FileUpload> fileUploads = context.fileUploads();
 
       final String contentType = context.request().getHeader(HttpHeaders.CONTENT_TYPE);
-      isMultipart = contentType != null && contentType.contains("multipart/form-data");
-      isUrlEncoded = contentType != null && contentType.contains("application/x-www-form-urlencoded");
+      if (contentType == null) {
+        isMultipart = false;
+        isUrlEncoded = false;
+      } else {
+        final String lowerCaseContentType = contentType.toLowerCase();
+        isMultipart = lowerCaseContentType.startsWith(HttpHeaderValues.MULTIPART_FORM_DATA.toString());
+        isUrlEncoded = lowerCaseContentType.startsWith(HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString());
+      }
 
       if (isMultipart || isUrlEncoded) {
         makeUploadDir(context.vertx().fileSystem());

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HeaderParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HeaderParser.java
@@ -99,13 +99,13 @@ public class HeaderParser {
     if (slashIndex < 0) {
       componentCallback.accept("*");
     } else {
-      componentCallback.accept(headerContent.substring(0, slashIndex));
+      componentCallback.accept(headerContent.substring(0, slashIndex).toLowerCase());
     }
 
     if (paramIndex < 0) {
       subcomponentCallback.accept(headerContent.substring(slashIndex + 1));
     } else {
-      subcomponentCallback.accept(headerContent.substring(slashIndex + 1, paramIndex));
+      subcomponentCallback.accept(headerContent.substring(slashIndex + 1, paramIndex).toLowerCase());
     }
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
@@ -313,6 +313,24 @@ public class BodyHandlerTest extends WebTestBase {
   }
 
   @Test
+  public void testFormContentTypeIgnoreCase() throws Exception {
+    router.route().handler(rc -> {
+      MultiMap attrs = rc.request().formAttributes();
+      assertNotNull(attrs);
+      assertEquals(1, attrs.size());
+      assertEquals("junit-testUserAlias", attrs.get("origin"));
+      rc.response().end();
+    });
+    testRequest(HttpMethod.POST, "/", req -> {
+      Buffer buffer = Buffer.buffer();
+      buffer.appendString("origin=junit-testUserAlias");
+      req.headers().set("content-length", String.valueOf(buffer.length()));
+      req.headers().set("content-type", "ApPlIcAtIoN/x-WwW-fOrM-uRlEnCoDeD");
+      req.write(buffer);
+    }, 200, "OK", null);
+  }
+
+  @Test
   public void testFormMultipartFormDataMergeAttributesDefault() throws Exception {
     testFormMultipartFormData(true);
   }


### PR DESCRIPTION
The first part of the content-type header should be case insensitive.
This is already correctly implemented in the Http(2)ServerRequestImpl.

We detected this problem when upstepping from vertx 3.2 where the behavior of vertx was correct.