### PR TITLE
Issue #724 - Changed json and xml media type checks to be contains like the rest.

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -68,7 +68,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
         if (contentType.contains("application/x-www-form-urlencoded") || contentType.contains("multipart/form-data")) {
           parsedParameters.setFormParameters(validateFormParams(routingContext));
           if (contentType.contains("multipart/form-data")) validateFileUpload(routingContext);
-        } else if (contentType.equals("application/json") || contentType.equals("application/xml"))
+        } else if (contentType.contains("application/json") || contentType.contains("application/xml"))
           parsedParameters.setBody(validateEntireBody(routingContext));
         else {
           routingContext.fail(400);

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/contract/openapi3/OpenAPI3ValidationTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/contract/openapi3/OpenAPI3ValidationTest.java
@@ -1,9 +1,12 @@
 package io.vertx.ext.web.api.contract.openapi3;
 
+import com.google.common.net.MediaType;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.swagger.oas.models.OpenAPI;
 import io.swagger.oas.models.Operation;
 import io.swagger.parser.v3.OpenAPIV3Parser;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.api.RequestParameter;
@@ -19,6 +22,7 @@ import org.junit.rules.ExternalResource;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * @author Francesco Guardiani @slinkydeveloper
@@ -237,7 +241,15 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
       valuesArray.add(getSuccessSample(ParameterType.INT).getInteger());
     object.put("values", valuesArray);
 
-    testRequestWithJSON(HttpMethod.POST, "/jsonBodyTest/sampleTest", object, 200, object.encode());
+    String serialized = object.encode();
+
+    testRequestWithJSON(HttpMethod.POST, "/jsonBodyTest/sampleTest", object, 200, serialized);
+
+    Consumer<HttpClientRequest> jsonWithEncoding = r -> r.putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8.toString())
+      .putHeader(HttpHeaderNames.CONTENT_LENGTH,"" + serialized.getBytes().length)
+      .write(serialized);
+    
+    testRequest(HttpMethod.POST, "/jsonBodyTest/sampleTest", jsonWithEncoding, 200, serialized, null);
   }
 
   @Test


### PR DESCRIPTION
All other media type checks used `.contains` and the json & xml one uses an `equals` check for some reason. Equals won't work since both may specify encoding or even have trailing `;`. 

Quick win fix was to change the checks in that if block to be `contains` like the other. 

Fixes #724 