### PR TITLE
Add fail as a reply function to vertx-eventbus.js

### DIFF
--- a/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/SockJSProxyTestBase.java
+++ b/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/SockJSProxyTestBase.java
@@ -1,0 +1,42 @@
+package io.vertx.serviceproxy;
+
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+import io.vertx.test.core.VertxTestBase;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SockJSProxyTestBase extends VertxTestBase {
+  private HttpServer server;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    // create bridge for sockjs-client proxy messages
+    SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
+    BridgeOptions allAccessOptions =
+      new BridgeOptions().addInboundPermitted(new PermittedOptions()).addOutboundPermitted(new PermittedOptions());
+    sockJSHandler.bridge(allAccessOptions);
+    Router router = Router.router(vertx);
+    router.route("/eventbus/*").handler(sockJSHandler);
+    HttpServerOptions serverOptions = new HttpServerOptions().setPort(8080).setHost("localhost");
+    server = vertx.createHttpServer(serverOptions);
+    CountDownLatch latch = new CountDownLatch(1);
+    server.requestHandler(router::accept).listen(onSuccess(res -> latch.countDown()));
+    awaitLatch(latch);
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    CountDownLatch latch = new CountDownLatch(1);
+    server.close(res -> {
+      assertTrue(res.succeeded());
+      latch.countDown();
+    });
+  }
+}

--- a/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/test/JSBusTest.java
+++ b/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/test/JSBusTest.java
@@ -1,7 +1,7 @@
 package io.vertx.serviceproxy.test;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.test.core.VertxTestBase;
+import io.vertx.serviceproxy.SockJSProxyTestBase;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class JSBusTest extends VertxTestBase {
+public class JSBusTest extends SockJSProxyTestBase {
 
   @Test
   public void testBusReconnect() {

--- a/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
+++ b/vertx-sockjs-service-proxy/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
@@ -4,14 +4,14 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.Addresses;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.SockJSProxyTestBase;
 import io.vertx.serviceproxy.testmodel.TestService;
-import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class JSServiceProxyTest extends VertxTestBase {
+public class JSServiceProxyTest extends SockJSProxyTestBase {
 
   TestService service;
   MessageConsumer<JsonObject> consumer;

--- a/vertx-sockjs-service-proxy/src/test/resources/bus_test_fail.js
+++ b/vertx-sockjs-service-proxy/src/test/resources/bus_test_fail.js
@@ -1,0 +1,8 @@
+var EventBus = require('vertx-js/vertx-eventbus');
+var bus = new EventBus();
+
+bus.onopen = function () {
+  bus.send("client_registered", {}, function (err, res) {
+    res.fail(520, "client_failure_message");
+  });
+};

--- a/vertx-sockjs-service-proxy/src/test/resources/sockjs-client.js
+++ b/vertx-sockjs-service-proxy/src/test/resources/sockjs-client.js
@@ -2,109 +2,37 @@
  * This is a Proxy to emulate the SockJS client
  */
 
-function wrapBody(body) {
-  var json = JSON.stringify(body);
-  return new Packages.io.vertx.core.json.JsonObject(json);
-}
-
-function unwrapMsg(msg) {
-  var json = new Packages.io.vertx.core.json.JsonObject();
-  var headers = new Packages.io.vertx.core.json.JsonObject();
-  var msgHeaders = msg.headers();
-  for (var i = msgHeaders.names().iterator();i.hasNext();) {
-    var headerName = i.next();
-    headers.put(headerName, msgHeaders.get(headerName));
-  }
-  json.put("body", msg.body());
-  json.put("headers", headers);
-  return JSON.parse(json.encode());
-}
-
-function wrapHeaders(headers) {
-  var ret = new Packages.io.vertx.core.eventbus.DeliveryOptions();
-  if (typeof headers !== 'undefined') {
-    for (var name in headers) {
-      if (headers.hasOwnProperty(name)) {
-        ret.addHeader(name, headers[name]);
-      }
-    }
-  }
-  return ret;
-}
-
-function unwrapError(err) {
-  return {
-    "failureType" : err.failureType().name(),
-    "failureCode" : err.failureCode(),
-    "message": err.getMessage()
-  };
-}
-
 function SockJS() {
   var self = this;
-  setTimeout(function () {
+  self.client = vertx.createHttpClient({ defaultPort: 8080 });
+  self.client.websocket("/eventbus/websocket", function (ws) {
+    self.ws = ws;
+    self.ws.handler(function (buffer) {
+      self.onmessage && self.onmessage({ data: buffer.toString() });
+    });
+    self.ws.closeHandler(function (e) {
+      self.onclose && self.onclose(e);
+    });
     self.onopen && self.onopen();
-  }, 1);
+  }, function (e) {
+    self.onclose && self.onclose(e)
+  });
 }
 
-SockJS.prototype.send = function(string) {
-  var json = JSON.parse(string);
-  var self = this;
-
-  if (json.type === 'ping') {
-    return;
+SockJS.prototype.send = function (str) {
+  if (this.ws === undefined) {
+    throw "INVALID_STATE_ERR";
   }
-
-  var address = json.address;
-  var headers = json.headers && wrapHeaders(json.headers);
-  var message = wrapBody(json.body);
-
-  var handler = function (ar) {
-    if (ar.failed()) {
-      var err = unwrapError(ar.cause());
-      err.type = 'err';
-
-      if (json.replyAddress) {
-        err.address = json.replyAddress;
-      }
-      // error messages are always delivered
-      self.onmessage && self.onmessage({data: JSON.stringify(err)});
-    } else {
-      var result = unwrapMsg(ar.result());
-
-      if (json.replyAddress) {
-        result.address = json.replyAddress;
-        self.onmessage && self.onmessage({data: JSON.stringify(result)});
-      }
-    }
-  };
-
-  if (address) {
-    var eb = vertx._jdel.eventBus();
-
-    switch (json.type) {
-      case 'send':
-        if (headers) {
-          eb.send(address, message, headers, handler)
-        } else {
-          eb.send(address, message, handler)
-        }
-        break;
-      case 'publish':
-        if (headers) {
-          eb.publish(address, message, headers)
-        } else {
-          eb.publish(address, message)
-        }
-        break;
-      default:
-        throw new Error('Can not understand ' + json.type);
-    }
-  }
+  this.ws.writeTextMessage(str);
 };
 
-SockJS.prototype.close = function() {
-  this.onclose && this.onclose();
+SockJS.prototype.close = function () {
+  if (this.ws) {
+    this.ws.close();
+  }
+  if (this.client) {
+    this.client.close();
+  }
 };
 
 module.exports = SockJS;


### PR DESCRIPTION
This PR adds fail method to eventbus client messages and closes #619.

It also changes how tests run in serviceproxy module. Testing vertx-eventbus.js with existing sockjs-client.js proxy was not possible, so I implemented a new proxy which delivers messages over SockJS bridge. I believe this will allow us to add tests for other client methods such as register, reply etc. without any modifications in the test base.