### PR TITLE
[773] Remove io.vertx.ext.web from export packages.

### DIFF
--- a/vertx-web-common/pom.xml
+++ b/vertx-web-common/pom.xml
@@ -68,7 +68,7 @@
             io.vertx.reactivex.*;resolution:=optional,\
             io.vertx.lang.reactivex.*;resolution:=optional,\
             *
-          -exportcontents: !examples, *
+          -exportcontents: !examples, !io.vertx.ext.web, *
           ]]></bnd>
         </configuration>
       </plugin>


### PR DESCRIPTION
Real io.vertx.ext.web is exporting from vertx-web bundle. If both
bundles exports same package then collision might arise and classes from
vertx-web bundle would not be resolvable.

I have signed the Eclipse CLA

Bug: https://github.com/vert-x3/vertx-web/issues/773
Signed-off-by: Aleksandar Vasilev <aleksandar.vassilev@gmail.com>