### PR TITLE
Header values comparation case insensitive

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ParsableHeaderValue.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ParsableHeaderValue.java
@@ -79,7 +79,7 @@ public class ParsableHeaderValue implements ParsedHeaderValue {
       String parameterValueToTest = parameter.get(requiredParameter.getKey());
       String requiredParamVal = requiredParameter.getValue();
       if (parameterValueToTest == null || (
-          !requiredParamVal.isEmpty() && !requiredParamVal.equals(parameterValueToTest))
+          !requiredParamVal.isEmpty() && !requiredParamVal.equalsIgnoreCase(parameterValueToTest))
          ){
         return false;
       }

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/ParsableHeaderValueTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/ParsableHeaderValueTest.java
@@ -1,0 +1,37 @@
+package io.vertx.ext.web.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.web.ParsedHeaderValue;
+
+import static org.junit.Assert.*;
+
+public class ParsableHeaderValueTest {
+	
+	private ParsableHeaderValue headerValue;
+	
+	@Before
+	public void initialize() {
+		headerValue = new ParsableHeaderValue("application/json; charset=UTF-8");
+	}
+
+	@Test
+	public void testIsMatchedByEqualsCases() {
+		ParsedHeaderValue value = new ParsableMIMEValue("application/json; charset=UTF-8").forceParse();
+		assertTrue(headerValue.isMatchedBy(value));
+	}
+	
+	@Test
+	public void testIsMatchedByDiffCases() {
+		ParsedHeaderValue value = new ParsableMIMEValue("application/json; charset=utf-8").forceParse();
+		assertTrue(headerValue.isMatchedBy(value));
+	}
+	
+	@Test
+	public void testIsMatchedByDiff() {
+		ParsedHeaderValue value = new ParsableMIMEValue("application/json; charset=UTF-16").forceParse();
+		assertFalse(headerValue.isMatchedBy(value));
+	}
+	
+}


### PR DESCRIPTION
Fixes #926. According to _RFC 2045 article 5.1_, "Matching of media type and subtype is ALWAYS case-insensitive". This pull request replaces **equals** to **equalsIgnoreCase**, in the content type comparation.