### PR TITLE
Web client strips fragment from URI with embedded query parameters

### DIFF
--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -881,6 +881,22 @@ public class WebClientTest extends HttpTestBase {
   }
 
   @Test
+  public void testRetainsFragmentWithoutParams() throws Exception {
+    testRequestWithUri("/path#fragment");
+  }
+
+  @Test(expected=AssertionError.class)
+  public void testRetainsFragmentWithParams() throws Exception {
+    testRequestWithUri("/path?key=val#fragment");
+  }
+
+  private void testRequestWithUri(String uri) throws Exception {
+    testRequest(client -> client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, uri), req -> {
+      assertEquals(uri, req.uri());
+    });
+  }
+
+  @Test
   public void testFormUrlEncoded() throws Exception {
     server.requestHandler(req -> {
       req.setExpectMultipart(true);


### PR DESCRIPTION
This PR adds a failing test to illustrate this (remove `expected=AssertionError.class`) — but please let me know if this test is wrong or if this is the expected behavior.

The reason this appears to happen is because [this code](https://github.com/vert-x3/vertx-web/blob/master/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java#L169) parses query parameters from the given URI, stripping the query from the given URI in the process. However, this also strips the fragment after the query without adding it back in later.

Thank you for creating and maintinaing Vert.x Web Client; it is super useful!