### PR TITLE
Fix a potential deadlock case in failure handling

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -215,12 +215,24 @@ public class RouteImpl implements Route {
     return sb.toString();
   }
 
-  synchronized void handleContext(RoutingContextImplBase context) {
-    contextHandlers.get(context.currentRouteNextHandlerIndex() - 1).handle(context);
+  void handleContext(RoutingContextImplBase context) {
+    Handler<RoutingContext> contextHandler;
+
+    synchronized (this) {
+      contextHandler = contextHandlers.get(context.currentRouteNextHandlerIndex() - 1);
+    }
+
+    contextHandler.handle(context);
   }
 
-  synchronized void handleFailure(RoutingContextImplBase context) {
-    failureHandlers.get(context.currentRouteNextFailureHandlerIndex() - 1).handle(context);
+  void handleFailure(RoutingContextImplBase context) {
+    Handler<RoutingContext> failureHandler;
+
+    synchronized (this) {
+      failureHandler = failureHandlers.get(context.currentRouteNextFailureHandlerIndex() - 1);
+    }
+
+    failureHandler.handle(context);
   }
 
   synchronized boolean matches(RoutingContextImplBase context, String mountPoint, boolean failure) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -20,14 +20,19 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -2307,5 +2312,67 @@ public class RouterTest extends WebTestBase {
     String path = "?test=something";
     router.route().handler(rc -> rc.response().end());
     testRequest(HttpMethod.GET, path, 400, "Bad Request");
+  }
+
+  @Test
+  public void testMultipleHandlersWithFailuresDeadlock() throws Exception {
+    AtomicBoolean first = new AtomicBoolean(true);
+    CountDownLatch firstHandlerLatch = new CountDownLatch(1);
+    CountDownLatch secondHandlerLatch = new CountDownLatch(1);
+
+    router.get("/path").handler(event -> {
+      if (!first.compareAndSet(true, false)) {
+        // Second run, block until the second handler runs
+        try {
+          firstHandlerLatch.countDown();
+          awaitLatch(secondHandlerLatch);
+
+          // Add a small delay so the exception handler happens first
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          // ignore
+        }
+
+        event.next();
+      } else {
+        vertx.executeBlocking(future -> {
+          event.next();
+          future.complete();
+        }, asyncResult -> {});
+      }
+    });
+
+    router.get("/path").handler(event -> {
+      try {
+        awaitLatch(firstHandlerLatch);
+      } catch (InterruptedException e) {
+        // ignore
+      }
+      secondHandlerLatch.countDown();
+      event.fail(new NullPointerException());
+    });
+
+    CountDownLatch latch = new CountDownLatch(2);
+    for (int i = 0; i < 2; i++) {
+      vertx.executeBlocking(future -> {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(request.rawMethod()).thenReturn("GET");
+        when(request.uri()).thenReturn("http://localhost/path");
+        when(request.absoluteURI()).thenReturn("http://localhost/path");
+        when(request.host()).thenReturn("localhost");
+        when(request.path()).thenReturn("/path");
+        when(request.response()).thenReturn(response);
+        when(response.ended()).thenReturn(true);
+        router.accept(request);
+        future.complete();
+      }, asyncResult -> {
+        assertFalse(asyncResult.failed());
+        assertNull(asyncResult.cause());
+        latch.countDown();
+      });
+    }
+    awaitLatch(latch);
   }
 }


### PR DESCRIPTION
This is essentially caused by calling the user-supplied RoutingContext handler in the synchronization block of RouteImpl, in addition to two conditions that can happen.

1. A handler may decided to release the synchronization lock on previous RouteImpl instances by scheduling an event, and regain the synchronization lock on the current RouteImpl only.
2. When a handler calls fail directly or indirectly because of exception in the handler, the scanning of failure handlers will go back to the first RouteImpl in RouterImpl, which requires gaining the synchronization lock of previous RouteImpl instances.

Imagine we have two threads and two RouteImpl instances, Route1 and Route2, in RouterImpl:
Thread 1: Lock Route1, Lock Route2, Release Route1 and Route2 due to scheduling an event, Lock Route2 only due to the scheduled event execution in the same thread, Try lock Route1 due to failure handling
Thread 2: Lock Route1, Try lock Route2 due to normal processing.

This creates a deadlock.

See the added unit test for details of how this can be reproduced. Timing is critical so CountDownLatch is used to sequence how things happen.