### PR TITLE
Patch x-www-form-urlencoded

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/groovy/index.adoc
@@ -1,124 +1,17 @@
 = Vert.x-Web API Contract
 :toc: left
 
-Vert.x-Web API Contract brings to Vert.x two features to help you to develop you API:
-
-* HTTP Requests validation
-* OpenAPI 3 Support with automatic requests validation
-
-== Using Vert.x API Contract
-
-To use Vert.x API Contract, add the following dependency to the _dependencies_ section of your build descriptor:
-
-* Maven (in your `pom.xml`):
-
-[source,xml,subs="+attributes"]
-----
-<dependency>
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-web-api-contract</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
-</dependency>
-----
-
-* Gradle (in your `build.gradle` file):
-
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  compile 'io.vertx:vertx-web-api-contract:3.5.1-SNAPSHOT'
-}
-----
-
-== HTTP Requests validation
-
-Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container.
-
-To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
-[source,groovy]
-----
-// Create Validation Handler with some stuff
-def validationHandler = HTTPRequestValidationHandler.create().addQueryParam("parameterName", ParameterType.INT, true).addFormParamWithPattern("formParameterName", "a{4}", true).addPathParam("pathParam", ParameterType.FLOAT)
-
-----
-
-Then you can mount your validation handler:
-[source,groovy]
-----
-// BodyHandler is required to manage body parameters like forms or json body
-router.route().handler(BodyHandler.create())
-
-router.get("/awesome/:pathParam").handler(validationHandler).handler({ routingContext ->
-  // Get Request parameters container
-  def params = routingContext.get("parsedParameters")
-
-  // Get parameters
-  def parameterName = params.queryParameter("parameterName").getInteger()
-  def formParameterName = params.formParameter("formParameterName").getString()
-  def pathParam = params.pathParameter("pathParam").getFloat()
-}).failureHandler({ routingContext ->
-  def failure = routingContext.failure()
-  if (failure instanceof io.vertx.ext.web.api.validation.ValidationException) {
-    // Something went wrong during validation!
-    def validationErrorMessage = failure.getMessage()
-  }
-})
-
-----
-
-If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
-
-=== Types of request parameters
-Every parameter has a type validator, a class that describes the expected type of parameter.
-A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
-
-* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
-* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
-* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
-
-=== Handling parameters
-Now you can handle parameter values:
-
-[source,groovy]
-----
-def params = routingContext.get("parsedParameters")
-def awesomeParameter = params.queryParameter("awesomeParameter")
-if (awesomeParameter != null) {
-  if (!awesomeParameter.isEmpty()) {
-    // Parameter exists and isn't empty
-    // ParameterTypeValidator mapped the parameter in equivalent language object
-    def awesome = awesomeParameter.getInteger()
-  } else {
-    // Parameter exists, but it's empty
-  }
-} else {
-  // Parameter doesn't exist (it's not required)
-}
-
-----
-
-As you can see, every parameter is mapped in respective language objects. You can also get a json body:
-
-[source,groovy]
-----
-def body = params.body()
-if (body != null) {
-  def jsonBody = body.getJsonObject()
-}
-
-----
-
 == OpenAPI 3 support
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
+Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach.
+
+Vert.x-Web provides:
 
 * OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
 * Automatic 501 response for not implemented operations
 * Router factory to provide all these features to users
-
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
 
 === The router factory
 You can create your web service based on OpenAPI3 specification with `link:../../apidocs/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.html[OpenAPI3RouterFactory]`.
@@ -141,16 +34,7 @@ To create a new router factory, you can use methods inside `link:../../apidocs/i
 For example:
 [source,groovy]
 ----
-OpenAPI3RouterFactory.createRouterFactoryFromFile(vertx, "src/main/resources/petstore.yaml", { ar ->
-  if (ar.succeeded()) {
-    // Spec loaded with success
-    def routerFactory = ar.result()
-  } else {
-    // Something went wrong during router factory initialization
-    def exception = ar.cause()
-  }
-})
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#constructRouterFactory-io.vertx.core.Vertx-[constructRouterFactory]`
 ----
 
 === Mount the handlers
@@ -172,22 +56,13 @@ IMPORTANT: If you want to use `link:../../apidocs/io/vertx/ext/web/api/contract/
 For example:
 [source,groovy]
 ----
-routerFactory.addHandlerByOperationId("awesomeOperation", { routingContext ->
-  def params = routingContext.get("parsedParameters")
-  def body = params.body()
-  def jsonBody = body.getJsonObject()
-  // Do something with body
-})
-routerFactory.addFailureHandlerByOperationId("awesomeOperation", { routingContext ->
-  // Handle failure
-})
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addRoute-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[addRoute]`
 ----
 
 .Add operations with operationId
 IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
 
-Now you can use parameter values as described above
+Now you can use parameter values as described in http://vertx.io/docs/vertx-web/java/#_andling_parameters[vertx-web documentation]
 
 == Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
@@ -195,16 +70,14 @@ For example:
 
 [source,groovy]
 ----
-routerFactory.addSecurityHandler("security_scheme_name", securityHandler)
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addSecurityHandler-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.core.Handler-[addSecurityHandler]`
 ----
 
 You can of course use included Vert.x security handlers, for example:
 
 [source,groovy]
 ----
-routerFactory.addSecurityHandler("jwt_auth", JWTAuthHandler.create(jwtAuthProvider))
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addJWT-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.ext.auth.jwt.JWTAuth-[addJWT]`
 ----
 
 === Error handling
@@ -218,12 +91,44 @@ When you are ready, generate the router and use it:
 
 [source,groovy]
 ----
-def router = routerFactory.getRouter()
+`link:../../apidocs/examples/OpenAPI3Examples.html#generateRouter-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[generateRouter]`
+----
 
-def server = vertx.createHttpServer([
-  port:8080,
-  host:"localhost"
-])
-server.requestHandler(router.&accept).listen()
+== Requests validation
 
+Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
+[source,groovy]
+----
+`link:../../apidocs/examples/WebExamples.html#example63-io.vertx.core.Vertx-io.vertx.ext.web.Router-[example63]`
+----
+
+Then you can mount your validation handler:
+[source,groovy]
+----
+`link:../../apidocs/examples/WebExamples.html#example64-io.vertx.core.Vertx-io.vertx.ext.web.Router-io.vertx.ext.web.api.validation.HTTPRequestValidationHandler-[example64]`
+----
+
+If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
+
+=== Types of request parameters
+Every parameter has a type validator, a class that describes the expected type of parameter.
+A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
+
+* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
+* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
+* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
+
+=== Handling parameters
+Now you can handle parameter values:
+
+[source,groovy]
+----
+`link:../../apidocs/examples/WebExamples.html#example65-io.vertx.ext.web.RoutingContext-[example65]`
+----
+
+As you can see, every parameter is mapped in respective language objects. You can also get a json body:
+
+[source,groovy]
+----
+`link:../../apidocs/examples/WebExamples.html#example66-io.vertx.ext.web.api.RequestParameters-[example66]`
 ----

--- a/vertx-web-api-contract/src/main/asciidoc/java/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/java/index.adoc
@@ -1,125 +1,17 @@
 = Vert.x-Web API Contract
 :toc: left
 
-Vert.x-Web API Contract brings to Vert.x two features to help you to develop you API:
-
-* HTTP Requests validation
-* OpenAPI 3 Support with automatic requests validation
-
-== Using Vert.x API Contract
-
-To use Vert.x API Contract, add the following dependency to the _dependencies_ section of your build descriptor:
-
-* Maven (in your `pom.xml`):
-
-[source,xml,subs="+attributes"]
-----
-<dependency>
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-web-api-contract</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
-</dependency>
-----
-
-* Gradle (in your `build.gradle` file):
-
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  compile 'io.vertx:vertx-web-api-contract:3.5.1-SNAPSHOT'
-}
-----
-
-== HTTP Requests validation
-
-Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container.
-
-To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
-[source,java]
-----
-HTTPRequestValidationHandler validationHandler = HTTPRequestValidationHandler.create().addQueryParam("parameterName", ParameterType.INT, true).addFormParamWithPattern("formParameterName", "a{4}", true).addPathParam("pathParam", ParameterType.FLOAT);
-----
-
-Then you can mount your validation handler:
-[source,java]
-----
-router.route().handler(BodyHandler.create());
-
-router.get("/awesome/:pathParam")
-  // Mount validation handler
-  .handler(validationHandler)
-  //Mount your handler
-  .handler((routingContext) -> {
-    // Get Request parameters container
-    RequestParameters params = routingContext.get("parsedParameters");
-
-    // Get parameters
-    Integer parameterName = params.queryParameter("parameterName").getInteger();
-    String formParameterName = params.formParameter("formParameterName").getString();
-    Float pathParam = params.pathParameter("pathParam").getFloat();
-  })
-
-  //Mount your failure handler
-  .failureHandler((routingContext) -> {
-    Throwable failure = routingContext.failure();
-    if (failure instanceof ValidationException) {
-      // Something went wrong during validation!
-      String validationErrorMessage = failure.getMessage();
-    }
-  });
-----
-
-If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
-
-=== Types of request parameters
-Every parameter has a type validator, a class that describes the expected type of parameter.
-A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
-
-* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
-* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
-* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
-
-=== Handling parameters
-Now you can handle parameter values:
-
-[source,java]
-----
-RequestParameters params = routingContext.get("parsedParameters");
-RequestParameter awesomeParameter = params.queryParameter("awesomeParameter");
-if (awesomeParameter != null) {
-  if (!awesomeParameter.isEmpty()) {
-    // Parameter exists and isn't empty
-    // ParameterTypeValidator mapped the parameter in equivalent language object
-    Integer awesome = awesomeParameter.getInteger();
-  } else {
-    // Parameter exists, but it's empty
-  }
-} else {
-  // Parameter doesn't exist (it's not required)
-}
-----
-
-As you can see, every parameter is mapped in respective language objects. You can also get a json body:
-
-[source,java]
-----
-RequestParameter body = params.body();
-if (body != null) {
-  JsonObject jsonBody = body.getJsonObject();
-}
-----
-
 == OpenAPI 3 support
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
+Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach.
+
+Vert.x-Web provides:
 
 * OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
 * Automatic 501 response for not implemented operations
 * Router factory to provide all these features to users
-
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
 
 === The router factory
 You can create your web service based on OpenAPI3 specification with `link:../../apidocs/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.html[OpenAPI3RouterFactory]`.
@@ -142,15 +34,7 @@ To create a new router factory, you can use methods inside `link:../../apidocs/i
 For example:
 [source,java]
 ----
-OpenAPI3RouterFactory.createRouterFactoryFromFile(vertx, "src/main/resources/petstore.yaml", ar -> {
-  if (ar.succeeded()) {
-    // Spec loaded with success
-    OpenAPI3RouterFactory routerFactory = ar.result();
-  } else {
-    // Something went wrong during router factory initialization
-    Throwable exception = ar.cause();
-  }
-});
+`link:../../apidocs/examples/OpenAPI3Examples.html#constructRouterFactory-io.vertx.core.Vertx-[constructRouterFactory]`
 ----
 
 === Mount the handlers
@@ -172,21 +56,13 @@ IMPORTANT: If you want to use `link:../../apidocs/io/vertx/ext/web/api/contract/
 For example:
 [source,java]
 ----
-routerFactory.addHandlerByOperationId("awesomeOperation", routingContext -> {
-  RequestParameters params = routingContext.get("parsedParameters");
-  RequestParameter body = params.body();
-  JsonObject jsonBody = body.getJsonObject();
-  // Do something with body
-});
-routerFactory.addFailureHandlerByOperationId("awesomeOperation", routingContext -> {
-  // Handle failure
-});
+`link:../../apidocs/examples/OpenAPI3Examples.html#addRoute-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[addRoute]`
 ----
 
 .Add operations with operationId
 IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
 
-Now you can use parameter values as described above
+Now you can use parameter values as described in http://vertx.io/docs/vertx-web/java/#_andling_parameters[vertx-web documentation]
 
 == Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
@@ -194,14 +70,14 @@ For example:
 
 [source,java]
 ----
-routerFactory.addSecurityHandler("security_scheme_name", securityHandler);
+`link:../../apidocs/examples/OpenAPI3Examples.html#addSecurityHandler-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.core.Handler-[addSecurityHandler]`
 ----
 
 You can of course use included Vert.x security handlers, for example:
 
 [source,java]
 ----
-routerFactory.addSecurityHandler("jwt_auth", JWTAuthHandler.create(jwtAuthProvider));
+`link:../../apidocs/examples/OpenAPI3Examples.html#addJWT-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.ext.auth.jwt.JWTAuth-[addJWT]`
 ----
 
 === Error handling
@@ -215,8 +91,44 @@ When you are ready, generate the router and use it:
 
 [source,java]
 ----
-Router router = routerFactory.getRouter();
+`link:../../apidocs/examples/OpenAPI3Examples.html#generateRouter-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[generateRouter]`
+----
 
-HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"));
-server.requestHandler(router::accept).listen();
+== Requests validation
+
+Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
+[source,java]
+----
+`link:../../apidocs/examples/WebExamples.html#example63-io.vertx.core.Vertx-io.vertx.ext.web.Router-[example63]`
+----
+
+Then you can mount your validation handler:
+[source,java]
+----
+`link:../../apidocs/examples/WebExamples.html#example64-io.vertx.core.Vertx-io.vertx.ext.web.Router-io.vertx.ext.web.api.validation.HTTPRequestValidationHandler-[example64]`
+----
+
+If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
+
+=== Types of request parameters
+Every parameter has a type validator, a class that describes the expected type of parameter.
+A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
+
+* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
+* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
+* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
+
+=== Handling parameters
+Now you can handle parameter values:
+
+[source,java]
+----
+`link:../../apidocs/examples/WebExamples.html#example65-io.vertx.ext.web.RoutingContext-[example65]`
+----
+
+As you can see, every parameter is mapped in respective language objects. You can also get a json body:
+
+[source,java]
+----
+`link:../../apidocs/examples/WebExamples.html#example66-io.vertx.ext.web.api.RequestParameters-[example66]`
 ----

--- a/vertx-web-api-contract/src/main/asciidoc/js/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/js/index.adoc
@@ -1,126 +1,17 @@
 = Vert.x-Web API Contract
 :toc: left
 
-Vert.x-Web API Contract brings to Vert.x two features to help you to develop you API:
-
-* HTTP Requests validation
-* OpenAPI 3 Support with automatic requests validation
-
-== Using Vert.x API Contract
-
-To use Vert.x API Contract, add the following dependency to the _dependencies_ section of your build descriptor:
-
-* Maven (in your `pom.xml`):
-
-[source,xml,subs="+attributes"]
-----
-<dependency>
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-web-api-contract</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
-</dependency>
-----
-
-* Gradle (in your `build.gradle` file):
-
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  compile 'io.vertx:vertx-web-api-contract:3.5.1-SNAPSHOT'
-}
-----
-
-== HTTP Requests validation
-
-Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container.
-
-To define a `link:../../jsdoc/module-vertx-web-api-contract-js_http_request_validation_handler-HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
-[source,js]
-----
-var HTTPRequestValidationHandler = require("vertx-web-api-contract-js/http_request_validation_handler");
-// Create Validation Handler with some stuff
-var validationHandler = HTTPRequestValidationHandler.create().addQueryParam("parameterName", 'INT', true).addFormParamWithPattern("formParameterName", "a{4}", true).addPathParam("pathParam", 'FLOAT');
-
-----
-
-Then you can mount your validation handler:
-[source,js]
-----
-var BodyHandler = require("vertx-web-js/body_handler");
-// BodyHandler is required to manage body parameters like forms or json body
-router.route().handler(BodyHandler.create().handle);
-
-router.get("/awesome/:pathParam").handler(validationHandler.handle).handler(function (routingContext) {
-  // Get Request parameters container
-  var params = routingContext.get("parsedParameters");
-
-  // Get parameters
-  var parameterName = params.queryParameter("parameterName").getInteger();
-  var formParameterName = params.formParameter("formParameterName").getString();
-  var pathParam = params.pathParameter("pathParam").getFloat();
-}).failureHandler(function (routingContext) {
-  var failure = routingContext.failure();
-  if (failure.getClass().getSimpleName() == 'ValidationException') {
-    // Something went wrong during validation!
-    var validationErrorMessage = failure.getMessage();
-  }
-});
-
-----
-
-If validation succeeds, It returns request parameters inside `link:../../jsdoc/module-vertx-web-api-contract-js_request_parameters-RequestParameters.html[RequestParameters]`, otherwise It will throw a `ValidationException`
-
-=== Types of request parameters
-Every parameter has a type validator, a class that describes the expected type of parameter.
-A type validator validates the value, casts it in required language type and then loads it inside a `link:../../jsdoc/module-vertx-web-api-contract-js_request_parameter-RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
-
-* There is a set of prebuilt types that you can use: `link:../enums.html#ParameterType[ParameterType]`
-* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../jsdoc/module-vertx-web-api-contract-js_parameter_type_validator-ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../jsdoc/module-vertx-web-api-contract-js_http_request_validation_handler-HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
-* You can create your own `ParameterTypeValidator` implementing `link:../../jsdoc/module-vertx-web-api-contract-js_parameter_type_validator-ParameterTypeValidator.html[ParameterTypeValidator]` interface
-
-=== Handling parameters
-Now you can handle parameter values:
-
-[source,js]
-----
-var params = routingContext.get("parsedParameters");
-var awesomeParameter = params.queryParameter("awesomeParameter");
-if ((awesomeParameter !== null && awesomeParameter !== undefined)) {
-  if (!awesomeParameter.isEmpty()) {
-    // Parameter exists and isn't empty
-    // ParameterTypeValidator mapped the parameter in equivalent language object
-    var awesome = awesomeParameter.getInteger();
-  } else {
-    // Parameter exists, but it's empty
-  }
-} else {
-  // Parameter doesn't exist (it's not required)
-}
-
-----
-
-As you can see, every parameter is mapped in respective language objects. You can also get a json body:
-
-[source,js]
-----
-var body = params.body();
-if ((body !== null && body !== undefined)) {
-  var jsonBody = body.getJsonObject();
-}
-
-----
-
 == OpenAPI 3 support
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
+Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach.
+
+Vert.x-Web provides:
 
 * OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
 * Automatic 501 response for not implemented operations
 * Router factory to provide all these features to users
-
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
 
 === The router factory
 You can create your web service based on OpenAPI3 specification with `link:../../jsdoc/module-vertx-web-api-contract-js_open_api3_router_factory-OpenAPI3RouterFactory.html[OpenAPI3RouterFactory]`.
@@ -143,17 +34,7 @@ To create a new router factory, you can use methods inside `link:../../jsdoc/mod
 For example:
 [source,js]
 ----
-var OpenAPI3RouterFactory = require("vertx-web-api-contract-js/open_api3_router_factory");
-OpenAPI3RouterFactory.createRouterFactoryFromFile(vertx, "src/main/resources/petstore.yaml", function (ar, ar_err) {
-  if (ar_err == null) {
-    // Spec loaded with success
-    var routerFactory = ar;
-  } else {
-    // Something went wrong during router factory initialization
-    var exception = ar_err;
-  }
-});
-
+`constructRouterFactory`
 ----
 
 === Mount the handlers
@@ -175,22 +56,13 @@ IMPORTANT: If you want to use `link:../../jsdoc/module-vertx-web-api-contract-js
 For example:
 [source,js]
 ----
-routerFactory.addHandlerByOperationId("awesomeOperation", function (routingContext) {
-  var params = routingContext.get("parsedParameters");
-  var body = params.body();
-  var jsonBody = body.getJsonObject();
-  // Do something with body
-});
-routerFactory.addFailureHandlerByOperationId("awesomeOperation", function (routingContext) {
-  // Handle failure
-});
-
+`addRoute`
 ----
 
 .Add operations with operationId
 IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
 
-Now you can use parameter values as described above
+Now you can use parameter values as described in http://vertx.io/docs/vertx-web/java/#_andling_parameters[vertx-web documentation]
 
 == Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
@@ -198,17 +70,14 @@ For example:
 
 [source,js]
 ----
-routerFactory.addSecurityHandler("security_scheme_name", securityHandler);
-
+`addSecurityHandler`
 ----
 
 You can of course use included Vert.x security handlers, for example:
 
 [source,js]
 ----
-var JWTAuthHandler = require("vertx-web-js/jwt_auth_handler");
-routerFactory.addSecurityHandler("jwt_auth", JWTAuthHandler.create(jwtAuthProvider).handle);
-
+`addJWT`
 ----
 
 === Error handling
@@ -222,12 +91,44 @@ When you are ready, generate the router and use it:
 
 [source,js]
 ----
-var router = routerFactory.getRouter();
+`generateRouter`
+----
 
-var server = vertx.createHttpServer({
-  "port" : 8080,
-  "host" : "localhost"
-});
-server.requestHandler(router.accept).listen();
+== Requests validation
 
+Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a `link:../../jsdoc/module-vertx-web-api-contract-js_http_request_validation_handler-HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
+[source,js]
+----
+`example63`
+----
+
+Then you can mount your validation handler:
+[source,js]
+----
+`example64`
+----
+
+If validation succeeds, It returns request parameters inside `link:../../jsdoc/module-vertx-web-api-contract-js_request_parameters-RequestParameters.html[RequestParameters]`, otherwise It will throw a `ValidationException`
+
+=== Types of request parameters
+Every parameter has a type validator, a class that describes the expected type of parameter.
+A type validator validates the value, casts it in required language type and then loads it inside a `link:../../jsdoc/module-vertx-web-api-contract-js_request_parameter-RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
+
+* There is a set of prebuilt types that you can use: `link:../enums.html#ParameterType[ParameterType]`
+* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../jsdoc/module-vertx-web-api-contract-js_parameter_type_validator-ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../jsdoc/module-vertx-web-api-contract-js_http_request_validation_handler-HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
+* You can create your own `ParameterTypeValidator` implementing `link:../../jsdoc/module-vertx-web-api-contract-js_parameter_type_validator-ParameterTypeValidator.html[ParameterTypeValidator]` interface
+
+=== Handling parameters
+Now you can handle parameter values:
+
+[source,js]
+----
+`example65`
+----
+
+As you can see, every parameter is mapped in respective language objects. You can also get a json body:
+
+[source,js]
+----
+`example66`
 ----

--- a/vertx-web-api-contract/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/kotlin/index.adoc
@@ -1,124 +1,17 @@
 = Vert.x-Web API Contract
 :toc: left
 
-Vert.x-Web API Contract brings to Vert.x two features to help you to develop you API:
-
-* HTTP Requests validation
-* OpenAPI 3 Support with automatic requests validation
-
-== Using Vert.x API Contract
-
-To use Vert.x API Contract, add the following dependency to the _dependencies_ section of your build descriptor:
-
-* Maven (in your `pom.xml`):
-
-[source,xml,subs="+attributes"]
-----
-<dependency>
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-web-api-contract</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
-</dependency>
-----
-
-* Gradle (in your `build.gradle` file):
-
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  compile 'io.vertx:vertx-web-api-contract:3.5.1-SNAPSHOT'
-}
-----
-
-== HTTP Requests validation
-
-Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container.
-
-To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
-[source,kotlin]
-----
-// Create Validation Handler with some stuff
-var validationHandler = HTTPRequestValidationHandler.create().addQueryParam("parameterName", ParameterType.INT, true).addFormParamWithPattern("formParameterName", "a{4}", true).addPathParam("pathParam", ParameterType.FLOAT)
-
-----
-
-Then you can mount your validation handler:
-[source,kotlin]
-----
-// BodyHandler is required to manage body parameters like forms or json body
-router.route().handler(BodyHandler.create())
-
-router.get("/awesome/:pathParam").handler(validationHandler).handler({ routingContext ->
-  // Get Request parameters container
-  var params = routingContext.get<Any>("parsedParameters")
-
-  // Get parameters
-  var parameterName = params.queryParameter("parameterName").getInteger()
-  var formParameterName = params.formParameter("formParameterName").getString()
-  var pathParam = params.pathParameter("pathParam").getFloat()
-}).failureHandler({ routingContext ->
-  var failure = routingContext.failure()
-  if (failure is io.vertx.ext.web.api.validation.ValidationException) {
-    // Something went wrong during validation!
-    var validationErrorMessage = failure.getMessage()
-  }
-})
-
-----
-
-If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
-
-=== Types of request parameters
-Every parameter has a type validator, a class that describes the expected type of parameter.
-A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
-
-* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
-* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
-* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
-
-=== Handling parameters
-Now you can handle parameter values:
-
-[source,kotlin]
-----
-var params = routingContext.get<Any>("parsedParameters")
-var awesomeParameter = params.queryParameter("awesomeParameter")
-if (awesomeParameter != null) {
-  if (!awesomeParameter.isEmpty()) {
-    // Parameter exists and isn't empty
-    // ParameterTypeValidator mapped the parameter in equivalent language object
-    var awesome = awesomeParameter.getInteger()
-  } else {
-    // Parameter exists, but it's empty
-  }
-} else {
-  // Parameter doesn't exist (it's not required)
-}
-
-----
-
-As you can see, every parameter is mapped in respective language objects. You can also get a json body:
-
-[source,kotlin]
-----
-var body = params.body()
-if (body != null) {
-  var jsonBody = body.getJsonObject()
-}
-
-----
-
 == OpenAPI 3 support
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
+Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach.
+
+Vert.x-Web provides:
 
 * OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
 * Automatic 501 response for not implemented operations
 * Router factory to provide all these features to users
-
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
 
 === The router factory
 You can create your web service based on OpenAPI3 specification with `link:../../apidocs/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.html[OpenAPI3RouterFactory]`.
@@ -141,16 +34,7 @@ To create a new router factory, you can use methods inside `link:../../apidocs/i
 For example:
 [source,kotlin]
 ----
-OpenAPI3RouterFactory.createRouterFactoryFromFile(vertx, "src/main/resources/petstore.yaml", { ar ->
-  if (ar.succeeded()) {
-    // Spec loaded with success
-    var routerFactory = ar.result()
-  } else {
-    // Something went wrong during router factory initialization
-    var exception = ar.cause()
-  }
-})
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#constructRouterFactory-io.vertx.core.Vertx-[constructRouterFactory]`
 ----
 
 === Mount the handlers
@@ -172,22 +56,13 @@ IMPORTANT: If you want to use `link:../../apidocs/io/vertx/ext/web/api/contract/
 For example:
 [source,kotlin]
 ----
-routerFactory.addHandlerByOperationId("awesomeOperation", { routingContext ->
-  var params = routingContext.get<Any>("parsedParameters")
-  var body = params.body()
-  var jsonBody = body.getJsonObject()
-  // Do something with body
-})
-routerFactory.addFailureHandlerByOperationId("awesomeOperation", { routingContext ->
-  // Handle failure
-})
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addRoute-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[addRoute]`
 ----
 
 .Add operations with operationId
 IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
 
-Now you can use parameter values as described above
+Now you can use parameter values as described in http://vertx.io/docs/vertx-web/java/#_andling_parameters[vertx-web documentation]
 
 == Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
@@ -195,16 +70,14 @@ For example:
 
 [source,kotlin]
 ----
-routerFactory.addSecurityHandler("security_scheme_name", securityHandler)
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addSecurityHandler-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.core.Handler-[addSecurityHandler]`
 ----
 
 You can of course use included Vert.x security handlers, for example:
 
 [source,kotlin]
 ----
-routerFactory.addSecurityHandler("jwt_auth", JWTAuthHandler.create(jwtAuthProvider))
-
+`link:../../apidocs/examples/OpenAPI3Examples.html#addJWT-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-io.vertx.ext.auth.jwt.JWTAuth-[addJWT]`
 ----
 
 === Error handling
@@ -218,11 +91,44 @@ When you are ready, generate the router and use it:
 
 [source,kotlin]
 ----
-var router = routerFactory.getRouter()
+`link:../../apidocs/examples/OpenAPI3Examples.html#generateRouter-io.vertx.core.Vertx-io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory-[generateRouter]`
+----
 
-var server = vertx.createHttpServer(HttpServerOptions(
-  port = 8080,
-  host = "localhost"))
-server.requestHandler({ router.accept(it) }).listen()
+== Requests validation
 
+Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
+[source,kotlin]
+----
+`link:../../apidocs/examples/WebExamples.html#example63-io.vertx.core.Vertx-io.vertx.ext.web.Router-[example63]`
+----
+
+Then you can mount your validation handler:
+[source,kotlin]
+----
+`link:../../apidocs/examples/WebExamples.html#example64-io.vertx.core.Vertx-io.vertx.ext.web.Router-io.vertx.ext.web.api.validation.HTTPRequestValidationHandler-[example64]`
+----
+
+If validation succeeds, It returns request parameters inside `link:../../apidocs/io/vertx/ext/web/api/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:../../apidocs/io/vertx/ext/web/api/validation/ValidationException.html[ValidationException]`
+
+=== Types of request parameters
+Every parameter has a type validator, a class that describes the expected type of parameter.
+A type validator validates the value, casts it in required language type and then loads it inside a `link:../../apidocs/io/vertx/ext/web/api/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
+
+* There is a set of prebuilt types that you can use: `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterType.html[ParameterType]`
+* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../apidocs/io/vertx/ext/web/api/validation/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
+* You can create your own `ParameterTypeValidator` implementing `link:../../apidocs/io/vertx/ext/web/api/validation/ParameterTypeValidator.html[ParameterTypeValidator]` interface
+
+=== Handling parameters
+Now you can handle parameter values:
+
+[source,kotlin]
+----
+`link:../../apidocs/examples/WebExamples.html#example65-io.vertx.ext.web.RoutingContext-[example65]`
+----
+
+As you can see, every parameter is mapped in respective language objects. You can also get a json body:
+
+[source,kotlin]
+----
+`link:../../apidocs/examples/WebExamples.html#example66-io.vertx.ext.web.api.RequestParameters-[example66]`
 ----

--- a/vertx-web-api-contract/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/ruby/index.adoc
@@ -1,126 +1,17 @@
 = Vert.x-Web API Contract
 :toc: left
 
-Vert.x-Web API Contract brings to Vert.x two features to help you to develop you API:
-
-* HTTP Requests validation
-* OpenAPI 3 Support with automatic requests validation
-
-== Using Vert.x API Contract
-
-To use Vert.x API Contract, add the following dependency to the _dependencies_ section of your build descriptor:
-
-* Maven (in your `pom.xml`):
-
-[source,xml,subs="+attributes"]
-----
-<dependency>
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-web-api-contract</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
-</dependency>
-----
-
-* Gradle (in your `build.gradle` file):
-
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  compile 'io.vertx:vertx-web-api-contract:3.5.1-SNAPSHOT'
-}
-----
-
-== HTTP Requests validation
-
-Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container.
-
-To define a `link:../../yardoc/VertxWebApiContract/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
-[source,ruby]
-----
-require 'vertx-web-api-contract/http_request_validation_handler'
-# Create Validation Handler with some stuff
-validationHandler = VertxWebApiContract::HTTPRequestValidationHandler.create().add_query_param("parameterName", :INT, true).add_form_param_with_pattern("formParameterName", "a{4}", true).add_path_param("pathParam", :FLOAT)
-
-----
-
-Then you can mount your validation handler:
-[source,ruby]
-----
-require 'vertx-web/body_handler'
-# BodyHandler is required to manage body parameters like forms or json body
-router.route().handler(&VertxWeb::BodyHandler.create().method(:handle))
-
-router.get("/awesome/:pathParam").handler(&validationHandler.method(:handle)).handler() { |routingContext|
-  # Get Request parameters container
-  params = routingContext.get("parsedParameters")
-
-  # Get parameters
-  parameterName = params.query_parameter("parameterName").get_integer()
-  formParameterName = params.form_parameter("formParameterName").get_string()
-  pathParam = params.path_parameter("pathParam").get_float()
-}.failure_handler() { |routingContext|
-  failure = routingContext.failure()
-  if (failure.class.name == 'Java::IoVertxExtWebApiValidation::ValidationException')
-    # Something went wrong during validation!
-    validationErrorMessage = failure.get_message()
-  end
-}
-
-----
-
-If validation succeeds, It returns request parameters inside `link:../../yardoc/VertxWebApiContract/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:unavailable[ValidationException]`
-
-=== Types of request parameters
-Every parameter has a type validator, a class that describes the expected type of parameter.
-A type validator validates the value, casts it in required language type and then loads it inside a `link:../../yardoc/VertxWebApiContract/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
-
-* There is a set of prebuilt types that you can use: `link:../enums.html#ParameterType[ParameterType]`
-* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../yardoc/VertxWebApiContract/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../yardoc/VertxWebApiContract/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
-* You can create your own `ParameterTypeValidator` implementing `link:../../yardoc/VertxWebApiContract/ParameterTypeValidator.html[ParameterTypeValidator]` interface
-
-=== Handling parameters
-Now you can handle parameter values:
-
-[source,ruby]
-----
-params = routingContext.get("parsedParameters")
-awesomeParameter = params.query_parameter("awesomeParameter")
-if (awesomeParameter != nil)
-  if (!awesomeParameter.empty?())
-    # Parameter exists and isn't empty
-    # ParameterTypeValidator mapped the parameter in equivalent language object
-    awesome = awesomeParameter.get_integer()
-  else
-    # Parameter exists, but it's empty
-  end
-else
-  # Parameter doesn't exist (it's not required)
-end
-
-----
-
-As you can see, every parameter is mapped in respective language objects. You can also get a json body:
-
-[source,ruby]
-----
-body = params.body()
-if (body != nil)
-  jsonBody = body.get_json_object()
-end
-
-----
-
 == OpenAPI 3 support
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
+Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach.
+
+Vert.x-Web provides:
 
 * OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
 * Automatic 501 response for not implemented operations
 * Router factory to provide all these features to users
-
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
 
 === The router factory
 You can create your web service based on OpenAPI3 specification with `link:../../yardoc/VertxWebApiContract/OpenAPI3RouterFactory.html[OpenAPI3RouterFactory]`.
@@ -143,17 +34,7 @@ To create a new router factory, you can use methods inside `link:../../yardoc/Ve
 For example:
 [source,ruby]
 ----
-require 'vertx-web-api-contract/open_api3_router_factory'
-VertxWebApiContract::OpenAPI3RouterFactory.create_router_factory_from_file(vertx, "src/main/resources/petstore.yaml") { |ar_err,ar|
-  if (ar_err == nil)
-    # Spec loaded with success
-    routerFactory = ar
-  else
-    # Something went wrong during router factory initialization
-    exception = ar_err
-  end
-}
-
+`link:unavailable#construct_router_factory-instance_method[constructRouterFactory]`
 ----
 
 === Mount the handlers
@@ -175,22 +56,13 @@ IMPORTANT: If you want to use `link:../../yardoc/VertxWebApiContract/DesignDrive
 For example:
 [source,ruby]
 ----
-routerFactory.add_handler_by_operation_id("awesomeOperation") { |routingContext|
-  params = routingContext.get("parsedParameters")
-  body = params.body()
-  jsonBody = body.get_json_object()
-  # Do something with body
-}
-routerFactory.add_failure_handler_by_operation_id("awesomeOperation") { |routingContext|
-  # Handle failure
-}
-
+`link:unavailable#add_route-instance_method[addRoute]`
 ----
 
 .Add operations with operationId
 IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
 
-Now you can use parameter values as described above
+Now you can use parameter values as described in http://vertx.io/docs/vertx-web/java/#_andling_parameters[vertx-web documentation]
 
 == Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
@@ -198,17 +70,14 @@ For example:
 
 [source,ruby]
 ----
-routerFactory.add_security_handler("security_scheme_name", &securityHandler)
-
+`link:unavailable#add_security_handler-instance_method[addSecurityHandler]`
 ----
 
 You can of course use included Vert.x security handlers, for example:
 
 [source,ruby]
 ----
-require 'vertx-web/jwt_auth_handler'
-routerFactory.add_security_handler("jwt_auth", &VertxWeb::JWTAuthHandler.create(jwtAuthProvider).method(:handle))
-
+`link:unavailable#add_jwt-instance_method[addJWT]`
 ----
 
 === Error handling
@@ -222,12 +91,44 @@ When you are ready, generate the router and use it:
 
 [source,ruby]
 ----
-router = routerFactory.get_router()
+`link:unavailable#generate_router-instance_method[generateRouter]`
+----
 
-server = vertx.create_http_server({
-  'port' => 8080,
-  'host' => "localhost"
-})
-server.request_handler(&router.method(:accept)).listen()
+== Requests validation
 
+Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a `link:../../yardoc/VertxWebApiContract/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]`:
+[source,ruby]
+----
+`link:unavailable#example63-instance_method[example63]`
+----
+
+Then you can mount your validation handler:
+[source,ruby]
+----
+`link:unavailable#example64-instance_method[example64]`
+----
+
+If validation succeeds, It returns request parameters inside `link:../../yardoc/VertxWebApiContract/RequestParameters.html[RequestParameters]`, otherwise It will throw a `link:unavailable[ValidationException]`
+
+=== Types of request parameters
+Every parameter has a type validator, a class that describes the expected type of parameter.
+A type validator validates the value, casts it in required language type and then loads it inside a `link:../../yardoc/VertxWebApiContract/RequestParameter.html[RequestParameter]` object. There are three ways to describe the type of your parameter:
+
+* There is a set of prebuilt types that you can use: `link:../enums.html#ParameterType[ParameterType]`
+* You can instantiate a custom instance of prebuilt type validators using static methods of `link:../../yardoc/VertxWebApiContract/ParameterTypeValidator.html[ParameterTypeValidator]` and then load it into `link:../../yardoc/VertxWebApiContract/HTTPRequestValidationHandler.html[HTTPRequestValidationHandler]` using functions ending with `WithCustomTypeValidator`
+* You can create your own `ParameterTypeValidator` implementing `link:../../yardoc/VertxWebApiContract/ParameterTypeValidator.html[ParameterTypeValidator]` interface
+
+=== Handling parameters
+Now you can handle parameter values:
+
+[source,ruby]
+----
+`link:unavailable#example65-instance_method[example65]`
+----
+
+As you can see, every parameter is mapped in respective language objects. You can also get a json body:
+
+[source,ruby]
+----
+`link:unavailable#example66-instance_method[example66]`
 ----

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -9,8 +9,6 @@ import io.vertx.ext.web.api.impl.RequestParameterImpl;
 import io.vertx.ext.web.api.impl.RequestParametersImpl;
 import io.vertx.ext.web.api.validation.*;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -199,11 +197,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
         // Decode values because I assume they are text/plain in this phase
         List<String> values = new ArrayList<>();
         for (String s : formParams.getAll(name)) {
-          try {
-            values.add(URLDecoder.decode(s, "UTF-8"));
-          } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-          }
+          values.add(s);
           RequestParameter parsedParam = rule.validateArrayParam(values);
           if (parsedParams.containsKey(parsedParam.getName()))
             parsedParam = parsedParam.merge(parsedParams.get(parsedParam.getName()));

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
@@ -224,6 +224,24 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
   }
 
   @Test
+  public void testFormURLEncodedCharParameter() throws Exception {
+    Operation op = testSpec.getPaths().get("/formTests/urlencodedchar").getPost();
+    if(op.getParameters()==null) op.setParameters(new ArrayList<>());
+    OpenAPI3RequestValidationHandler validationHandler = new OpenAPI3RequestValidationHandlerImpl(op, op.getParameters(), testSpec);
+    loadHandlers("/formTests/urlencodedchar", HttpMethod.POST, false, validationHandler, (routingContext) -> {
+      RequestParameters params = routingContext.get("parsedParameters");
+      routingContext.response().setStatusMessage(params.formParameter("name").getString()).end();
+    });
+
+    String name = "test+urlencoded+char";
+
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form.add("name", name);
+
+    testRequestWithForm(HttpMethod.POST, "/formTests/urlencodedchar", FormType.FORM_URLENCODED, form, 200, name);
+  }
+
+  @Test
   public void testJsonBody() throws Exception {
     Operation op = testSpec.getPaths().get("/jsonBodyTest/sampleTest").getPost();
     if(op.getParameters()==null) op.setParameters(new ArrayList<>());

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
@@ -19,7 +19,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
 
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -194,7 +193,7 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
 
     MultiMap form = MultiMap.caseInsensitiveMultiMap();
     form.add("id", id);
-    form.add("values", URLEncoder.encode(values, "UTF-8"));
+    form.add("values", values);
 
     testRequestWithForm(HttpMethod.POST, "/formTests/arraytest", FormType.FORM_URLENCODED, form, 200, id + values);
   }
@@ -218,7 +217,7 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
 
     MultiMap form = MultiMap.caseInsensitiveMultiMap();
     form.add("id", id);
-    form.add("values", URLEncoder.encode(values, "UTF-8"));
+    form.add("values", values);
 
     testRequestWithForm(HttpMethod.POST, "/formTests/arraytest", FormType.FORM_URLENCODED, form, 400, errorMessage
       (ValidationException.ErrorType.NO_MATCH));
@@ -374,14 +373,14 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
     pet.put("id", 14612);
     pet.put("name", "Willy");
 
-    form.add("param2", URLEncoder.encode(pet.encode(), "UTF-8"));
+    form.add("param2", pet.encode());
 
-    form.add("param3", URLEncoder.encode("SELECT * FROM table;", "UTF-8"));
+    form.add("param3", "SELECT * FROM table;");
 
     List<String> valuesArray = new ArrayList<>();
     for (int i = 0; i < 4; i++)
       valuesArray.add(getSuccessSample(ParameterType.FLOAT).getFloat().toString());
-    form.add("param4", URLEncoder.encode(serializeInCSVStringArray(valuesArray), "UTF-8"));
+    form.add("param4", serializeInCSVStringArray(valuesArray));
 
     testRequestWithForm(HttpMethod.POST, "/multipart/complex", FormType.MULTIPART, form, 200, "ok");
   }

--- a/vertx-web-api-contract/src/test/resources/swaggers/validation_test.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/validation_test.yaml
@@ -125,6 +125,20 @@ paths:
       responses:
         default:
           description: ok
+  /formTests/urlencodedchar:
+    post:
+      operationId: formURLEncodedCharTest
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        default:
+          description: ok
   /formTests/arraytest:
     post:
       operationId: formArrayTest

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -123,14 +123,15 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
           });
         }
       });
-    }
-    // redirect request to the oauth2 server
-    if (callback == null) {
-      handler.handle(Future.failedFuture("callback route is not configured."));
-      return;
-    }
+    } else {
+      // redirect request to the oauth2 server
+      if (callback == null) {
+        handler.handle(Future.failedFuture("callback route is not configured."));
+        return;
+      }
 
-    handler.handle(Future.failedFuture(new HttpStatusException(302, authURI(context.request().uri()))));
+      handler.handle(Future.failedFuture(new HttpStatusException(302, authURI(context.request().uri()))));
+    }
   }
 
   private String authURI(String redirectURL) {


### PR DESCRIPTION
Fixing double encoding/decoding of form parameters.
You were not able to handle a simple POST (x-www-form-urlencoded) with any char supposed to be url encoded (plus sign, for instance).

If you write a HTML form, with an input field text, and place this value: "test+urlencoded+char", you will get this as result: "test urlencoded char".

Version 3.5.0 basically can't be used with form parameters reliably.
Test cases attached as well.