### PR TITLE
Issue-1026: giving user an option to decode query params

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -135,6 +135,23 @@ public interface Router extends Handler<HttpServerRequest> {
   Route getWithRegex(String regex);
 
   /**
+   * Add a route that matches the specified method, path and the query param decoding flag.
+   * @param method the HTTP method to match
+   * @param path URI paths that begin with this path will match
+   * @param decodeQueryParam flag that gives an option to decode the query param.
+   * @return the route
+   */
+  Route route(HttpMethod method, String path, boolean decodeQueryParam);
+
+  /**
+   * Add a route that matches the specified path and the query param decoding flag.
+   * @param path URI paths that begin with this path will match
+   * @param decodeQueryParam flag that gives an option to decode the query param.
+   * @return the route
+   */
+  Route route(String path, boolean decodeQueryParam);
+
+  /**
    * Add a route that matches any HTTP HEAD request
    *
    * @return the route

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -57,6 +57,7 @@ public class RouteImpl implements Route {
   private List<String> groups;
   private boolean useNormalisedPath = true;
   private Set<String> namedGroupsInRegex = new TreeSet<>();
+  private boolean decodeQueryParam = true;
 
   RouteImpl(RouterImpl router, int order) {
     this.router = router;
@@ -87,6 +88,21 @@ public class RouteImpl implements Route {
   RouteImpl(RouterImpl router, int order, String regex, boolean bregex) {
     this(router, order);
     setRegex(regex);
+  }
+
+  RouteImpl(RouterImpl router, int order, boolean decodeQueryParam, HttpMethod method, String path) {
+    this(router, order);
+    methods.add(method);
+    checkPath(path);
+    setPath(path);
+    this.decodeQueryParam = decodeQueryParam;
+  }
+
+  RouteImpl(RouterImpl router, int order, boolean decodeQueryParam, String path) {
+    this(router, order);
+    checkPath(path);
+    setPath(path);
+    this.decodeQueryParam = decodeQueryParam;
   }
 
   @Override
@@ -306,7 +322,7 @@ public class RouteImpl implements Route {
     }
 
     // Check if query params are already parsed
-    if (context.queryParams().size() == 0) {
+    if (context.queryParams().size() == 0 && decodeQueryParam) {
       // Decode query parameters and put inside context.queryParams
       Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -105,6 +105,16 @@ public class RouterImpl implements Router {
   }
 
   @Override
+  public Route route(HttpMethod method, String path, boolean decodeQueryParam) {
+    return new RouteImpl(this, orderSequence.getAndIncrement(), decodeQueryParam, method, path);
+  }
+
+  @Override
+  public Route route(String path, boolean decodeQueryParam) {
+    return new RouteImpl(this, orderSequence.getAndIncrement(), decodeQueryParam, path);
+  }
+
+  @Override
   public Route get() {
     return route().method(HttpMethod.GET);
   }


### PR DESCRIPTION
When a vertx server receives a url whose query params cannot be decoded then it automatically throws 400 error. But there are many scenarios where we would not want to simply throw 400 like in the [Issue 1026](https://github.com/vert-x3/vertx-web/issues/1026). Similar issue has also been raised in [Issue-817](https://github.com/vert-x3/vertx-web/issues/817)

So we can give an option to a user when he creates a route by passing a flag that signifies whether to decode query params or not. Eg

`    Router router = Router.router(vertx);
    router.route("/stats", false).handler(routingContext -> {
      routingContext.response().end("Hellow Stats");
    });`

So this will server a large audience and give more flexibility to a developer.

Thanks.