### PR TITLE
Fix for #720 - Remove preemptive handling of filename parameter

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
@@ -17,6 +17,7 @@ import io.vertx.ext.web.api.contract.openapi3.impl.OpenAPI3RouterFactoryImpl;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.util.Objects;
 
 /**
  * Interface for OpenAPI3RouterFactory. <br/>
@@ -89,11 +90,12 @@ public interface OpenAPI3RouterFactory extends DesignDrivenRouterFactory<OpenAPI
    */
   static void createRouterFactoryFromFile(Vertx vertx, String filename, Handler<AsyncResult<OpenAPI3RouterFactory>>
     handler) {
+    Objects.requireNonNull(vertx);
+    Objects.requireNonNull(filename);
+    Objects.requireNonNull(handler);
+
     vertx.executeBlocking((Future<OpenAPI3RouterFactory> future) -> {
-      File spec = new File(filename);
-      if (!spec.exists())
-        future.fail(RouterFactoryException.createSpecNotExistsException(filename));
-      SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(spec.getAbsolutePath(), null, null);
+      SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(filename, null, null);
 
       if (swaggerParseResult.getMessages().isEmpty()) future.complete(new OpenAPI3RouterFactoryImpl(vertx, swaggerParseResult.getOpenAPI()));
       else {

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.api.contract.openapi3;
 
+import com.google.common.io.Resources;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
@@ -122,5 +123,38 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
 
     stopServer();
 
+  }
+
+  @Test
+  public void loadInvalidFilePathDoesntResultInSevereException() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.createRouterFactoryFromFile(this.vertx, "some/bad/test/path.yaml",
+      openAPI3RouterFactoryAsyncResult -> {
+        assertTrue(openAPI3RouterFactoryAsyncResult.failed());
+        latch.countDown();
+      });
+    awaitLatch(latch);
+  }
+
+  @Test
+  public void loadInvalidUrlDoesntResultInSevereException() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.createRouterFactoryFromFile(this.vertx, "http://some/bad/test/url.yaml",
+      openAPI3RouterFactoryAsyncResult -> {
+        assertTrue(openAPI3RouterFactoryAsyncResult.failed());
+        latch.countDown();
+      });
+    awaitLatch(latch);
+  }
+
+  @Test
+  public void loadSwaggerFromResources() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.createRouterFactoryFromFile(this.vertx, Resources.getResource("swaggers/testSpec.yaml").toString(),
+      openAPI3RouterFactoryAsyncResult -> {
+        assertTrue(openAPI3RouterFactoryAsyncResult.succeeded());
+        latch.countDown();
+      });
+    awaitLatch(latch);
   }
 }


### PR DESCRIPTION
Handling filename parameter as a File severely limits the support of the OpenApiV3Parser.

Parser has full support for URLs (including file paths, resources, web, etc). Code now simply verifies some url was provided and passes it along to the parser.
All parser errors are already handled by the return processing.

Fixes #720 

Signed-off-by: Jeff Taylor <jtaylor@finovertech.com>