### PR TITLE
Allow authorization values when reading a remote openapi spec

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/index.adoc
@@ -112,6 +112,13 @@ You can also construct a router factory from a remote spec:
 {@link examples.OpenAPI3Examples#constructRouterFactoryFromUrl}
 ----
 
+Or, you can also access a private remote spec by passing one or more https://github.com/swagger-api/swagger-parser#usage[AuthorizationValue]:
+
+[source,$lang]
+----
+{@link examples.OpenAPI3Examples#constructRouterFactoryFromUrlWithAuthenticationHeader}
+----
+
 You can also modify the behaviours of the router factory with {@link io.vertx.ext.web.api.contract.RouterFactoryOptions}.
 For example you can ask to router factory to mount the validation failure handler but to not mount the not implemented handler as follows:
 

--- a/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
+++ b/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
@@ -1,21 +1,24 @@
 package examples;
 
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.RequestParameter;
 import io.vertx.ext.web.api.RequestParameters;
-import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.RouterFactoryOptions;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
-import io.vertx.ext.web.handler.JWTAuthHandler;
 import io.vertx.ext.web.api.validation.ValidationException;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+
+import java.util.Collections;
+import java.util.List;
 
 public class OpenAPI3Examples {
 
@@ -35,6 +38,27 @@ public class OpenAPI3Examples {
     OpenAPI3RouterFactory.create(
       vertx,
       "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml",
+      ar -> {
+        if (ar.succeeded()) {
+          // Spec loaded with success
+          OpenAPI3RouterFactory routerFactory = ar.result();
+        } else {
+          // Something went wrong during router factory initialization
+          Throwable exception = ar.cause();
+        }
+      });
+  }
+
+  public void constructRouterFactoryFromUrlWithAuthenticationHeader(Vertx vertx) {
+    AuthorizationValue authorizationValue = new AuthorizationValue()
+      .type("header")
+      .keyName("Authorization")
+      .value("Bearer xx.yy.zz");
+    List<JsonObject> authorizations = Collections.singletonList(JsonObject.mapFrom(authorizationValue));
+    OpenAPI3RouterFactory.create(
+      vertx,
+      "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml",
+      authorizations,
       ar -> {
         if (ar.succeeded()) {
           // Spec loaded with success


### PR DESCRIPTION
Added the possibility of reading a private OpenAPI specification.

Closes #1068 