### PR TITLE
Expose openAPI extensions to routing context

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -241,6 +241,12 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
       OpenAPI3PathResolver pathResolver = new OpenAPI3PathResolver(operation.getPath(), operation.getParameters());
       Route route = router.routeWithRegex(operation.getMethod(), pathResolver.solve().toString());
 
+      // Add OpenAPI extensions to the routing context
+      Map<String, Object> extensions = operation.getOperationModel().getExtensions();
+      if(extensions != null) {
+        route.handler(ctx -> ctx.put("openapi-extensions", extensions).next());
+      }
+
       // Set produces/consumes
       Set<String> consumes = new HashSet<>();
       Set<String> produces = new HashSet<>();

--- a/vertx-web-api-contract/src/test/resources/swaggers/router_factory_test.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/router_factory_test.yaml
@@ -39,6 +39,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+      x-test-extension: test
     post:
       summary: Create a pet
       operationId: createPets


### PR DESCRIPTION
The OpenAPI specification allows adding custom properties (so-called extensions: https://swagger.io/specification/#specificationExtensions) to the schema. 

Currently, there's no way for the underlying code to get the values of those extensions

This pull request exposes the raw map of extensions (already parsed by swagger-parser) to the routing context