### PR TITLE
Updated swagger-parser to 2.0.5

### DIFF
--- a/vertx-web-api-contract/pom.xml
+++ b/vertx-web-api-contract/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.0.0-rc3</version>
+      <version>2.0.5</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/vertx-web-api-contract/src/test/resources/swaggers/schemas_test_spec.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/schemas_test_spec.yaml
@@ -127,7 +127,7 @@ paths:
             schema:
               allOf:
                 - $ref: 'http://localhost:8081/card.json'
-                - $ref: './src/test/resources/swaggers/schemas/Card_id.yaml'
+                - $ref: './schemas/Card_id.yaml'
                 - type: object
                   properties:
                     parent_card:
@@ -157,7 +157,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: './src/test/resources/swaggers/schemas/tree.yaml#/tree'
+              $ref: './schemas/tree.yaml#/tree'
   /test12:
     post:
       operationId: test12


### PR DESCRIPTION
Note now that relative refs are solved from openapi spec directory as it should, not from current directory of jar/project

Signed-off-by: francesco <francescoguard@gmail.com>