### PR TITLE
Fix #865 Add global handlers to be added to router before swagger routes.

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -7,6 +7,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.validation.ValidationException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Francesco Guardiani @slinkydeveloper
  */
@@ -63,6 +66,7 @@ public class RouterFactoryOptions {
   private boolean mountNotImplementedHandler;
   private boolean requireSecurityHandlers;
   private boolean mountResponseContentTypeHandler;
+  private List<Handler<RoutingContext>> globalHandlers;
 
   public RouterFactoryOptions() {
     init();
@@ -80,6 +84,7 @@ public class RouterFactoryOptions {
     this.mountNotImplementedHandler = other.isMountNotImplementedHandler();
     this.requireSecurityHandlers = other.isRequireSecurityHandlers();
     this.mountResponseContentTypeHandler = other.isMountResponseContentTypeHandler();
+    this.globalHandlers = other.getGlobalHandlers();
   }
 
   public JsonObject toJson() {
@@ -95,6 +100,7 @@ public class RouterFactoryOptions {
     this.mountNotImplementedHandler = DEFAULT_MOUNT_NOT_IMPLEMENTED_HANDLER;
     this.requireSecurityHandlers = DEFAULT_REQUIRE_SECURITY_HANDLERS;
     this.mountResponseContentTypeHandler = DEFAULT_MOUNT_RESPONSE_CONTENT_TYPE_HANDLER;
+    this.globalHandlers = new ArrayList<>();
   }
 
   public Handler<RoutingContext> getValidationFailureHandler() {
@@ -195,6 +201,22 @@ public class RouterFactoryOptions {
   @Fluent
   public RouterFactoryOptions setMountResponseContentTypeHandler(boolean mountResponseContentTypeHandler) {
     this.mountResponseContentTypeHandler = mountResponseContentTypeHandler;
+    return this;
+  }
+
+  public List<Handler<RoutingContext>> getGlobalHandlers() {
+    return globalHandlers;
+  }
+
+  /**
+   * Add global handler to be applied prior to {@link io.vertx.ext.web.Router} being generated.
+   *
+   * @param globalHandler
+   * @return this object
+   */
+  @Fluent
+  public RouterFactoryOptions addGlobalHandler(Handler<RoutingContext> globalHandler) {
+    this.globalHandlers.add(globalHandler);
     return this;
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -192,11 +192,12 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
   @Override
   public Router getRouter() {
     Router router = Router.router(vertx);
-    router.route().handler(BodyHandler.create());
+    Route globalRoute = router.route();
+    globalRoute.handler(BodyHandler.create());
 
     List<Handler<RoutingContext>> globalHandlers = this.getOptions().getGlobalHandlers();
     for (Handler<RoutingContext> globalHandler: globalHandlers) {
-      router.route().handler(globalHandler);
+      globalRoute.handler(globalHandler);
     }
 
     List<Handler<RoutingContext>> globalSecurityHandlers = securityHandlers

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -193,6 +193,12 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
   public Router getRouter() {
     Router router = Router.router(vertx);
     router.route().handler(BodyHandler.create());
+
+    List<Handler<RoutingContext>> globalHandlers = this.getOptions().getGlobalHandlers();
+    for (Handler<RoutingContext> globalHandler: globalHandlers) {
+      router.route().handler(globalHandler);
+    }
+
     List<Handler<RoutingContext>> globalSecurityHandlers = securityHandlers
       .solveSecurityHandlers(spec.getSecurity(), this.getOptions().isRequireSecurityHandlers());
     for (OperationValue operation : operations.values()) {

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -573,6 +573,44 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
   }
 
   @Test
+  public void addGlobalHandlersTest() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
+      openAPI3RouterFactoryAsyncResult -> {
+        routerFactory = openAPI3RouterFactoryAsyncResult.result();
+        routerFactory.setOptions(
+          new RouterFactoryOptions()
+            .setRequireSecurityHandlers(false)
+            .addGlobalHandler(rc -> {
+              rc.response().putHeader("header-from-global-handler", "some dummy data");
+              rc.next();
+            })
+            .addGlobalHandler(rc -> {
+              rc.response().putHeader("header-from-global-handler", "some more dummy data");
+              rc.next();
+            })
+        );
+
+        routerFactory.addHandlerByOperationId("listPets", routingContext -> {
+          routingContext
+            .response()
+            .setStatusCode(200)
+            .setStatusMessage("OK")
+            .end();
+        });
+
+        latch.countDown();
+      });
+    awaitLatch(latch);
+
+    startServer();
+
+    testRequest(HttpMethod.GET, "/pets", null,
+      response -> assertEquals(response.getHeader("header-from-global-handler"),
+        "some more dummy data"), 200, "OK", null);
+  }
+
+  @Test
   public void consumesTest() throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/produces_consumes_test.yaml",


### PR DESCRIPTION
#865 Allow handlers for all routes to be added in order to the router before any other routes are added.

Signed-off-by: Paul Seddon <paul.seddon@gmail.com>