### PR TITLE
Removed deprecated methods from vertx-web-api-contract

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/index.adoc
@@ -122,20 +122,9 @@ For example you can ask to router factory to mount the validation failure handle
 ----
 
 === Mount the handlers
-Now load your first path. There are two functions to load the handlers:
-
-* {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandler(io.vertx.core.http.HttpMethod, java.lang.String, io.vertx.core.Handler)}
-* {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}
-
-And, of course, two functions to load failure handlers
-
-* {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandler(io.vertx.core.http.HttpMethod, java.lang.String, io.vertx.core.Handler)}
-* {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}
+Now load your first operation handlers. To load an handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}. To load a failure handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}
 
 You can, of course,*add multiple handlers to same operation**, without overwrite the existing ones.
-
-.Path in OpenAPI format
-IMPORTANT: If you want to use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandler(io.vertx.core.http.HttpMethod, java.lang.String, io.vertx.core.Handler)} or {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandler(io.vertx.core.http.HttpMethod, java.lang.String, io.vertx.core.Handler)} pay attention: You can provide a path only in OpenAPI styles (for example path `/hello/:param` doesn't work)
 
 For example:
 

--- a/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
+++ b/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
@@ -112,15 +112,6 @@ public class OpenAPI3Examples {
               (ValidationException) failure).type().name()).end();
         });
 
-        // Add an handler with a combination of HttpMethod and path
-        routerFactory.addHandler(HttpMethod.POST, "/pets", routingContext -> {
-          // Extract request body and use it
-          RequestParameters params = routingContext.get("parsedParameters");
-          JsonObject pet = params.body().getJsonObject();
-          routingContext.response().putHeader("content-type", "application/json; charset=utf-8").end(pet
-            .encodePrettily());
-        });
-
         // Add a security handler
         // Handle security here
         routerFactory.addSecurityHandler("api_key", RoutingContext::next);

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
@@ -25,32 +25,6 @@ public interface RouterFactory<Specification> {
   RouterFactory addSecurityHandler(String securitySchemaName, Handler<RoutingContext> handler);
 
   /**
-   * Add an handler to a path with a method. If combination path/method is not available in
-   * specification, it will throw a {@link RouterFactoryException}. Deprecated in favour of
-   * operation id
-   *
-   * @param method
-   * @param path
-   * @param handler
-   * @return
-   */
-  @Fluent @Deprecated
-  RouterFactory addHandler(HttpMethod method, String path, Handler<RoutingContext> handler);
-
-  /**
-   * Add a failure handler to a path with a method. If combination path/method is not available in
-   * specification, it will throw a {@link RouterFactoryException}. Deprecated in favour of
-   * operation id
-   *
-   * @param method
-   * @param path
-   * @param failureHandler
-   * @return
-   */
-  @Fluent @Deprecated
-  RouterFactory addFailureHandler(HttpMethod method, String path, Handler<RoutingContext> failureHandler);
-
-  /**
    * Override options
    *
    * @param options
@@ -65,36 +39,6 @@ public interface RouterFactory<Specification> {
    * @return
    */
   RouterFactoryOptions getOptions();
-
-  /**
-   * Deprecated. Instantiate {@link RouterFactoryOptions}
-   * and load it using {@link RouterFactory#setOptions(RouterFactoryOptions)}
-   *
-   * @param handler
-   * @return
-   */
-  @Fluent @Deprecated
-  RouterFactory setValidationFailureHandler(Handler<RoutingContext> handler);
-
-  /**
-   * Deprecated. Instantiate {@link RouterFactoryOptions}
-   * and load it using {@link RouterFactory#setOptions(RouterFactoryOptions)}
-   *
-   * @param enable
-   * @return
-   */
-  @Fluent @Deprecated
-  RouterFactory enableValidationFailureHandler(boolean enable);
-
-  /**
-   * Deprecated. Instantiate {@link RouterFactoryOptions}
-   * and load it using {@link RouterFactory#setOptions(RouterFactoryOptions)}
-   *
-   * @param enable
-   * @return
-   */
-  @Fluent @Deprecated
-  RouterFactory mountOperationsWithoutHandlers(boolean enable);
 
   /**
    * Construct a new router based on spec. It will fail if you are trying to mount a spec with security schemes

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/BaseRouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/BaseRouterFactory.java
@@ -25,30 +25,6 @@ abstract public class BaseRouterFactory<Specification> implements RouterFactory<
     this(vertx, spec, new RouterFactoryOptions());
   }
 
-  @Override @Deprecated
-  public RouterFactory enableValidationFailureHandler(boolean enable) {
-    if (options == null)
-      this.options = new RouterFactoryOptions();
-    this.options.setMountValidationFailureHandler(enable);
-    return this;
-  }
-
-  @Override @Deprecated
-  public BaseRouterFactory setValidationFailureHandler(Handler<RoutingContext> handler) {
-    if (options == null)
-      this.options = new RouterFactoryOptions();
-    this.options.setValidationFailureHandler(handler);
-    return this;
-  }
-
-  @Override @Deprecated
-  public RouterFactory mountOperationsWithoutHandlers(boolean enable) {
-    if (options == null)
-      this.options = new RouterFactoryOptions();
-    this.options.setMountNotImplementedHandler(enable);
-    return this;
-  }
-
   @Override
   public RouterFactory setOptions(RouterFactoryOptions options) {
     this.options = options;

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
@@ -19,9 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Interface for OpenAPI3RouterFactory. <br/>
- * To add an handler, use {@link OpenAPI3RouterFactory#addHandlerByOperationId(String, Handler)}, in this
- * class is better than generic {@link RouterFactory#addHandler(HttpMethod, String, Handler)}<br/>
- * If you want to use {@link RouterFactory#addHandler(HttpMethod, String, Handler)} remember that <b>you have to pass path as declared in openapi specification</b>
+ * To add an handler, use {@link OpenAPI3RouterFactory#addHandlerByOperationId(String, Handler)}<br/>
  * Usage example:
  * <pre>
  * {@code
@@ -99,30 +97,5 @@ public interface OpenAPI3RouterFactory extends RouterFactory<OpenAPI> {
           future.fail(RouterFactoryException.createSpecInvalidException(StringUtils.join(swaggerParseResult.getMessages(), ", ")));
       }
     }, handler);
-  }
-
-
-  /**
-   * @deprecated use {@link OpenAPI3RouterFactory#create(Vertx, String, Handler)}
-   *
-   * @param vertx
-   * @param url
-   * @param handler
-   */
-  @Deprecated
-  static void createRouterFactoryFromFile(Vertx vertx, String url, Handler<AsyncResult<OpenAPI3RouterFactory>> handler) {
-    OpenAPI3RouterFactory.create(vertx, url, handler);
-  }
-
-  /**
-   * @deprecated use {@link OpenAPI3RouterFactory#create(Vertx, String, Handler)}
-   *
-   * @param vertx
-   * @param url
-   * @param handler
-   */
-  @Deprecated
-  static void createRouterFactoryFromURL(Vertx vertx, String url, Handler<AsyncResult<OpenAPI3RouterFactory>> handler) {
-    OpenAPI3RouterFactory.create(vertx, url, handler);
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -136,58 +136,6 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
     return this;
   }
 
-  private String resolveOperationId(HttpMethod method, String path) {
-    // I assume the user give path in openapi style
-    PathItem pathObject = this.spec.getPaths().get(path);
-    if (pathObject == null) {
-      throw RouterFactoryException.createPathNotFoundException(path);
-    }
-    Operation operation;
-    switch (method) {
-      case GET:
-        operation = pathObject.getGet();
-        break;
-      case PUT:
-        operation = pathObject.getPut();
-        break;
-      case HEAD:
-        operation = pathObject.getHead();
-        break;
-      case DELETE:
-        operation = pathObject.getDelete();
-        break;
-      case PATCH:
-        operation = pathObject.getPatch();
-        break;
-      case POST:
-        operation = pathObject.getPost();
-        break;
-      case OPTIONS:
-        operation = pathObject.getOptions();
-        break;
-      case TRACE:
-        operation = pathObject.getTrace();
-        break;
-      case OTHER:
-      case CONNECT:
-      default:
-        throw RouterFactoryException.createPathNotFoundException(path);
-    }
-    return operation.getOperationId();
-  }
-
-  @Override
-  public OpenAPI3RouterFactory addHandler(HttpMethod method, String path, Handler handler) {
-    addHandlerByOperationId(resolveOperationId(method, path), handler);
-    return this;
-  }
-
-  @Override
-  public OpenAPI3RouterFactory addFailureHandler(HttpMethod method, String path, Handler failureHandler) {
-    addFailureHandlerByOperationId(resolveOperationId(method, path), failureHandler);
-    return this;
-  }
-
   @Override
   public Router getRouter() {
     Router router = Router.router(vertx);


### PR DESCRIPTION
* addHandler(HttpMethod, String, Handler)
* addFailureHandler(HttpMethod, String, Handler)
* setValidationFailureHandler(Handler) (Replaced by RouterFactoryOptions)
* enableValidationFailureHandler(boolean) (Replaced by RouterFactoryOptions)
* mountOperationsWithoutHandlers(boolean) (Replaced by RouterFactoryOptions)

Signed-off-by: francesco <francescoguard@gmail.com>