### PR TITLE
Update pebble and add vert.x json object/array resolving support

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-pebble/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
 	    <groupId>io.pebbletemplates</groupId>
 	    <artifactId>pebble</artifactId>
-	    <version>3.0.0</version>
+	    <version>3.0.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
@@ -20,7 +20,11 @@ import com.mitchellbosecke.pebble.PebbleEngine;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.templ.pebble.impl.PebbleTemplateEngineImpl;
 

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/JsonArrayAttributeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/JsonArrayAttributeResolver.java
@@ -1,0 +1,38 @@
+package io.vertx.ext.web.templ.pebble.impl;
+
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.attributes.ResolvedAttribute;
+import com.mitchellbosecke.pebble.node.ArgumentsNode;
+import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
+
+import io.vertx.core.json.JsonArray;
+
+public class JsonArrayAttributeResolver implements AttributeResolver {
+
+  @Override
+  public ResolvedAttribute resolve(Object instance, Object attributeNameValue, Object[] argumentValues, ArgumentsNode args,
+    EvaluationContextImpl context, String filename, int lineNumber) {
+    // Only handle fields. Don't handle method calls with arguments
+    if (instance instanceof JsonArray && argumentValues == null) {
+      JsonArray jsonArray = ((JsonArray) instance);
+      if (attributeNameValue instanceof String) {
+        String name = (String) attributeNameValue;
+        if ("length".equals(name) || "size".equals(name)) {
+          return new ResolvedAttribute(jsonArray.size());
+        }
+      } else if (attributeNameValue instanceof Number) {
+        Number num = (Number) attributeNameValue;
+        int idx = num.intValue();
+        if (idx > jsonArray.size()) {
+          return new ResolvedAttribute(null);
+        }
+        Object value = jsonArray.getValue(idx);
+        if (value != null) {
+          return new ResolvedAttribute(value);
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/JsonObjectAttributeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/JsonObjectAttributeResolver.java
@@ -1,0 +1,29 @@
+package io.vertx.ext.web.templ.pebble.impl;
+
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.attributes.ResolvedAttribute;
+import com.mitchellbosecke.pebble.node.ArgumentsNode;
+import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
+
+import io.vertx.core.json.JsonObject;
+
+public class JsonObjectAttributeResolver implements AttributeResolver {
+
+  @Override
+  public ResolvedAttribute resolve(Object instance, Object attributeNameValue, Object[] argumentValues, ArgumentsNode args,
+    EvaluationContextImpl context, String filename, int lineNumber) {
+    if (instance instanceof JsonObject) {
+      JsonObject json = (JsonObject) instance;
+      if (attributeNameValue instanceof String) {
+        String name = (String) attributeNameValue;
+        // We only return found values. Resolved null values will be returned by the default resolvers of pebble
+        if (json.containsKey(name)) {
+          Object value = json.getValue(name);
+          return new ResolvedAttribute(value);
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
@@ -39,7 +39,7 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
-    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).cacheActive(false).build());
+    this(new PebbleEngine.Builder().extension(new VertxAttributeResolverExtension()).loader(new PebbleVertxLoader(vertx)).cacheActive(false).build());
   }
 
   public PebbleTemplateEngineImpl(PebbleEngine engine) {

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/VertxAttributeResolverExtension.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/VertxAttributeResolverExtension.java
@@ -1,0 +1,18 @@
+package io.vertx.ext.web.templ.pebble.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.extension.AbstractExtension;
+
+public class VertxAttributeResolverExtension extends AbstractExtension {
+
+  @Override
+  public List<AttributeResolver> getAttributeResolver() {
+    List<AttributeResolver> attributeResolvers = new ArrayList<>();
+    attributeResolvers.add(new JsonObjectAttributeResolver());
+    attributeResolvers.add(new JsonArrayAttributeResolver());
+    return attributeResolvers;
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template6.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template6.peb
@@ -1,0 +1,1 @@
+No number index: {{foo["bar"].name}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template7.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template7.peb
@@ -1,0 +1,1 @@
+Goodbye {{foo.bar.one}} and {{foo.bar.two}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template8.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template8.peb
@@ -1,0 +1,1 @@
+Iterator: {% for item in foo %}{{item}},{% endfor %} Element by index:{{foo[1]}} - {{foo[2].name}} - Out of bounds: {{foo[42].name}} - Size:{{foo.length}}


### PR DESCRIPTION
This change adds the resolving logic for JsonObject and JsonArray to pebble which I have already added to handlebars.