### PR TITLE
Javadoc: HttpResponse bodyAs methods return null if body codec is not "Buffer"

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
@@ -110,14 +110,14 @@ public interface HttpResponse<T> {
   T body();
 
   /**
-   * @return the response body decoded as a {@link Buffer}, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as a {@link Buffer}, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
   Buffer bodyAsBuffer();
 
   /**
-   * @return the response body decoded as a {@code String}, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as a {@code String}, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
@@ -127,7 +127,7 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as a {@code String} given a specific {@code encoding}, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as a {@code String} given a specific {@code encoding}, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @Nullable
   default String bodyAsString(String encoding) {
@@ -136,7 +136,7 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as {@link JsonObject}, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as {@link JsonObject}, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
@@ -146,14 +146,14 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as a {@link JsonArray}, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as a {@link JsonArray}, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
   JsonArray bodyAsJsonArray();
 
   /**
-   * @return the response body decoded as the specified {@code type} with the Jackson mapper, or null if a codec other than {@link BodyCodec#buffer()} was used
+   * @return the response body decoded as the specified {@code type} with the Jackson mapper, or {@code null} if a codec other than {@link BodyCodec#buffer()} was used
    */
   @Nullable
   default <R> R bodyAsJson(Class<R> type) {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
@@ -15,8 +15,6 @@
  */
 package io.vertx.ext.web.client;
 
-import java.util.List;
-
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
@@ -25,7 +23,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
+
+import java.util.List;
 
 /**
  * An HTTP response.
@@ -109,14 +110,14 @@ public interface HttpResponse<T> {
   T body();
 
   /**
-   * @return the response body decoded as a {@link Buffer}
+   * @return the response body decoded as a {@link Buffer}, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
   Buffer bodyAsBuffer();
 
   /**
-   * @return the response body decoded as a {@code String}
+   * @return the response body decoded as a {@code String}, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
@@ -126,7 +127,7 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as a {@code String} given a specific {@code encoding}
+   * @return the response body decoded as a {@code String} given a specific {@code encoding}, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @Nullable
   default String bodyAsString(String encoding) {
@@ -135,7 +136,7 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as a json object
+   * @return the response body decoded as {@link JsonObject}, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
@@ -145,14 +146,14 @@ public interface HttpResponse<T> {
   }
 
   /**
-   * @return the response body decoded as a json array
+   * @return the response body decoded as a {@link JsonArray}, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @CacheReturn
   @Nullable
   JsonArray bodyAsJsonArray();
 
   /**
-   * @return the response body decoded as the specified {@code type} with the Jackson mapper.
+   * @return the response body decoded as the specified {@code type} with the Jackson mapper, or null if a codec other than {@link BodyCodec#buffer()} was used
    */
   @Nullable
   default <R> R bodyAsJson(Class<R> type) {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -15,19 +15,8 @@
  */
 package io.vertx.ext.web.client.impl;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 import io.netty.handler.codec.http.QueryStringEncoder;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -42,6 +31,12 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.codec.spi.BodyStream;
 import io.vertx.ext.web.multipart.MultipartForm;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -147,7 +142,6 @@ public class HttpContext {
                     resp.headers(),
                     resp.trailers(),
                     resp.cookies(),
-                    null,
                     stream.result().result()));
                 } else {
                   fut.fail(stream.result().cause());

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpResponseImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpResponseImpl.java
@@ -15,14 +15,14 @@
  */
 package io.vertx.ext.web.client.impl;
 
-import java.util.List;
-
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
+
+import java.util.List;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -35,7 +35,6 @@ class HttpResponseImpl<T> implements HttpResponse<T> {
   private final MultiMap headers;
   private final MultiMap trailers;
   private final List<String> cookies;
-  private final Buffer buff;
   private final T body;
 
   public HttpResponseImpl(HttpVersion version,
@@ -44,7 +43,6 @@ class HttpResponseImpl<T> implements HttpResponse<T> {
                           MultiMap headers,
                           MultiMap trailers,
                           List<String> cookies,
-                          Buffer buff,
                           T body) {
     this.version = version;
     this.statusCode = statusCode;
@@ -52,7 +50,6 @@ class HttpResponseImpl<T> implements HttpResponse<T> {
     this.headers = headers;
     this.trailers = trailers;
     this.cookies = cookies;
-    this.buff = buff;
     this.body = body;
   }
 
@@ -103,7 +100,7 @@ class HttpResponseImpl<T> implements HttpResponse<T> {
 
   @Override
   public Buffer bodyAsBuffer() {
-    return buff != null ? buff : body instanceof Buffer ? (Buffer)body : null;
+    return body instanceof Buffer ? (Buffer) body : null;
   }
 
   @Override


### PR DESCRIPTION
Fixes #828