### PR TITLE
Enable Rocker templating for Java 9

### DIFF
--- a/vertx-template-engines/pom.xml
+++ b/vertx-template-engines/pom.xml
@@ -24,25 +24,7 @@
     <module>vertx-web-templ-thymeleaf</module>
     <module>vertx-web-templ-freemarker</module>
     <module>vertx-web-templ-pebble</module>
+    <module>vertx-web-templ-rocker</module>
   </modules>
-
-  <profiles>
-    <!-- Rocker template engine maven plugin does not seem to work with Java 9: https://github.com/fizzed/rocker/issues/73 -->
-    <profile>
-      <id>java-1.8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <modules>
-        <module>vertx-web-templ-jade</module>
-        <module>vertx-web-templ-mvel</module>
-        <module>vertx-web-templ-handlebars</module>
-        <module>vertx-web-templ-thymeleaf</module>
-        <module>vertx-web-templ-freemarker</module>
-        <module>vertx-web-templ-pebble</module>
-        <module>vertx-web-templ-rocker</module>
-      </modules>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Rocker 24.0 added support for Java 9: https://github.com/fizzed/rocker/pull/82

6360352319764bc60264b881eae5d0d34b62f2f9 upgraded the Rocker dependency to version 24.0, so we can remove the separate Java 8 profile