### PR TITLE
Keeping operation order as they appear in the spec

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -154,7 +154,7 @@ public class OpenAPI3RouterFactoryImpl extends BaseDesignDrivenRouterFactory<Ope
 
   public OpenAPI3RouterFactoryImpl(Vertx vertx, OpenAPI spec) {
     super(vertx, spec);
-    this.operations = new HashMap<>();
+    this.operations = new LinkedHashMap<>();
     this.securityHandlers = new HashMap<>();
 
     /* --- Initialization of all arrays and maps --- */

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -226,8 +226,6 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
         });
         routerFactory.addFailureHandlerByOperationId("showProductById", generateFailureHandler(false));
 
-        // Add security handler
-        routerFactory.addSecurityHandler("api_key", routingContext -> routingContext.next());
         router[0] = routerFactory.getRouter();
 
         latch.countDown();

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -209,7 +209,7 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
   public void loadSpecAndTestPrecedence() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     final Router[] router = {null};
-    OpenAPI3RouterFactory.createRouterFactoryFromFile(this.vertx, "src/test/resources/swaggers/testOrderSpec.yaml",
+    OpenAPI3RouterFactory.createRouterFactoryFromFile(this.vertx, "src/test/resources/swaggers/test_order_spec.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         assertTrue(openAPI3RouterFactoryAsyncResult.succeeded());
         OpenAPI3RouterFactory routerFactory = openAPI3RouterFactoryAsyncResult.result();

--- a/vertx-web-api-contract/src/test/resources/swaggers/testOrderSpec.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/testOrderSpec.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Vertx test order spec
+paths:
+  /product/special:
+    get:
+      summary: Get special product
+      operationId: showSpecialProduct
+      responses:
+        default:
+          description: ok
+  /product/{id}:
+    get:
+      summary: Product detail
+      operationId: showProductById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the product to retrieve
+          schema:
+            type: integer
+            format: int32
+      responses:
+        default:
+          description: ok
+
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/vertx-web-api-contract/src/test/resources/swaggers/test_order_spec.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/test_order_spec.yaml
@@ -25,10 +25,3 @@ paths:
       responses:
         default:
           description: ok
-
-components:
-  securitySchemes:
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header

--- a/vertx-web-api-contract/src/test/resources/swaggers/test_order_spec.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/test_order_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   version: 1.0.0
-  title: Vertx test order spec
+  title: Test spec for OpenAPI3RouterFactoryTest.loadSpecAndTestPrecedence()
 paths:
   /product/special:
     get:


### PR DESCRIPTION
By feeding operations to router in the same order as they appear in the spec, allows correct override from specific / wildcard paths.

Given this sample routes:

GET /product/special
GET /product/{id}

If they are not added in this specific order to router, /product/special will never be called.

(sorry, had to reopen as another PR, original was #754)