### PR TITLE
Add simple test for multipart file upload

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/client/MultipartFileUploadTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/client/MultipartFileUploadTest.java
@@ -1,0 +1,94 @@
+package io.vertx.ext.web.client;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URL;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.impl.MultipartFormUpload;
+import io.vertx.ext.web.client.testserver.MainVerticle;
+import io.vertx.ext.web.multipart.MultipartForm;
+
+@RunWith(VertxUnitRunner.class)
+public class MultipartFileUploadTest {
+	private Vertx vertx;
+	private int port;
+	private final static Logger LOGGER = LoggerFactory.getLogger(MultipartFileUploadTest.class);
+
+	@Before
+	public void deployVerticle(TestContext testContext) throws IOException {
+		vertx = Vertx.vertx();
+
+		ServerSocket socket = new ServerSocket(0);
+		port = socket.getLocalPort();
+		socket.close();
+
+		DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
+
+		vertx.deployVerticle(MainVerticle.class.getName(), options, testContext.asyncAssertSuccess());
+	}
+
+	@After
+	public void stopVertx(TestContext context) {
+		vertx.close(context.asyncAssertSuccess());
+	}
+
+	@Test
+	public void testPostFile(TestContext context) throws Exception {
+		Async async = context.async();
+
+		URL testFileResource = this.getClass().getResource("/test.bin");
+		
+		final MultipartForm parts = MultipartForm.create();
+		parts.attribute("attribute", "value");
+		parts.binaryFileUpload("fileToUpload","file.bin",testFileResource.getFile(), "application/octet-stream");
+
+		HttpClientRequest request = vertx.createHttpClient().post(port, "localhost", "/post")
+				.handler(response -> {
+					context.assertEquals(201, response.statusCode());
+				}).endHandler(end -> {
+					LOGGER.info("Request complete.");
+					async.complete();
+				}).exceptionHandler(t -> {
+					LOGGER.error(t);
+					context.fail();
+					async.complete();
+				});
+
+		MultipartFormUpload upload = new MultipartFormUpload(vertx.getOrCreateContext(), parts, true);
+		upload.run();
+		upload.endHandler(e -> {
+			LOGGER.info("Finished handling data.");
+			// LOGGER.info("" + request.headers());
+			// request.end();
+		});
+		upload.handler(data -> {
+			LOGGER.info("Handling data: " + data);
+			request.putHeader("Content-Length", String.valueOf(data.length()));
+			//request.putHeader("Content-Type", "multipart/form-data");
+
+			request.write(data).end();
+		});
+		upload.exceptionHandler(t -> {
+			LOGGER.error(t);
+			context.fail();
+			async.complete();
+		});
+		upload.resume();
+
+		async.await(3000L);
+	}
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/DefaultHandler.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/DefaultHandler.java
@@ -1,0 +1,24 @@
+package io.vertx.ext.web.client.testserver;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
+
+public final class DefaultHandler implements Handler<RoutingContext> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHandler.class);
+
+	@Override
+	public void handle(RoutingContext context) {
+		LOGGER.info("Handling default call");
+		// This handler will be called for every request
+		HttpServerResponse response = context.response();
+		response.putHeader("content-type", "text/plain");
+
+		// Write to the response and end it
+		response.end("Vertx Server to Test Vertx Client.");
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/FileUploadHandler.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/FileUploadHandler.java
@@ -1,0 +1,30 @@
+package io.vertx.ext.web.client.testserver;
+
+import java.util.Set;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+public final class FileUploadHandler implements Handler<RoutingContext> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(FileUploadHandler.class);
+
+	@Override
+	public void handle(RoutingContext context) {
+		LOGGER.debug("Post called!");
+		Set<FileUpload> uploads = context.fileUploads();
+		LOGGER.debug("Number of uploads: " + uploads.size());
+		HttpServerResponse response = context.response();
+		if (uploads.size() > 0) {
+			response.setStatusCode(201);
+		} else {
+			response.setStatusCode(400);
+		}
+		response.end();
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/MainVerticle.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/client/testserver/MainVerticle.java
@@ -1,0 +1,38 @@
+package io.vertx.ext.web.client.testserver;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class MainVerticle extends AbstractVerticle {
+	
+	private final static Logger LOGGER = LoggerFactory.getLogger(MainVerticle.class);
+
+	@Override
+	public void start(Future<Void> startFuture) throws Exception {
+		Router mainRouter = Router.router(vertx);
+		Router v3ApiRouter = Router.router(vertx);
+
+		mainRouter.route().last().handler(new DefaultHandler());
+		mainRouter.mountSubRouter("/api/v1", v3ApiRouter);
+
+		v3ApiRouter.post("/post").handler(BodyHandler.create().setDeleteUploadedFilesOnEnd(false)).handler(new FileUploadHandler());
+		v3ApiRouter.route().last().handler(new DefaultHandler());
+
+		vertx.createHttpServer().requestHandler(v3ApiRouter::accept).listen(config().getInteger("http.port",8080), serverStartup -> completeStartup(serverStartup, startFuture));
+	}
+
+	private void completeStartup(AsyncResult<HttpServer> serverStartup, Future<Void> future) {
+		if (serverStartup.succeeded()) {
+			future.complete();
+		} else {
+			future.fail(serverStartup.cause());
+		}
+	}
+
+}

--- a/vertx-web/src/test/resources/test.bin
+++ b/vertx-web/src/test/resources/test.bin
@@ -1,0 +1,1 @@
+this is just some random garbage data.


### PR DESCRIPTION
Contains a test case showing problems with the multipart upload functionality added in 3.6.0, as discussed in Gitter.