### PR TITLE
Avoid having method references which makes the usage cleaner IMHO

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -147,7 +147,7 @@ For every request that is routed there is a unique routing context instance, and
 all handlers for that request.
 
 Once we've set up the handler, we set the request handler of the HTTP server to pass all incoming requests
-to {@link io.vertx.ext.web.Router#accept}.
+to {@link io.vertx.ext.web.Router#handle}.
 
 So, that's the basics. Now we'll look at things in more detail:
 

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -71,7 +71,7 @@ public class WebExamples {
       response.end("Hello World from Vert.x-Web!");
     });
 
-    server.requestHandler(router::accept).listen(8080);
+    server.requestHandler(router).listen(8080);
 
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -48,14 +48,21 @@ public interface Router extends Handler<HttpServerRequest> {
     return new RouterImpl(vertx);
   }
 
-//  /**
-//   * This method is used to provide a request to the router. Usually you take request from the
-//   * {@link io.vertx.core.http.HttpServer#requestHandler(Handler)} and pass it to this method. The
-//   * router then routes it to matching routes.
-//   *
-//   * @param request  the request
-//   */
-//  void accept(HttpServerRequest request);
+  /**
+   * This method is used to provide a request to the router. Usually you take request from the
+   * {@link io.vertx.core.http.HttpServer#requestHandler(Handler)} and pass it to this method. The
+   * router then routes it to matching routes.
+   *
+   * This method is now deprecated you can use this object directly as a request handler, which
+   * means there is no need for a method reference anymore.
+   *
+   * @param request  the request
+   * @deprecated
+   */
+  @Deprecated
+  default void accept(HttpServerRequest request) {
+    handle(request);
+  }
 
   /**
    * Add a route with no matching criteria, i.e. it matches all requests or failures.

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface Router {
+public interface Router extends Handler<HttpServerRequest> {
 
   /**
    * Create a router
@@ -48,14 +48,14 @@ public interface Router {
     return new RouterImpl(vertx);
   }
 
-  /**
-   * This method is used to provide a request to the router. Usually you take request from the
-   * {@link io.vertx.core.http.HttpServer#requestHandler(Handler)} and pass it to this method. The
-   * router then routes it to matching routes.
-   *
-   * @param request  the request
-   */
-  void accept(HttpServerRequest request);
+//  /**
+//   * This method is used to provide a request to the router. Usually you take request from the
+//   * {@link io.vertx.core.http.HttpServer#requestHandler(Handler)} and pass it to this method. The
+//   * router then routes it to matching routes.
+//   *
+//   * @param request  the request
+//   */
+//  void accept(HttpServerRequest request);
 
   /**
    * Add a route with no matching criteria, i.e. it matches all requests or failures.

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * Represents the context for the handling of a request in Vert.x-Web.
  * <p>
  * A new instance is created for each HTTP request that is received in the
- * {@link Router#accept(HttpServerRequest)} of the router.
+ * {@link Router#handle(HttpServerRequest)} of the router.
  * <p>
  * The same instance is passed to any matching request or failure handlers during the routing of the request or
  * failure.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -335,7 +335,7 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
     HttpServer server = vertx.createHttpServer();
     Router router = Router.router(vertx);
     installTestApplications(router, vertx);
-    server.requestHandler(router::accept).listen(8081);
+    server.requestHandler(router).listen(8081);
   }
 }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -73,7 +73,7 @@ public class RouterImpl implements Router {
   private Handler<Throwable> exceptionHandler;
 
   @Override
-  public void accept(HttpServerRequest request) {
+  public void handle(HttpServerRequest request) {
     if (log.isTraceEnabled()) log.trace("Router: " + System.identityHashCode(this) +
       " accepting request " + request.method() + " " + request.absoluteURI());
     new RoutingContextImpl(null, this, request, routes).next();

--- a/vertx-web/src/test/java/io/vertx/ext/web/RoutingContextNullCurrentRouteTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RoutingContextNullCurrentRouteTest.java
@@ -68,7 +68,7 @@ public class RoutingContextNullCurrentRouteTest {
                     }));
 
             vertx.createHttpServer()
-                    .requestHandler(router::accept)
+                    .requestHandler(router)
                     .listen(PORT, asyncResult -> {
                         if (asyncResult.succeeded()) {
                             startFuture.complete();

--- a/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
@@ -57,7 +57,7 @@ public class WebTestBase extends VertxTestBase {
     server = vertx.createHttpServer(getHttpServerOptions());
     client = vertx.createHttpClient(getHttpClientOptions());
     CountDownLatch latch = new CountDownLatch(1);
-    server.requestHandler(router::accept).listen(onSuccess(res -> latch.countDown()));
+    server.requestHandler(router).listen(onSuccess(res -> latch.countDown()));
     awaitLatch(latch);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -196,7 +196,7 @@ public class StaticHandlerTest extends WebTestBase {
       .setUseAlpn(true)
       .setSsl(true)
       .setPemKeyCertOptions(new PemKeyCertOptions().setKeyPath("tls/server-key.pem").setCertPath("tls/server-cert.pem")));
-    http2Server.requestHandler(router::accept).listen(8443);
+    http2Server.requestHandler(router).listen(8443);
 
     HttpClientOptions options = new HttpClientOptions()
       .setSsl(true)
@@ -229,7 +229,7 @@ public class StaticHandlerTest extends WebTestBase {
         .setUseAlpn(true)
         .setSsl(true)
         .setPemKeyCertOptions(new PemKeyCertOptions().setKeyPath("tls/server-key.pem").setCertPath("tls/server-cert.pem")));
-    http2Server.requestHandler(router::accept).listen(8443);
+    http2Server.requestHandler(router).listen(8443);
 
     HttpClientOptions options = new HttpClientOptions()
       .setSsl(true)

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
@@ -35,7 +35,7 @@ public abstract class SockJSTestBase extends VertxTestBase {
     router.route("/test/*").handler(sockJSHandler);
     server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"));
     CountDownLatch latch = new CountDownLatch(1);
-    server.requestHandler(router::accept).listen(ar -> latch.countDown());
+    server.requestHandler(router).listen(ar -> latch.countDown());
     awaitLatch(latch);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
@@ -73,7 +73,7 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
     SessionStore store1 = ClusteredSessionStore.create(vertices[0]);
     router1.route().handler(SessionHandler.create(store1));
     HttpServer server1 = vertices[0].createHttpServer(new HttpServerOptions().setPort(8081).setHost("localhost"));
-    server1.requestHandler(router1::accept);
+    server1.requestHandler(router1);
     server1.listen(onSuccess(s -> serversReady.countDown()));
     HttpClient client1 = vertices[0].createHttpClient(new HttpClientOptions());
 
@@ -82,7 +82,7 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
     SessionStore store2 = ClusteredSessionStore.create(vertices[1]);
     router2.route().handler(SessionHandler.create(store2));
     HttpServer server2 = vertices[1].createHttpServer(new HttpServerOptions().setPort(8082).setHost("localhost"));
-    server2.requestHandler(router2::accept);
+    server2.requestHandler(router2);
     server2.listen(onSuccess(s -> serversReady.countDown()));
     HttpClient client2 = vertices[0].createHttpClient(new HttpClientOptions());
 
@@ -91,7 +91,7 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
     SessionStore store3 = ClusteredSessionStore.create(vertices[2]);
     router3.route().handler(SessionHandler.create(store3));
     HttpServer server3 = vertices[2].createHttpServer(new HttpServerOptions().setPort(8083).setHost("localhost"));
-    server3.requestHandler(router3::accept);
+    server3.requestHandler(router3);
     server3.listen(onSuccess(s -> serversReady.countDown()));
     HttpClient client3 = vertices[0].createHttpClient(new HttpClientOptions());
 


### PR DESCRIPTION
Currently to use a router on a http server, one must use a method reference. Why not just have the router extend the `Handler<HttpServerRequest>` interface though?