### PR TITLE
Do not override CORS for SockJS

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
@@ -50,6 +50,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 import io.vertx.ext.web.handler.sockjs.Transport;
+import io.vertx.ext.web.impl.Utils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -158,11 +159,14 @@ class BaseTransport {
     if (origin == null || "null".equals(origin)) {
       origin = "*";
     }
-    req.response().headers().set("Access-Control-Allow-Origin", origin);
-    req.response().headers().set("Access-Control-Allow-Credentials", "true");
+    Utils.addToMapIfAbsent(req.response().headers(), "Access-Control-Allow-Origin", origin);
+    // https://developer.mozilla.org/En/HTTP_access_control#Requests_with_credentials
+    if (!"*".equals(origin)) {
+      Utils.addToMapIfAbsent(req.response().headers(), "Access-Control-Allow-Credentials", "true");
+    }
     String hdr = req.headers().get("Access-Control-Request-Headers");
     if (hdr != null) {
-      req.response().headers().set("Access-Control-Allow-Headers", hdr);
+      Utils.addToMapIfAbsent(req.response().headers(), "Access-Control-Allow-Headers", hdr);
     }
   }
 

--- a/vertx-web/src/test/sockjs-protocol/sockjs-protocol-0.3.3.py
+++ b/vertx-web/src/test/sockjs-protocol/sockjs-protocol-0.3.3.py
@@ -109,11 +109,11 @@ class Test(unittest.TestCase):
     def verify_cors(self, r, origin=None):
         if origin and origin != 'null':
             self.assertEqual(r['access-control-allow-origin'], origin)
+            # In order to get cookies (`JSESSIONID` mostly) flying, we
+            # need to set `allow-credentials` header to true.
+            self.assertEqual(r['access-control-allow-credentials'], 'true')
         else:
             self.assertEqual(r['access-control-allow-origin'], '*')
-        # In order to get cookies (`JSESSIONID` mostly) flying, we
-        # need to set `allow-credentials` header to true.
-        self.assertEqual(r['access-control-allow-credentials'], 'true')
 
     # Sometimes, due to transports limitations we need to request
     # private data using GET method. In such case it's very important


### PR DESCRIPTION
Fixes #649

Does not override CORS headers if headers have been set by for example the CORS handler. It also respects the requirement that user credentials are not allowed for wildcard origin