### PR TITLE
Fixed IllegalStateException bug when wrong url of specification

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
@@ -91,13 +91,15 @@ public interface OpenAPI3RouterFactory extends DesignDrivenRouterFactory<OpenAPI
     handler) {
     vertx.executeBlocking((Future<OpenAPI3RouterFactory> future) -> {
       File spec = new File(filename);
-      if (!spec.exists())
+      if (!spec.exists()) {
         future.fail(RouterFactoryException.createSpecNotExistsException(filename));
-      SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(spec.getAbsolutePath(), null, null);
-
-      if (swaggerParseResult.getMessages().isEmpty()) future.complete(new OpenAPI3RouterFactoryImpl(vertx, swaggerParseResult.getOpenAPI()));
-      else {
-          future.fail(RouterFactoryException.createSpecInvalidException(StringUtils.join(swaggerParseResult.getMessages(),", ")));
+      } else {
+        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(spec.getAbsolutePath(), null, null);
+        if (swaggerParseResult.getMessages().isEmpty())
+          future.complete(new OpenAPI3RouterFactoryImpl(vertx, swaggerParseResult.getOpenAPI()));
+        else {
+          future.fail(RouterFactoryException.createSpecInvalidException(StringUtils.join(swaggerParseResult.getMessages(), ", ")));
+        }
       }
     }, handler);
   }


### PR DESCRIPTION
When loading specification with wrong url, future.fail was fired two times and returns an IllegalStateException