### PR TITLE
Support named path segments and regular expressions with the SockJSHandler

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -23,6 +23,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.impl.PrefixedRouterImpl;
 import io.vertx.ext.web.impl.RouterImpl;
 
 import java.util.List;
@@ -46,6 +47,16 @@ public interface Router {
    */
   static Router router(Vertx vertx) {
     return new RouterImpl(vertx);
+  }
+
+  /**
+   * Create a new router where every route will be created with the given prefix.
+   * @param vertx
+   * @param routePrefix The prefix, must not be empty or null
+   * @return the router
+   */
+  static Router prefixedRouter(Vertx vertx, String routePrefix ){
+    return new PrefixedRouterImpl(vertx, routePrefix);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -51,12 +51,13 @@ public interface Router {
 
   /**
    * Create a new router where every route will be created with the given prefix.
-   * @param vertx
+   * @param vertx the Vert.x instance
    * @param routePrefix The prefix, must not be empty or null
+   * @param isRegex {@code true} if routePrefix is to be used as an regular expression, {@code false} if it's a static text literal
    * @return the router
    */
-  static Router prefixedRouter(Vertx vertx, String routePrefix ){
-    return new PrefixedRouterImpl(vertx, routePrefix);
+  static Router prefixedRouter(Vertx vertx, String routePrefix, boolean isRegex){
+    return new PrefixedRouterImpl(vertx, routePrefix, isRegex);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
@@ -50,11 +50,34 @@ public interface SockJSHandler extends Handler<RoutingContext> {
    * Create a SockJS handler
    *
    * @param vertx  the Vert.x instance
+   * @param router the router where the routes are added
+   * @return the handler
+   */
+  static SockJSHandler create(Vertx vertx, Router router) {
+    return new SockJSHandlerImpl(vertx, router, new SockJSHandlerOptions());
+  }
+
+  /**
+   * Create a SockJS handler
+   *
+   * @param vertx  the Vert.x instance
    * @param options  options to configure the handler
    * @return the handler
    */
   static SockJSHandler create(Vertx vertx, SockJSHandlerOptions options) {
     return new SockJSHandlerImpl(vertx, options);
+  }
+
+  /**
+   * Create a SockJS handler
+   *
+   * @param vertx  the Vert.x instance
+   * @param router the router where the routes are added
+   * @param options  options to configure the handler
+   * @return the handler
+   */
+  static SockJSHandler create(Vertx vertx, Router router, SockJSHandlerOptions options) {
+    return new SockJSHandlerImpl(vertx, router, options);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -42,23 +42,13 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.sockjs.BridgeEvent;
-import io.vertx.ext.web.handler.sockjs.BridgeOptions;
-import io.vertx.ext.web.handler.sockjs.SockJSHandler;
-import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
-import io.vertx.ext.web.handler.sockjs.SockJSSocket;
-import io.vertx.ext.web.handler.sockjs.Transport;
+import io.vertx.ext.web.handler.sockjs.*;
 
 import java.security.MessageDigest;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import static io.vertx.core.buffer.Buffer.*;
+import static io.vertx.core.buffer.Buffer.buffer;
 
 /**
  *
@@ -74,10 +64,14 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
   private SockJSHandlerOptions options;
 
   public SockJSHandlerImpl(Vertx vertx, SockJSHandlerOptions options) {
+    this(vertx, Router.router(vertx), options);
+  }
+
+  public SockJSHandlerImpl(Vertx vertx, Router router, SockJSHandlerOptions options) {
     this.vertx = vertx;
     // TODO use clustered map
     this.sessions = vertx.sharedData().getLocalMap("_vertx.sockjssessions");
-    this.router = Router.router(vertx);
+    this.router = router;
     this.options = options;
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/PrefixedRouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/PrefixedRouterImpl.java
@@ -1,0 +1,65 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.Route;
+
+import java.util.regex.Pattern;
+
+/**
+ * A router which adds a prefix to every route added to it.
+ * It's useful in place where a router is accepted and is used as a sub-router.
+ * A sub-router can't be used with regular expressions or named path segments.
+ *
+ * <pre>
+ *     Router prefixedRouter = Router.prefixedRouter(vertx, "/api/:name/events");
+ *     SockJSHandler sockHandler = SockJSHandler.create(vertx, prefixedRouter).bridge(options)
+ *
+ *     Router httpRouter = Router.create(vertx)
+ *     httpRouter.route("/*").handler(sockHandler)
+ * </pre>
+ *
+ * @author jansorg
+ */
+public class PrefixedRouterImpl extends RouterImpl {
+  private final String routePrefix;
+
+  public PrefixedRouterImpl(Vertx vertx, String routePrefix) {
+    super(vertx);
+    this.routePrefix = routePrefix;
+  }
+
+  @Override
+  public Route route() {
+    return super.route(routePrefix);
+  }
+
+  @Override
+  public Route route(String path) {
+    return super.route(prefixedPath(path));
+  }
+
+  @Override
+  public Route route(HttpMethod method, String path) {
+    return super.route(method, prefixedPath(path));
+  }
+
+  @Override
+  public Route routeWithRegex(HttpMethod method, String regex) {
+    return super.routeWithRegex(method, prefixedRegex(regex));
+  }
+
+  @Override
+  public Route routeWithRegex(String regex) {
+    return super.routeWithRegex(prefixedRegex(regex));
+  }
+
+
+  private String prefixedPath(String path) {
+    return routePrefix + path;
+  }
+
+  private String prefixedRegex(String regex) {
+    return Pattern.quote(routePrefix) + regex;
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/PrefixedRouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/PrefixedRouterImpl.java
@@ -22,44 +22,113 @@ import java.util.regex.Pattern;
  * @author jansorg
  */
 public class PrefixedRouterImpl extends RouterImpl {
-  private final String routePrefix;
+  private final String prefix;
+  private final String escapedPrefix;
+  private final boolean isRegex;
 
-  public PrefixedRouterImpl(Vertx vertx, String routePrefix) {
+  public PrefixedRouterImpl(Vertx vertx, String routePrefix, boolean isRegex) {
     super(vertx);
-    this.routePrefix = routePrefix;
+    this.prefix = routePrefix;
+    this.isRegex = isRegex;
+
+    this.escapedPrefix = Pattern.quote(routePrefix);
   }
 
   @Override
   public Route route() {
-    return super.route(routePrefix);
+    return isRegex
+      ? super.routeWithRegex(prefix)
+      : super.route(prefix);
   }
 
   @Override
   public Route route(String path) {
-    return super.route(prefixedPath(path));
+    return isRegex
+      ? super.routeWithRegex(prefix + Pattern.quote(path))
+      : super.route(prefix + path);
   }
 
   @Override
   public Route route(HttpMethod method, String path) {
-    return super.route(method, prefixedPath(path));
-  }
-
-  @Override
-  public Route routeWithRegex(HttpMethod method, String regex) {
-    return super.routeWithRegex(method, prefixedRegex(regex));
+    return isRegex
+      ? super.routeWithRegex(method, prefix + Pattern.quote(path))
+      : super.route(method, prefix + path);
   }
 
   @Override
   public Route routeWithRegex(String regex) {
-    return super.routeWithRegex(prefixedRegex(regex));
+    return isRegex
+      ? super.routeWithRegex(prefix + regex)
+      : super.routeWithRegex(escapedPrefix + regex);
   }
 
-
-  private String prefixedPath(String path) {
-    return routePrefix + path;
+  @Override
+  public Route routeWithRegex(HttpMethod method, String regex) {
+    return isRegex
+      ? super.routeWithRegex(method, prefix + regex)
+      : super.routeWithRegex(method, escapedPrefix + regex);
   }
 
-  private String prefixedRegex(String regex) {
-    return Pattern.quote(routePrefix) + regex;
+  @Override
+  public Route getWithRegex(String path) {
+    return isRegex
+      ? super.getWithRegex(prefix + path)
+      : super.getWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route headWithRegex(String path) {
+    return isRegex
+      ? super.headWithRegex(prefix + path)
+      : super.headWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route optionsWithRegex(String path) {
+    return isRegex
+      ? super.optionsWithRegex(prefix + path)
+      : super.optionsWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route putWithRegex(String path) {
+    return isRegex
+      ? super.putWithRegex(prefix + path)
+      : super.putWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route postWithRegex(String path) {
+    return isRegex
+      ? super.postWithRegex(prefix + path)
+      : super.postWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route deleteWithRegex(String path) {
+    return isRegex
+      ? super.deleteWithRegex(prefix + path)
+      : super.deleteWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route traceWithRegex(String path) {
+    return isRegex
+      ? super.traceWithRegex(prefix + path)
+      : super.traceWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route connectWithRegex(String path) {
+    return isRegex
+      ? super.connectWithRegex(prefix + path)
+      : super.connectWithRegex(escapedPrefix + path);
+  }
+
+  @Override
+  public Route patchWithRegex(String path) {
+    return isRegex
+      ? super.patchWithRegex(prefix + path)
+      : super.patchWithRegex(escapedPrefix + path);
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/PrefixedRouterImplTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/PrefixedRouterImplTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.impl;
 
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.WebTestBase;
 import org.junit.Assert;
@@ -8,10 +9,10 @@ import org.junit.Test;
 /**
  * @author jansorg
  */
-public class PrefixedRouterTest extends WebTestBase {
+public class PrefixedRouterImplTest extends WebTestBase {
   @Test
   public void test_prefixed_path() {
-    Router r = new PrefixedRouterImpl(vertx, "/api/:segment");
+    Router r = new PrefixedRouterImpl(vertx, "/api/:segment", false);
 
     Assert.assertEquals("/api/:segment", r.route().getPath());
     Assert.assertEquals("/api/:segment/ping", r.route("/ping").getPath());
@@ -19,11 +20,27 @@ public class PrefixedRouterTest extends WebTestBase {
     Assert.assertEquals("/api/:segment/*", r.route("/*").getPath());
 
     Assert.assertEquals("/api/:segment/user/login", r.route("/user/login").getPath());
+
+    Route routeWithRegex = r.routeWithRegex("/user/login");
+    Assert.assertNull(routeWithRegex.getPath());
+    Assert.assertTrue(routeWithRegex.toString().contains("pattern:\\Q/api/:segment\\E/user/login"));
+  }
+
+  @Test
+  public void test_prefixed_regex_path() {
+    Router r = new PrefixedRouterImpl(vertx, "/api/[0-9]+", true);
+
+    Assert.assertNull(r.route().getPath());
+    Assert.assertTrue(r.route().toString().contains("pattern:/api/[0-9]+"));
+    Assert.assertTrue(r.route("/ping").toString(), (r.route("/ping").toString().contains("pattern:/api/[0-9]+\\Q/ping\\E")));
+    Assert.assertTrue(r.route("/*").toString().contains("pattern:/api/[0-9]+\\Q/*\\E"));
+
+    Assert.assertTrue(r.routeWithRegex("/*").toString().contains("pattern:/api/[0-9]+/*"));
   }
 
   @Test
   public void test_get() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.get().getPath());
     Assert.assertEquals("/api/login", r.get("/login").getPath());
     Assert.assertEquals("/apilogin", r.get("login").getPath());
@@ -34,7 +51,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_post() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.post().getPath());
     Assert.assertEquals("/api/login", r.post("/login").getPath());
     Assert.assertEquals("/apilogin", r.post("login").getPath());
@@ -45,7 +62,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_put() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.put().getPath());
     Assert.assertEquals("/api/login", r.put("/login").getPath());
     Assert.assertEquals("/apilogin", r.put("login").getPath());
@@ -56,7 +73,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_connect() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.connect().getPath());
     Assert.assertEquals("/api/login", r.connect("/login").getPath());
     Assert.assertEquals("/apilogin", r.connect("login").getPath());
@@ -67,7 +84,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_options() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.options().getPath());
     Assert.assertEquals("/api/login", r.options("/login").getPath());
     Assert.assertEquals("/apilogin", r.options("login").getPath());
@@ -79,7 +96,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_delete() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.delete().getPath());
     Assert.assertEquals("/api/login", r.delete("/login").getPath());
     Assert.assertEquals("/apilogin", r.delete("login").getPath());
@@ -90,7 +107,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_head() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.head().getPath());
     Assert.assertEquals("/api/login", r.head("/login").getPath());
     Assert.assertEquals("/apilogin", r.head("login").getPath());
@@ -101,7 +118,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_patch() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.patch().getPath());
     Assert.assertEquals("/api/login", r.patch("/login").getPath());
     Assert.assertEquals("/apilogin", r.patch("login").getPath());
@@ -112,7 +129,7 @@ public class PrefixedRouterTest extends WebTestBase {
 
   @Test
   public void test_trace() {
-    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Router r = new PrefixedRouterImpl(vertx, "/api", false);
     Assert.assertEquals("/api", r.trace().getPath());
     Assert.assertEquals("/api/login", r.trace("/login").getPath());
     Assert.assertEquals("/apilogin", r.trace("login").getPath());

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/PrefixedRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/PrefixedRouterTest.java
@@ -1,0 +1,123 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.WebTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author jansorg
+ */
+public class PrefixedRouterTest extends WebTestBase {
+  @Test
+  public void test_prefixed_path() {
+    Router r = new PrefixedRouterImpl(vertx, "/api/:segment");
+
+    Assert.assertEquals("/api/:segment", r.route().getPath());
+    Assert.assertEquals("/api/:segment/ping", r.route("/ping").getPath());
+    Assert.assertEquals("/api/:segmentping", r.route("ping").getPath());
+    Assert.assertEquals("/api/:segment/*", r.route("/*").getPath());
+
+    Assert.assertEquals("/api/:segment/user/login", r.route("/user/login").getPath());
+  }
+
+  @Test
+  public void test_get() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.get().getPath());
+    Assert.assertEquals("/api/login", r.get("/login").getPath());
+    Assert.assertEquals("/apilogin", r.get("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.getWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_post() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.post().getPath());
+    Assert.assertEquals("/api/login", r.post("/login").getPath());
+    Assert.assertEquals("/apilogin", r.post("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.postWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_put() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.put().getPath());
+    Assert.assertEquals("/api/login", r.put("/login").getPath());
+    Assert.assertEquals("/apilogin", r.put("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.putWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_connect() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.connect().getPath());
+    Assert.assertEquals("/api/login", r.connect("/login").getPath());
+    Assert.assertEquals("/apilogin", r.connect("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.connectWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_options() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.options().getPath());
+    Assert.assertEquals("/api/login", r.options("/login").getPath());
+    Assert.assertEquals("/apilogin", r.options("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.optionsWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+
+  @Test
+  public void test_delete() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.delete().getPath());
+    Assert.assertEquals("/api/login", r.delete("/login").getPath());
+    Assert.assertEquals("/apilogin", r.delete("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.deleteWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_head() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.head().getPath());
+    Assert.assertEquals("/api/login", r.head("/login").getPath());
+    Assert.assertEquals("/apilogin", r.head("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.headWithRegex("/[a-z]+[0-9]+").toString(), r.headWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_patch() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.patch().getPath());
+    Assert.assertEquals("/api/login", r.patch("/login").getPath());
+    Assert.assertEquals("/apilogin", r.patch("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.patchWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+
+  @Test
+  public void test_trace() {
+    Router r = new PrefixedRouterImpl(vertx, "/api");
+    Assert.assertEquals("/api", r.trace().getPath());
+    Assert.assertEquals("/api/login", r.trace("/login").getPath());
+    Assert.assertEquals("/apilogin", r.trace("login").getPath());
+
+    //there's getter for pattern
+    Assert.assertTrue(r.traceWithRegex("/[a-z]+[0-9]+").toString().contains("pattern:\\Q/api\\E/[a-z]+[0-9]+"));
+  }
+}


### PR DESCRIPTION
This PR: adds support for named path segments and regular expressions in sockjs routing paths.

- New static factory method in Router
- New constructor for SockJSHandler which takes a router
- API is backwards compatible

I've needed this to mount a sockjs bridge at a path which contains a named segment:

This mounts a SockJS handler at "/api/:repository/events" and the websocket at "/api/:repository/events/websocket".

```java
        Router prefixRouter = Router.prefixedRouter(vertx, "/api/:repository/events", false);
        SockJSHandler handler = SockJSHandler.create(vertx, prefixRouter).bridge(new BridgeOptions()) {
            it.complete(true)
        }
        router.route("/*").handler(handler)
```

Afaik this should also fix https://github.com/vert-x3/vertx-web/issues/667

See the commit log for more details.