### PR TITLE
less strict content type comparison

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -68,7 +68,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
         if (contentType.contains("application/x-www-form-urlencoded") || contentType.contains("multipart/form-data")) {
           parsedParameters.setFormParameters(validateFormParams(routingContext));
           if (contentType.contains("multipart/form-data")) validateFileUpload(routingContext);
-        } else if (contentType.equals("application/json") || contentType.equals("application/xml"))
+        } else if (contentType.startsWith("application/json") || contentType.startsWith("application/xml"))
           parsedParameters.setBody(validateEntireBody(routingContext));
         else {
           routingContext.fail(400);


### PR DESCRIPTION
I want to resolve #770 this enables the usage of encoding for `application/json` and `application/xml` e.g. `application/json; charset=utf-8`