### PR TITLE
DO NOT MERGE: Example of tracing using new interceptors

### DIFF
--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -17,6 +17,18 @@
     <doc.skip>false</doc.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-bom</artifactId>
+        <version>5.5.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -31,10 +43,32 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Temporarily adds brave instrumentation to prove interceptor design -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-server -Xmx1200M</argLine>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientPhase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientPhase.java
@@ -15,7 +15,7 @@
  */
 package io.vertx.ext.web.client.impl;
 
-public enum ClientEventType {
+public enum ClientPhase {
 
   /**
    * The {@link io.vertx.core.http.HttpClientRequest} has not yet been created, the {@link HttpContext#request()} can be fully modified.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -228,7 +228,7 @@ class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   private void send(String contentType, Object body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    HttpContext ex = new HttpContext(((HttpClientImpl)client.client).getVertx().getOrCreateContext(), this, contentType, body, (Handler)handler);
-    ex.prepareRequest();
+    HttpContext<T> ex = new HttpContext<T>(((HttpClientImpl)client.client).getVertx().getOrCreateContext(), handler);
+    ex.prepareRequest(this, contentType, body);
   }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
@@ -218,7 +218,7 @@ public class WebClientImpl implements WebClientInternal {
   }
 
   @Override
-  public <T> WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor) {
+  public WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor) {
     interceptors.add((Handler) interceptor);
     return this;
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
@@ -218,8 +218,8 @@ public class WebClientImpl implements WebClientInternal {
   }
 
   @Override
-  public WebClientImpl addInterceptor(Handler<HttpContext<?>> interceptor) {
-    interceptors.add(interceptor);
+  public <T> WebClientInternal addInterceptor(Handler<HttpContext<T>> interceptor) {
+    interceptors.add((Handler) interceptor);
     return this;
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientImpl.java
@@ -218,7 +218,7 @@ public class WebClientImpl implements WebClientInternal {
   }
 
   @Override
-  public <T> WebClientInternal addInterceptor(Handler<HttpContext<T>> interceptor) {
+  public <T> WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor) {
     interceptors.add((Handler) interceptor);
     return this;
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -36,6 +36,6 @@ public interface WebClientInternal extends WebClient {
    * @param interceptor the interceptor to add, must not be null
    * @return a reference to this, so the API can be used fluently
    */
-  WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
+  <T> WebClientInternal addInterceptor(Handler<HttpContext<T>> interceptor);
 
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -36,6 +36,6 @@ public interface WebClientInternal extends WebClient {
    * @param interceptor the interceptor to add, must not be null
    * @return a reference to this, so the API can be used fluently
    */
-  <T> WebClientInternal addInterceptor(Handler<HttpContext<T>> interceptor);
+  <T> WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
 
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -36,6 +36,6 @@ public interface WebClientInternal extends WebClient {
    * @param interceptor the interceptor to add, must not be null
    * @return a reference to this, so the API can be used fluently
    */
-  <T> WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
+  WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
 
 }

--- a/vertx-web-client/src/test/java/brave/vertx/web/client/ITVertxHttpClientTracing.java
+++ b/vertx-web-client/src/test/java/brave/vertx/web/client/ITVertxHttpClientTracing.java
@@ -18,7 +18,7 @@ public class ITVertxHttpClientTracing extends ITHttpAsyncClient<WebClientInterna
     return ((WebClientInternal) WebClient.wrap(vertx.createHttpClient(new HttpClientOptions()
       .setDefaultPort(port)
       .setDefaultHost("127.0.0.1"))))
-      .addInterceptor(new TracingHttpClientRequestHandler<>(httpTracing));
+      .addInterceptor(new TracingHttpClientRequestHandler(httpTracing));
   }
 
   // TODO: we are unaware of the redirect. Ideally, redirects re-use the same infrastructure, simply

--- a/vertx-web-client/src/test/java/brave/vertx/web/client/ITVertxHttpClientTracing.java
+++ b/vertx-web-client/src/test/java/brave/vertx/web/client/ITVertxHttpClientTracing.java
@@ -1,0 +1,63 @@
+package brave.vertx.web.client;
+
+import brave.test.http.ITHttpAsyncClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.impl.WebClientInternal;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Test;
+
+// WARNING: this is internal hook!
+public class ITVertxHttpClientTracing extends ITHttpAsyncClient<WebClientInternal> {
+  Vertx vertx = Vertx.vertx(new VertxOptions());
+
+  @Override protected WebClientInternal newClient(int port) {
+    return ((WebClientInternal) WebClient.wrap(vertx.createHttpClient(new HttpClientOptions()
+      .setDefaultPort(port)
+      .setDefaultHost("127.0.0.1"))))
+      .addInterceptor(new TracingHttpClientRequestHandler<>(httpTracing));
+  }
+
+  // TODO: we are unaware of the redirect. Ideally, redirects re-use the same infrastructure, simply
+  // looping through again. The redirect handler likely needs to be re-considered to reduce
+  // complexity vs what currently seems like a wrapping game.
+  @Test @Override public void redirect() throws Exception {
+    super.redirect();
+  }
+
+  @Override protected void closeClient(WebClientInternal client) {
+    client.close();
+  }
+
+  @Override protected void get(WebClientInternal client, String pathIncludingQuery) {
+    CountDownLatch latch = new CountDownLatch(1);
+    client.get(pathIncludingQuery).send(r -> latch.countDown());
+
+    // TODO: not sure if there's a blocking api anywhere
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override protected void post(WebClientInternal client, String pathIncludingQuery, String body) {
+    CountDownLatch latch = new CountDownLatch(1);
+    client.post(pathIncludingQuery).sendBuffer(Buffer.buffer(body), r -> latch.countDown());
+
+    // TODO: not sure if there's a blocking api anywhere
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override protected void getAsync(WebClientInternal client, String pathIncludingQuery) {
+    client.get(pathIncludingQuery).send(r -> {
+    });
+  }
+}

--- a/vertx-web-client/src/test/java/brave/vertx/web/client/TracingHttpClientRequestHandler.java
+++ b/vertx-web-client/src/test/java/brave/vertx/web/client/TracingHttpClientRequestHandler.java
@@ -1,0 +1,114 @@
+package brave.vertx.web.client;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.http.HttpClientAdapter;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.Propagation.Setter;
+import brave.propagation.TraceContext;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.client.impl.HttpContext;
+
+/**
+ * @param <T> only used for fluent api. We don't read it here.
+ */
+final class TracingHttpClientRequestHandler<T> implements Handler<HttpContext<T>> {
+  static final Setter<HttpClientRequest, String> SETTER = new Setter<HttpClientRequest, String>() {
+    @Override public void put(HttpClientRequest carrier, String key, String value) {
+      carrier.putHeader(key, value);
+    }
+
+    @Override public String toString() {
+      return "HttpClientRequest::putHeader";
+    }
+  };
+
+  final Tracer tracer;
+  final HttpClientHandler<HttpClientRequest, HttpClientResponse> handler;
+  final TraceContext.Injector<HttpClientRequest> injector;
+  final String serverName;
+
+  TracingHttpClientRequestHandler(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = HttpClientHandler.create(httpTracing, new Adapter());
+    injector = httpTracing.tracing().propagation().injector(SETTER);
+    serverName = httpTracing.serverName();
+  }
+
+  @Override public void handle(HttpContext<T> context) {
+    // TODO: for redirects
+    Span span = null;
+    switch (context.eventType()) {
+      case SEND_REQUEST:
+        span = handler.handleSend(injector, context.clientRequest());
+        context.set(Span.class.getName(), span);
+        break;
+      case DISPATCH_RESPONSE:
+      case FAILURE:
+        span = context.get(Span.class.getName());
+        assert span != null : "unexpected lifecycle";
+        if (span == null) break; // don't break
+        parseConnectionAddress(context.clientRequest(), span);
+        handler.handleReceive(context.clientResponse(), context.failure(), span);
+        context.set(Span.class.getName(), null);
+        span = null;
+        break;
+    }
+
+    // TODO: test that this is readable ex trace IDs in logs
+    if (span != null) {
+      try (SpanInScope ws = tracer.withSpanInScope(span)) {
+        context.next();
+      } catch (RuntimeException | Error e) {
+        span.error(e); // TODO: test that other interceptors having an error end up in the span
+        context.set(Span.class.getName(), null);
+        throw e;
+      }
+    } else {
+      context.next();
+    }
+  }
+
+  static void parseConnectionAddress(HttpClientRequest request, Span span) {
+    if (span.isNoop()) return;
+    HttpConnection connection = request.connection();
+    if (connection == null) return;
+    SocketAddress address = connection.remoteAddress();
+    if (address != null) {
+      if (span.remoteIpAndPort(address.host(), address.port())) return;
+    }
+  }
+
+  static final class Adapter extends HttpClientAdapter<HttpClientRequest, HttpClientResponse> {
+
+    @Override public String method(HttpClientRequest request) {
+      return request.method().name();
+    }
+
+    @Override public String path(HttpClientRequest request) {
+      return request.path();
+    }
+
+    @Override public String url(HttpClientRequest request) {
+      return request.absoluteURI();
+    }
+
+    @Override public String requestHeader(HttpClientRequest request, String name) {
+      return request.headers().get(name);
+    }
+
+    @Override public Integer statusCode(HttpClientResponse response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(HttpClientResponse response) {
+      return response.statusCode();
+    }
+  }
+}


### PR DESCRIPTION
Ideally some refactoring can be done such that automatic redirect
follow-ups look no different than individual requests (to this handler).
Waiting to see if such a thing is feasible or not.

See https://github.com/vert-x3/vertx-web/issues/891