### PR TITLE
Expose openAPI model to routing context

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
@@ -11,6 +11,9 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[exposeConfigurationKey]]`@exposeConfigurationKey`|`String`|+++
+If set, the operation configuration will be exposed in the routing context
++++
 |[[mountNotImplementedHandler]]`@mountNotImplementedHandler`|`Boolean`|+++
 Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
 +++

--- a/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
@@ -23,7 +23,8 @@ Enable or disable validation failure handler. If you enable it during router cre
  handler will be called.
 +++
 |[[operationModelKey]]`@operationModelKey`|`String`|+++
-If set, the operation configuration will be exposed in the routing context
+When set, an additional handler will be created to expose the operation model in the routing
+ context under the given key. When the key is null, the handler is not added.
 +++
 |[[requireSecurityHandlers]]`@requireSecurityHandlers`|`Boolean`|+++
 If true, when you call link the factory will mount for every path

--- a/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
@@ -11,9 +11,6 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[exposeConfigurationKey]]`@exposeConfigurationKey`|`String`|+++
-If set, the operation configuration will be exposed in the routing context
-+++
 |[[mountNotImplementedHandler]]`@mountNotImplementedHandler`|`Boolean`|+++
 Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
 +++
@@ -24,6 +21,9 @@ If true, when required, the factory will mount a link
 Enable or disable validation failure handler. If you enable it during router creation a failure handler
  that manages ValidationException will be mounted. You can change the validation failure handler with with function link. If failure is different from ValidationException, next failure
  handler will be called.
++++
+|[[operationModelKey]]`@operationModelKey`|`String`|+++
+If set, the operation configuration will be exposed in the routing context
 +++
 |[[requireSecurityHandlers]]`@requireSecurityHandlers`|`Boolean`|+++
 If true, when you call link the factory will mount for every path

--- a/vertx-web-api-contract/src/main/generated/io/vertx/ext/web/api/contract/RouterFactoryOptionsConverter.java
+++ b/vertx-web-api-contract/src/main/generated/io/vertx/ext/web/api/contract/RouterFactoryOptionsConverter.java
@@ -14,11 +14,6 @@ import java.time.format.DateTimeFormatter;
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RouterFactoryOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "exposeConfigurationKey":
-          if (member.getValue() instanceof String) {
-            obj.setExposeConfigurationKey((String)member.getValue());
-          }
-          break;
         case "mountNotImplementedHandler":
           if (member.getValue() instanceof Boolean) {
             obj.setMountNotImplementedHandler((Boolean)member.getValue());
@@ -32,6 +27,11 @@ import java.time.format.DateTimeFormatter;
         case "mountValidationFailureHandler":
           if (member.getValue() instanceof Boolean) {
             obj.setMountValidationFailureHandler((Boolean)member.getValue());
+          }
+          break;
+        case "operationModelKey":
+          if (member.getValue() instanceof String) {
+            obj.setOperationModelKey((String)member.getValue());
           }
           break;
         case "requireSecurityHandlers":
@@ -48,12 +48,12 @@ import java.time.format.DateTimeFormatter;
   }
 
    static void toJson(RouterFactoryOptions obj, java.util.Map<String, Object> json) {
-    if (obj.getExposeConfigurationKey() != null) {
-      json.put("exposeConfigurationKey", obj.getExposeConfigurationKey());
-    }
     json.put("mountNotImplementedHandler", obj.isMountNotImplementedHandler());
     json.put("mountResponseContentTypeHandler", obj.isMountResponseContentTypeHandler());
     json.put("mountValidationFailureHandler", obj.isMountValidationFailureHandler());
+    if (obj.getOperationModelKey() != null) {
+      json.put("operationModelKey", obj.getOperationModelKey());
+    }
     json.put("requireSecurityHandlers", obj.isRequireSecurityHandlers());
   }
 }

--- a/vertx-web-api-contract/src/main/generated/io/vertx/ext/web/api/contract/RouterFactoryOptionsConverter.java
+++ b/vertx-web-api-contract/src/main/generated/io/vertx/ext/web/api/contract/RouterFactoryOptionsConverter.java
@@ -14,6 +14,11 @@ import java.time.format.DateTimeFormatter;
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RouterFactoryOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "exposeConfigurationKey":
+          if (member.getValue() instanceof String) {
+            obj.setExposeConfigurationKey((String)member.getValue());
+          }
+          break;
         case "mountNotImplementedHandler":
           if (member.getValue() instanceof Boolean) {
             obj.setMountNotImplementedHandler((Boolean)member.getValue());
@@ -43,6 +48,9 @@ import java.time.format.DateTimeFormatter;
   }
 
    static void toJson(RouterFactoryOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getExposeConfigurationKey() != null) {
+      json.put("exposeConfigurationKey", obj.getExposeConfigurationKey());
+    }
     json.put("mountNotImplementedHandler", obj.isMountNotImplementedHandler());
     json.put("mountResponseContentTypeHandler", obj.isMountResponseContentTypeHandler());
     json.put("mountValidationFailureHandler", obj.isMountValidationFailureHandler());

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -59,6 +59,11 @@ public class RouterFactoryOptions {
    */
   public final static boolean DEFAULT_MOUNT_RESPONSE_CONTENT_TYPE_HANDLER = true;
 
+  /**
+   * By default, RouterFactory will not expose operation configuration in the the routing context
+   */
+  public final static String DEFAULT_EXPOSE_CONFIGURATION_KEY = null;
+
   private Handler<RoutingContext> validationFailureHandler;
   private boolean mountValidationFailureHandler;
   private Handler<RoutingContext> notImplementedFailureHandler;
@@ -67,6 +72,7 @@ public class RouterFactoryOptions {
   private boolean mountResponseContentTypeHandler;
   private BodyHandler bodyHandler;
   private List<Handler<RoutingContext>> globalHandlers;
+  private String exposeConfigurationKey;
 
   public RouterFactoryOptions() {
     init();
@@ -86,6 +92,7 @@ public class RouterFactoryOptions {
     this.mountResponseContentTypeHandler = other.isMountResponseContentTypeHandler();
     this.bodyHandler = other.getBodyHandler();
     this.globalHandlers = other.getGlobalHandlers();
+    this.exposeConfigurationKey = other.getExposeConfigurationKey();
   }
 
   public JsonObject toJson() {
@@ -103,6 +110,7 @@ public class RouterFactoryOptions {
     this.mountResponseContentTypeHandler = DEFAULT_MOUNT_RESPONSE_CONTENT_TYPE_HANDLER;
     this.bodyHandler = BodyHandler.create();
     this.globalHandlers = new ArrayList<>();
+    this.exposeConfigurationKey = DEFAULT_EXPOSE_CONFIGURATION_KEY;
   }
 
   public Handler<RoutingContext> getValidationFailureHandler() {
@@ -235,6 +243,21 @@ public class RouterFactoryOptions {
   @Fluent
   public RouterFactoryOptions addGlobalHandler(Handler<RoutingContext> globalHandler) {
     this.globalHandlers.add(globalHandler);
+    return this;
+  }
+
+  public String getExposeConfigurationKey() {
+    return exposeConfigurationKey;
+  }
+
+  /**
+   * If set, the operation configuration will be exposed in the routing context
+   * @param exposeConfigurationKey
+   * @return
+   */
+  @Fluent
+  public RouterFactoryOptions setExposeConfigurationKey(String exposeConfigurationKey) {
+    this.exposeConfigurationKey = exposeConfigurationKey;
     return this;
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -72,7 +72,7 @@ public class RouterFactoryOptions {
   private boolean mountResponseContentTypeHandler;
   private BodyHandler bodyHandler;
   private List<Handler<RoutingContext>> globalHandlers;
-  private String exposeConfigurationKey;
+  private String operationModelKey;
 
   public RouterFactoryOptions() {
     init();
@@ -92,7 +92,7 @@ public class RouterFactoryOptions {
     this.mountResponseContentTypeHandler = other.isMountResponseContentTypeHandler();
     this.bodyHandler = other.getBodyHandler();
     this.globalHandlers = other.getGlobalHandlers();
-    this.exposeConfigurationKey = other.getExposeConfigurationKey();
+    this.operationModelKey = other.getOperationModelKey();
   }
 
   public JsonObject toJson() {
@@ -110,7 +110,7 @@ public class RouterFactoryOptions {
     this.mountResponseContentTypeHandler = DEFAULT_MOUNT_RESPONSE_CONTENT_TYPE_HANDLER;
     this.bodyHandler = BodyHandler.create();
     this.globalHandlers = new ArrayList<>();
-    this.exposeConfigurationKey = DEFAULT_EXPOSE_CONFIGURATION_KEY;
+    this.operationModelKey = DEFAULT_EXPOSE_CONFIGURATION_KEY;
   }
 
   public Handler<RoutingContext> getValidationFailureHandler() {
@@ -246,18 +246,18 @@ public class RouterFactoryOptions {
     return this;
   }
 
-  public String getExposeConfigurationKey() {
-    return exposeConfigurationKey;
+  public String getOperationModelKey() {
+    return operationModelKey;
   }
 
   /**
    * If set, the operation configuration will be exposed in the routing context
-   * @param exposeConfigurationKey
+   * @param operationModelKey
    * @return
    */
   @Fluent
-  public RouterFactoryOptions setExposeConfigurationKey(String exposeConfigurationKey) {
-    this.exposeConfigurationKey = exposeConfigurationKey;
+  public RouterFactoryOptions setOperationModelKey(String operationModelKey) {
+    this.operationModelKey = operationModelKey;
     return this;
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -251,7 +251,8 @@ public class RouterFactoryOptions {
   }
 
   /**
-   * If set, the operation configuration will be exposed in the routing context
+   * When set, an additional handler will be created to expose the operation model in the routing
+   * context under the given key. When the key is null, the handler is not added.
    * @param operationModelKey
    * @return
    */

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -241,6 +241,10 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
       OpenAPI3PathResolver pathResolver = new OpenAPI3PathResolver(operation.getPath(), operation.getParameters());
       Route route = router.routeWithRegex(operation.getMethod(), pathResolver.solve().toString());
 
+      String exposeConfigurationKey = this.getOptions().getExposeConfigurationKey();
+      if (exposeConfigurationKey != null)
+        route.handler(context -> context.put(exposeConfigurationKey, operation.getOperationModel()).next());
+
       // Set produces/consumes
       Set<String> consumes = new HashSet<>();
       Set<String> produces = new HashSet<>();

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -241,7 +241,7 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
       OpenAPI3PathResolver pathResolver = new OpenAPI3PathResolver(operation.getPath(), operation.getParameters());
       Route route = router.routeWithRegex(operation.getMethod(), pathResolver.solve().toString());
 
-      String exposeConfigurationKey = this.getOptions().getExposeConfigurationKey();
+      String exposeConfigurationKey = this.getOptions().getOperationModelKey();
       if (exposeConfigurationKey != null)
         route.handler(context -> context.put(exposeConfigurationKey, operation.getOperationModel()).next());
 

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -601,7 +601,7 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(new RouterFactoryOptions().setExposeConfigurationKey("fooBarKey"));
+        routerFactory.setOptions(new RouterFactoryOptions().setOperationModelKey("fooBarKey"));
 
         routerFactory.addHandlerByOperationId("listPets", routingContext -> {
           Operation operation = routingContext.get("fooBarKey");

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.api.contract.openapi3;
 
+import io.swagger.v3.oas.models.Operation;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientOptions;
@@ -592,6 +593,33 @@ public class OpenAPI3RouterFactoryTest extends WebTestWithWebClientBase {
     testRequest(HttpMethod.GET, "/pets", null,
       response -> assertEquals(response.getHeader("header-from-global-handler"),
         "some more dummy data"), 200, "OK", null);
+  }
+
+  @Test
+  public void exposeConfigurationTest() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
+      openAPI3RouterFactoryAsyncResult -> {
+        routerFactory = openAPI3RouterFactoryAsyncResult.result();
+        routerFactory.setOptions(new RouterFactoryOptions().setExposeConfigurationKey("fooBarKey"));
+
+        routerFactory.addHandlerByOperationId("listPets", routingContext -> {
+          Operation operation = routingContext.get("fooBarKey");
+
+          routingContext
+            .response()
+            .setStatusCode(200)
+            .setStatusMessage("OK")
+            .end(operation.getOperationId());
+        });
+
+        latch.countDown();
+      });
+    awaitLatch(latch);
+
+    startServer();
+
+    testRequest(HttpMethod.GET, "/pets", 200, "OK", "listPets");
   }
 
   @Test


### PR DESCRIPTION
Similar to #1000, the idea is to expose configuration (and thus also extension properties) to the routing context, so that it can be used in the code