### PR TITLE
Added sockjs.close() with status code and reason

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
@@ -41,8 +41,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.ext.web.Session;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.web.Session;
 
 /**
  *
@@ -113,6 +113,23 @@ public interface SockJSSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    * Close it
    */
   void close();
+
+  /**
+   * Close sending a close frame with specified status code. You can give a look at various close payloads
+   * here: <a href="https://tools.ietf.org/html/rfc6455#section-7.4.1">RFC6455 Section 7.4.1</a>
+   *
+   * @param statusCode status code
+   */
+  void close(short statusCode);
+
+  /**
+   * Close sending a close frame with specified status code and a reason. You can give a look at various close payloads
+   * here: <a href="https://tools.ietf.org/html/rfc6455#section-7.4.1">RFC6455 Section 7.4.1</a>
+   *
+   * @param statusCode status code
+   * @param reason reason of closure
+   */
+  void close(short statusCode, String reason);
 
   /**
    * Return the remote address for this socket

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -44,7 +44,9 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.bridge.BridgeEventType;
 import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.sockjs.*;
+import io.vertx.ext.web.handler.sockjs.BridgeEvent;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -320,7 +322,8 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
         	// Trigger an event to allow custom behavior before disconnecting client.
             checkCallHook(() -> new BridgeEventImpl(BridgeEventType.SOCKET_IDLE, null, sock), null, null);
             // We didn't receive a ping in time so close the socket
-            sock.close();
+            sock.close((short)1001);
+            // In fact there isn't a specified code for pong timeout, so I use code CLOSE_GOING_AWAY
           }
         });
         SockInfo sockInfo = new SockInfo();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
@@ -40,10 +40,10 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.sockjs.SockJSSocket;
-import io.vertx.ext.auth.User;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -114,6 +114,18 @@ class RawWebSocketTransport {
     public void close() {
       super.close();
       ws.close();
+    }
+
+    @Override
+    public void close(short statusCode) {
+      super.close();
+      ws.close(statusCode);
+    }
+
+    @Override
+    public void close(short statusCode, String reason) {
+      super.close();
+      ws.close(statusCode, reason);
     }
 
     @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -199,6 +199,17 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
     }
   }
 
+  // The status code/reason is only for websocket transport
+  @Override
+  public void close(short statusCode) {
+    this.close();
+  }
+
+  @Override
+  public void close(short statusCode, String reason) {
+    this.close();
+  }
+
   private synchronized void doClose() {
     Context ctx = transportCtx;
     if (ctx != Vertx.currentContext()) {


### PR DESCRIPTION
Added close() with status code and reason (reflecting https://github.com/eclipse/vert.x/pull/2280 and solving #804). Two notes:

* As is now, status code and reason are discarded when transport is different from websocket
* When pong is not received, I changed the close with status code 1001. In fact, watching the [rfc](https://tools.ietf.org/html/rfc6455#section-7.4.1), there isn't a dedicated status code for ping-pong timeout, so the more congruent seems 1001 "Going away"