### PR TITLE
[Web Api Contract] Add UUID validation parameter

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
@@ -159,6 +159,9 @@ public class OpenAPI3RequestValidationHandlerImpl extends HTTPOperationRequestVa
           case "email":
             regex = RegularExpressions.EMAIL;
             break;
+          case "uuid":
+            regex = RegularExpressions.UUID;
+            break;
           default:
             throw new SpecFeatureNotSupportedException("format " + schema.getFormat() + " not supported");
         }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/ParameterType.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/ParameterType.java
@@ -41,7 +41,12 @@ public enum ParameterType {
    */
   TIME(new StringTypeValidator(RegularExpressions.TIME)), BASE64(new StringTypeValidator(RegularExpressions.BASE64)),
   IPV4(new StringTypeValidator(RegularExpressions.IPV4)), IPV6(new StringTypeValidator(RegularExpressions.IPV6)),
-  HOSTNAME(new StringTypeValidator(RegularExpressions.HOSTNAME));
+  HOSTNAME(new StringTypeValidator(RegularExpressions.HOSTNAME)),
+
+  /**
+   * UUID as defined by RFC4122
+   */
+  UUID(new StringTypeValidator(RegularExpressions.UUID));
 
   private ParameterTypeValidator validationMethod;
 

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/RegularExpressions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/RegularExpressions.java
@@ -31,4 +31,6 @@ public class RegularExpressions {
   public static final String HOSTNAME = "^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*" + "" +
     "([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9])$";
 
+  public static final String UUID = "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$";
+
 }

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/HTTPRequestValidationTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/HTTPRequestValidationTest.java
@@ -68,6 +68,11 @@ public class HTTPRequestValidationTest extends WebTestValidationBase {
     testPrimitiveParameterType(ParameterType.BASE64);
   }
 
+  @Test
+  public void testUUIDValidation() {
+    testPrimitiveParameterType(ParameterType.UUID);
+  }
+
   //TODO write all tests for validation methods
 
   /*

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/WebTestValidationBase.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/WebTestValidationBase.java
@@ -48,6 +48,8 @@ public class WebTestValidationBase extends WebTestWithWebClientBase {
     sampleValuesFailure.put(ParameterType.TIME, Arrays.asList(new SimpleDateFormat("yyyy:MM:dd").format(new Date())));
     sampleValuesSuccess.put(ParameterType.BASE64, Arrays.asList("SGVsbG8gVmVydHg="));
     sampleValuesFailure.put(ParameterType.BASE64, Arrays.asList());
+    sampleValuesSuccess.put(ParameterType.UUID, Arrays.asList(UUID.randomUUID().toString()));
+    sampleValuesFailure.put(ParameterType.UUID, Arrays.asList(UUID.randomUUID().toString() + "a"));
 
   }
 

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/impl/StringTypeValidatorTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/impl/StringTypeValidatorTest.java
@@ -4,6 +4,8 @@ import io.vertx.ext.web.api.validation.ParameterTypeValidator;
 import io.vertx.ext.web.api.validation.ValidationException;
 import org.junit.Test;
 
+import java.util.UUID;
+
 /**
  * @author Francesco Guardiani @slinkydeveloper
  */
@@ -45,4 +47,15 @@ public class StringTypeValidatorTest {
     validator.isValid("a");
   }
 
+  @Test
+  public void isValidUUID() {
+    ParameterTypeValidator validator = new StringTypeValidator(RegularExpressions.UUID);
+    validator.isValid(UUID.randomUUID().toString());
+  }
+
+  @Test(expected = ValidationException.class)
+  public void isNotValidUUID() {
+    ParameterTypeValidator validator = new StringTypeValidator(RegularExpressions.UUID);
+    validator.isValid(UUID.randomUUID().toString().replaceAll("-","#"));
+  }
 }


### PR DESCRIPTION
Add validation on uuid for Web APi Contract

I know that format is an open value but UUID is a classical and standard format.
Today for public API which want to use a UUID in format, can't. We need to add hack by using pattern field but not compliant with everybody.
Another thing today for clients of API which add format uuid in their request: not only it's not supported but we can't pass validation stage (due to an exception).

Please consider this PR.

In parallel fix issue  #1003 pending the new version of the validation.

Documentations:
[OAS](https://swagger.io/specification/#dataTypes) 
[Data Types specification](https://swagger.io/docs/specification/data-models/data-types/) 

