### PR TITLE
Resolve refs for requestBody definitions

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
@@ -2,6 +2,7 @@ package io.vertx.ext.web.api.contract.openapi3;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.ResolverCache;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
@@ -95,7 +96,7 @@ public interface OpenAPI3RouterFactory extends RouterFactory<OpenAPI> {
     vertx.executeBlocking((Future<OpenAPI3RouterFactory> future) -> {
       SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(url, null, OpenApi3Utils.getParseOptions());
       if (swaggerParseResult.getMessages().isEmpty()) {
-        future.complete(new OpenAPI3RouterFactoryImpl(vertx, swaggerParseResult.getOpenAPI()));
+        future.complete(new OpenAPI3RouterFactoryImpl(vertx, swaggerParseResult.getOpenAPI(), new ResolverCache(swaggerParseResult.getOpenAPI(), null, url)));
       } else {
         if (swaggerParseResult.getMessages().size() == 1 && swaggerParseResult.getMessages().get(0).matches("unable to read location `?\\Q" + url + "\\E`?"))
           future.fail(RouterFactoryException.createSpecNotExistsException(url));

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.ResolverCache;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -27,6 +28,7 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
 
   // This map is fullfilled when spec is loaded in memory
   Map<String, OperationValue> operations;
+  ResolverCache refsCache;
 
   SecurityHandlersStore securityHandlers;
 
@@ -90,8 +92,9 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
     }
   }
 
-  public OpenAPI3RouterFactoryImpl(Vertx vertx, OpenAPI spec) {
+  public OpenAPI3RouterFactoryImpl(Vertx vertx, OpenAPI spec, ResolverCache refsCache) {
     super(vertx, spec);
+    this.refsCache = refsCache;
     this.operations = new LinkedHashMap<>();
     this.securityHandlers = new SecurityHandlersStore();
 
@@ -212,7 +215,7 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
 
       // Generate ValidationHandler
       Handler<RoutingContext> validationHandler = new OpenAPI3RequestValidationHandlerImpl(operation
-        .getOperationModel(), operation.getParameters(), this.spec);
+        .getOperationModel(), operation.getParameters(), this.spec, refsCache);
       handlersToLoad.add(validationHandler);
 
       // Check validation failure handler

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenApi3Utils.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenApi3Utils.java
@@ -259,9 +259,8 @@ public class OpenApi3Utils {
         ObjectNode schema = ObjectMapperFactory.createJson().convertValue(s, ObjectNode.class);
         // We need to search inside for other refs
         if (!root.has("definitions")) {
-          ObjectNode definitions = JsonNodeFactory.instance.objectNode();
+          ObjectNode definitions = root.putObject("definitions");
           definitions.set(schemaName, schema);
-          root.putObject("definitions");
         } else {
           ((ObjectNode)root.get("definitions")).set(schemaName, schema);
         }

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ParametersUnitTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ParametersUnitTest.java
@@ -2,6 +2,7 @@ package io.vertx.ext.web.api.contract.openapi3;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.ResolverCache;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -41,11 +42,13 @@ public class OpenAPI3ParametersUnitTest extends WebTestValidationBase {
   ApiClient apiClient;
   OpenAPI3RouterFactory routerFactory;
 
+  public final static String SPEC_URL = "./src/test/resources/swaggers/openapi_parameters_compatibility_spec.yaml";
+
   @Rule
   public ExternalResource resource = new ExternalResource() {
     @Override
     protected void before() throws Throwable {
-      spec = loadSwagger("./src/test/resources/swaggers/openapi_parameters_compatibility_spec.yaml");
+      spec = loadSwagger(SPEC_URL);
     }
 
     @Override
@@ -57,7 +60,7 @@ public class OpenAPI3ParametersUnitTest extends WebTestValidationBase {
     super.setUp();
     stopServer(); // Have to stop default server of WebTestBase
     apiClient = new io.vertx.ext.web.api.contract.openapi3.ApiClient(webClient);
-    routerFactory = new OpenAPI3RouterFactoryImpl(this.vertx, spec);
+    routerFactory = new OpenAPI3RouterFactoryImpl(this.vertx, spec, new ResolverCache(spec, null, SPEC_URL));
     routerFactory.setOptions(
       new RouterFactoryOptions()
         .setRequireSecurityHandlers(false)

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebTestWithWebClientBase;
+import io.vertx.ext.web.api.RequestParameter;
 import io.vertx.ext.web.api.RequestParameters;
 import io.vertx.ext.web.api.contract.RouterFactoryOptions;
 import io.vertx.ext.web.api.contract.RouterFactoryException;
@@ -46,7 +47,7 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
   }
 
   private void startServer() throws InterruptedException {
-    Router router = routerFactory.getRouter();
+    router = routerFactory.getRouter();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"));
     CountDownLatch latch = new CountDownLatch(1);
     server.requestHandler(router::accept).listen(onSuccess(res -> {
@@ -701,5 +702,38 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
     startServer();
 
     testRequest(HttpMethod.GET, "/foo/a%3Ab?p2=a%3Ab", 200, "a:b");
+  }
+
+  @Test
+  public void testSharedRequestBody() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/shared_request_body.yaml",
+      openAPI3RouterFactoryAsyncResult -> {
+        routerFactory = openAPI3RouterFactoryAsyncResult.result();
+        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS);
+
+        final Handler<RoutingContext> handler = routingContext -> {
+          RequestParameters params = routingContext.get("parsedParameters");
+          RequestParameter body = params.body();
+          JsonObject jsonBody = body.getJsonObject();
+          routingContext
+            .response()
+            .setStatusCode(200)
+            .setStatusMessage("OK")
+            .end(jsonBody.encodePrettily());
+        };
+
+        routerFactory.addHandlerByOperationId("thisWayWorks", handler);
+        routerFactory.addHandlerByOperationId("thisWayBroken", handler);
+
+        latch.countDown();
+      });
+    awaitLatch(latch);
+
+    startServer();
+
+    JsonObject obj = new JsonObject().put("id", "aaa").put("name", "bla");
+    testRequestWithJSON(HttpMethod.POST, "/v1/working", obj, 200, "OK", obj);
+    testRequestWithJSON(HttpMethod.POST, "/v1/notworking", obj, 200, "OK", obj);
   }
 }

--- a/vertx-web-api-contract/src/test/resources/swaggers/shared_request_body.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/shared_request_body.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  description: bug repro
+  version: 1.0.0
+  title: bug repro
+
+paths:
+  /v1/working:
+    post:
+      operationId: thisWayWorks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bug'
+      responses:
+        '200':
+          $ref: '#/components/responses/200_Bug'
+
+  /v1/notworking:
+    post:
+      operationId: thisWayBroken
+      requestBody:
+        $ref: '#/components/requestBodies/Bug'
+      responses:
+        '200':
+          $ref: '#/components/responses/200_Bug'
+
+components:
+  requestBodies:
+    Bug:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Bug'
+  responses:
+    200_Bug:
+      description: Bug
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Bug'
+  schemas:
+    Bug:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - name

--- a/vertx-web/src/test/java/io/vertx/ext/web/WebTestWithWebClientBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/WebTestWithWebClientBase.java
@@ -60,7 +60,9 @@ public class WebTestWithWebClientBase extends WebTestBase {
 
   public void testRequestWithJSON(HttpMethod method, String path, JsonObject jsonObject, int statusCode, String statusMessage, JsonObject obj) throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
-    webClient.request(method, 8080, "localhost", path).sendJsonObject(jsonObject, (ar) -> {
+    webClient.request(method, 8080, "localhost", path)
+      .putHeader("content-type", "application/json")
+      .sendJsonObject(jsonObject, (ar) -> {
       assertEquals(statusCode, ar.result().statusCode());
       assertEquals(statusMessage, ar.result().statusMessage());
       assertEquals(obj, ar.result().bodyAsJsonObject());


### PR DESCRIPTION
Fixes #861 and #883. Before accepting this, we should wait if it's possible to get the refs cache directly from the parser, avoiding creating a new one: https://github.com/swagger-api/swagger-parser/issues/669