### PR TITLE
add writeText() to SockJSSocket

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
@@ -77,15 +77,26 @@ public interface SockJSSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   SockJSSocket write(Buffer data);
 
   /**
-   * Write a {@link String} to the socket, encoded in UTF-8.
+   * Write a {@link String} to the socket, encoded in UTF-8. If
+   * the transport is raw websocket, this will write a binary message
+   * (for legacy reasons).
    *
    * @param data  the string to write
    * @return a reference to this, so the API can be used fluently
+   * @see #writeText(String)
    */
   @Fluent
-  default SockJSSocket write(String data) {
-    return write(Buffer.buffer(data));
-  }
+  SockJSSocket write(String data);
+
+  /**
+   * Write a {@link String} to the socket, encoded in UTF-8.
+   * If the transport is raw websocket, this will write a text message.
+   *
+   * @param text  the string to write
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  SockJSSocket writeText(String text);
 
   @Override
   SockJSSocket setWriteQueueMaxSize(int maxSize);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
@@ -87,6 +87,16 @@ class RawWebSocketTransport {
       return this;
     }
 
+    public SockJSSocket write(String data) {
+      ws.writeBinaryMessage(Buffer.buffer(data));
+      return this;
+    }
+
+    public SockJSSocket writeText(String text) {
+      ws.writeTextMessage(text);
+      return this;
+    }
+
     public SockJSSocket setWriteQueueMaxSize(int maxQueueSize) {
       ws.setWriteQueueMaxSize(maxQueueSize);
       return this;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -113,8 +113,17 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
 
   @Override
   public SockJSSocket write(Buffer buffer) {
+    return writeText(buffer.toString());
+  }
+
+  @Override
+  public SockJSSocket write(String data) {
+    return writeText(data);
+  }
+
+  @Override
+  public SockJSSocket writeText(String msgStr) {
     synchronized (this) {
-      String msgStr = buffer.toString();
       pendingWrites.add(msgStr);
       this.messagesSize += msgStr.length();
       if (listener != null) {


### PR DESCRIPTION
When using raw websocket transport with SockJSHandler, there's currently no way to send text messages (everything becomes binary), which is super annoying for the JS clients. This adds a writeText(String) to SockJSSocket, which will send a text message instead.