### PR TITLE
Moved some handlers configurations (back) to RouterFactory

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
@@ -45,6 +45,7 @@ Get request principal user as routingContext.user().principal(), null if no user
 ^|Name | Type ^| Description
 |[[mountNotImplementedHandler]]`@mountNotImplementedHandler`|`Boolean`|+++
 Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
+ You can change the "not implemented handler" with link
 +++
 |[[mountResponseContentTypeHandler]]`@mountResponseContentTypeHandler`|`Boolean`|+++
 If true, when required, the factory will mount a link

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
@@ -4,8 +4,13 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * Main interface for Design Driven Router factory
@@ -25,7 +30,7 @@ public interface RouterFactory<Specification> {
   RouterFactory addSecurityHandler(String securitySchemaName, Handler<RoutingContext> handler);
 
   /**
-   * Override options
+   * Set options of router factory. For more info {@link RouterFactoryOptions}
    *
    * @param options
    * @return
@@ -49,4 +54,53 @@ public interface RouterFactory<Specification> {
    */
   Router getRouter();
 
+
+  Handler<RoutingContext> getValidationFailureHandler();
+
+  /**
+   * Set default validation failure handler. You can enable/disable this feature from
+   * {@link RouterFactoryOptions#setMountValidationFailureHandler(boolean)}
+   *
+   * @param validationFailureHandler
+   * @return this object
+   */
+  @Fluent
+  RouterFactory setValidationFailureHandler(Handler<RoutingContext> validationFailureHandler);
+
+  /**
+   * Set not implemented failure handler. It's called when you don't define an handler for a
+   * specific operation. You can enable/disable this feature from
+   * {@link RouterFactoryOptions#setMountNotImplementedHandler(boolean)}
+   *
+   * @param notImplementedFailureHandler
+   * @return this object
+   */
+  @Fluent
+  RouterFactory setNotImplementedFailureHandler(Handler<RoutingContext> notImplementedFailureHandler);
+
+  /**
+   * Supply your own BodyHandler if you would like to control body limit, uploads directory and deletion of uploaded files
+   * @param bodyHandler
+   * @return self
+   */
+  @Fluent
+  RouterFactory setBodyHandler(BodyHandler bodyHandler);
+
+  /**
+   * Add global handler to be applied prior to {@link io.vertx.ext.web.Router} being generated. <br/>
+   * Please note that you should not add a body handler inside that list. If you want to modify the body handler, please use {@link RouterFactory#setBodyHandler(BodyHandler)}
+   *
+   * @param globalHandler
+   * @return this object
+   */
+  @Fluent
+  RouterFactory addGlobalHandler(Handler<RoutingContext> globalHandler);
+
+  /**
+   * When set, this function is called while creating the payload of {@link io.vertx.ext.web.api.OperationRequest}
+   * @param extraOperationContextPayloadMapper
+   * @return
+   */
+  @Fluent
+  RouterFactory setExtraOperationContextPayloadMapper(Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper);
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -19,30 +19,9 @@ import java.util.function.Function;
 public class RouterFactoryOptions {
 
   /**
-   * Default validation failure handler. When ValidationException occurs, It sends a response
-   * with status code 400, status message "Bad Request" and error message as body
-   */
-  public final static Handler<RoutingContext> DEFAULT_VALIDATION_HANDLER = (routingContext -> {
-    if (routingContext.failure() instanceof ValidationException) {
-      routingContext
-        .response()
-        .setStatusCode(400)
-        .setStatusMessage("Bad Request")
-        .end(routingContext.failure().getMessage());
-    } else routingContext.next();
-  });
-
-  /**
    * By default, RouterFactory loads validation failure handler
    */
   public final static boolean DEFAULT_MOUNT_VALIDATION_FAILURE_HANDLER = true;
-
-  /**
-   * Default not implemented handler. It sends a response with status code 501,
-   * status message "Not Implemented" and empty body
-   */
-  public final static Handler<RoutingContext> DEFAULT_NOT_IMPLEMENTED_HANDLER = (routingContext) -> routingContext.response().setStatusCode(501).setStatusMessage("Not Implemented").end();
-
 
   /**
    * By default, RouterFactory mounts Not Implemented handler
@@ -65,18 +44,11 @@ public class RouterFactoryOptions {
    */
   public final static String DEFAULT_OPERATION_MODEL_KEY = null;
 
-  public final static Function<RoutingContext, JsonObject> DEFAULT_EXTRA_OPERATION_CONTEXT_PAYLOAD_MAPPER = null;
-
-  private Handler<RoutingContext> validationFailureHandler;
   private boolean mountValidationFailureHandler;
-  private Handler<RoutingContext> notImplementedFailureHandler;
   private boolean mountNotImplementedHandler;
   private boolean requireSecurityHandlers;
   private boolean mountResponseContentTypeHandler;
-  private BodyHandler bodyHandler;
-  private List<Handler<RoutingContext>> globalHandlers;
   private String operationModelKey;
-  private Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper;
 
   public RouterFactoryOptions() {
     init();
@@ -88,14 +60,10 @@ public class RouterFactoryOptions {
   }
 
   public RouterFactoryOptions(RouterFactoryOptions other) {
-    this.validationFailureHandler = other.getValidationFailureHandler();
     this.mountValidationFailureHandler = other.isMountValidationFailureHandler();
-    this.notImplementedFailureHandler = other.getNotImplementedFailureHandler();
     this.mountNotImplementedHandler = other.isMountNotImplementedHandler();
     this.requireSecurityHandlers = other.isRequireSecurityHandlers();
     this.mountResponseContentTypeHandler = other.isMountResponseContentTypeHandler();
-    this.bodyHandler = other.getBodyHandler();
-    this.globalHandlers = other.getGlobalHandlers();
     this.operationModelKey = other.getOperationModelKey();
   }
 
@@ -106,33 +74,11 @@ public class RouterFactoryOptions {
   }
 
   private void init() {
-    this.validationFailureHandler = DEFAULT_VALIDATION_HANDLER;
     this.mountValidationFailureHandler = DEFAULT_MOUNT_VALIDATION_FAILURE_HANDLER;
-    this.notImplementedFailureHandler = DEFAULT_NOT_IMPLEMENTED_HANDLER;
     this.mountNotImplementedHandler = DEFAULT_MOUNT_NOT_IMPLEMENTED_HANDLER;
     this.requireSecurityHandlers = DEFAULT_REQUIRE_SECURITY_HANDLERS;
     this.mountResponseContentTypeHandler = DEFAULT_MOUNT_RESPONSE_CONTENT_TYPE_HANDLER;
-    this.bodyHandler = BodyHandler.create();
-    this.globalHandlers = new ArrayList<>();
     this.operationModelKey = DEFAULT_OPERATION_MODEL_KEY;
-    this.extraOperationContextPayloadMapper = DEFAULT_EXTRA_OPERATION_CONTEXT_PAYLOAD_MAPPER;
-  }
-
-  public Handler<RoutingContext> getValidationFailureHandler() {
-    return validationFailureHandler;
-  }
-
-  /**
-   * Set default validation failure handler. You can enable/disable this feature from
-   * {@link RouterFactoryOptions#setMountValidationFailureHandler(boolean)}
-   *
-   * @param validationFailureHandler
-   * @return this object
-   */
-  @Fluent
-  public RouterFactoryOptions setValidationFailureHandler(Handler<RoutingContext> validationFailureHandler) {
-    this.validationFailureHandler = validationFailureHandler;
-    return this;
   }
 
   public boolean isMountValidationFailureHandler() {
@@ -141,7 +87,7 @@ public class RouterFactoryOptions {
 
   /**
    * Enable or disable validation failure handler. If you enable it during router creation a failure handler
-   * that manages ValidationException will be mounted. You can change the validation failure handler with with function {@link RouterFactoryOptions#setValidationFailureHandler(Handler)}. If failure is different from ValidationException, next failure
+   * that manages ValidationException will be mounted. You can change the validation failure handler with with function {@link RouterFactory#setValidationFailureHandler(Handler)}. If failure is different from ValidationException, next failure
    * handler will be called.
    *
    * @param mountGlobalValidationFailureHandler
@@ -153,30 +99,13 @@ public class RouterFactoryOptions {
     return this;
   }
 
-  public Handler<RoutingContext> getNotImplementedFailureHandler() {
-    return notImplementedFailureHandler;
-  }
-
-  /**
-   * Set not implemented failure handler. It's called when you don't define an handler for a
-   * specific operation. You can enable/disable this feature from
-   * {@link RouterFactoryOptions#setMountNotImplementedHandler(boolean)}
-   *
-   * @param notImplementedFailureHandler
-   * @return this object
-   */
-  @Fluent
-  public RouterFactoryOptions setNotImplementedFailureHandler(Handler<RoutingContext> notImplementedFailureHandler) {
-    this.notImplementedFailureHandler = notImplementedFailureHandler;
-    return this;
-  }
-
   public boolean isMountNotImplementedHandler() {
     return mountNotImplementedHandler;
   }
 
   /**
    * Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
+   * You can change the "not implemented handler" with {@link RouterFactory#setNotImplementedFailureHandler(Handler)}
    *
    * @param mountOperationsWithoutHandler
    * @return this object
@@ -219,38 +148,6 @@ public class RouterFactoryOptions {
     return this;
   }
 
-  public BodyHandler getBodyHandler() {
-    return bodyHandler;
-  }
-
-  /**
-   * Supply your own BodyHandler if you would like to control body limit, uploads directory and deletion of uploaded files
-   * @param bodyHandler
-   * @return self
-   */
-  @Fluent
-  public RouterFactoryOptions setBodyHandler(BodyHandler bodyHandler) {
-    this.bodyHandler = bodyHandler;
-    return this;
-  }
-
-  public List<Handler<RoutingContext>> getGlobalHandlers() {
-    return globalHandlers;
-  }
-
-  /**
-   * Add global handler to be applied prior to {@link io.vertx.ext.web.Router} being generated. <br/>
-   * Please note that you should not add a body handler inside that list. If you want to modify the body handler, please use {@link RouterFactoryOptions#setBodyHandler(BodyHandler)}
-   *
-   * @param globalHandler
-   * @return this object
-   */
-  @Fluent
-  public RouterFactoryOptions addGlobalHandler(Handler<RoutingContext> globalHandler) {
-    this.globalHandlers.add(globalHandler);
-    return this;
-  }
-
   public String getOperationModelKey() {
     return operationModelKey;
   }
@@ -264,21 +161,6 @@ public class RouterFactoryOptions {
   @Fluent
   public RouterFactoryOptions setOperationModelKey(String operationModelKey) {
     this.operationModelKey = operationModelKey;
-    return this;
-  }
-
-  public Function<RoutingContext, JsonObject> getExtraOperationContextPayloadMapper() {
-    return extraOperationContextPayloadMapper;
-  }
-
-  /**
-   * When set, this function is called while creating the payload of {@link io.vertx.ext.web.api.OperationRequest}
-   * @param extraOperationContextPayloadMapper
-   * @return
-   */
-  @Fluent
-  public RouterFactoryOptions setExtraOperationContextPayloadMapper(Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper) {
-    this.extraOperationContextPayloadMapper = extraOperationContextPayloadMapper;
     return this;
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/BaseRouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/BaseRouterFactory.java
@@ -1,27 +1,71 @@
 package io.vertx.ext.web.api.contract.impl;
 
+import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.contract.RouterFactory;
 import io.vertx.ext.web.api.contract.RouterFactoryException;
 import io.vertx.ext.web.api.contract.RouterFactoryOptions;
+import io.vertx.ext.web.api.validation.ValidationException;
+import io.vertx.ext.web.handler.BodyHandler;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Francesco Guardiani @slinkydeveloper
  */
 abstract public class BaseRouterFactory<Specification> implements RouterFactory<Specification> {
 
+  /**
+   * Default validation failure handler. When ValidationException occurs, It sends a response
+   * with status code 400, status message "Bad Request" and error message as body
+   */
+  public final static Handler<RoutingContext> DEFAULT_VALIDATION_FAILURE_HANDLER = (routingContext -> {
+    if (routingContext.failure() instanceof ValidationException) {
+      routingContext
+        .response()
+        .setStatusCode(400)
+        .setStatusMessage("Bad Request")
+        .end(routingContext.failure().getMessage());
+    } else routingContext.next();
+  });
+
+  /**
+   * Default not implemented handler. It sends a response with status code 501,
+   * status message "Not Implemented" and empty body
+   */
+  public final static Handler<RoutingContext> DEFAULT_NOT_IMPLEMENTED_HANDLER = (routingContext) -> routingContext.response().setStatusCode(501).setStatusMessage("Not Implemented").end();
+
+  /** Default extra payload mapper for {@link io.vertx.ext.web.api.OperationRequest}. By default, no mapper is specified
+   *
+   */
+  public final static Function<RoutingContext, JsonObject> DEFAULT_EXTRA_OPERATION_CONTEXT_PAYLOAD_MAPPER = null;
+
   protected Vertx vertx;
   protected Specification spec;
   protected RouterFactoryOptions options;
+
+  private Handler<RoutingContext> validationFailureHandler;
+  private Handler<RoutingContext> notImplementedFailureHandler;
+  private BodyHandler bodyHandler;
+  private List<Handler<RoutingContext>> globalHandlers;
+  private Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper;
 
   public BaseRouterFactory(Vertx vertx, Specification spec, RouterFactoryOptions options) {
     this.vertx = vertx;
     this.spec = spec;
     this.options = options;
+
+    this.validationFailureHandler = DEFAULT_VALIDATION_FAILURE_HANDLER;
+    this.notImplementedFailureHandler = DEFAULT_NOT_IMPLEMENTED_HANDLER;
+    this.bodyHandler = BodyHandler.create();
+    this.globalHandlers = new ArrayList<>();
+    this.extraOperationContextPayloadMapper = DEFAULT_EXTRA_OPERATION_CONTEXT_PAYLOAD_MAPPER;
   }
 
   public BaseRouterFactory(Vertx vertx, Specification spec) {
@@ -37,5 +81,61 @@ abstract public class BaseRouterFactory<Specification> implements RouterFactory<
   @Override
   public RouterFactoryOptions getOptions() {
     return options;
+  }
+
+  @Override
+  public Handler<RoutingContext> getValidationFailureHandler() {
+    return validationFailureHandler;
+  }
+
+  @Override
+  @Fluent
+  public RouterFactory setValidationFailureHandler(Handler<RoutingContext> validationFailureHandler) {
+    this.validationFailureHandler = validationFailureHandler;
+    return this;
+  }
+
+  protected Handler<RoutingContext> getNotImplementedFailureHandler() {
+    return notImplementedFailureHandler;
+  }
+
+  @Override
+  @Fluent
+  public RouterFactory setNotImplementedFailureHandler(Handler<RoutingContext> notImplementedFailureHandler) {
+    this.notImplementedFailureHandler = notImplementedFailureHandler;
+    return this;
+  }
+
+  protected BodyHandler getBodyHandler() {
+    return bodyHandler;
+  }
+
+  @Override
+  @Fluent
+  public RouterFactory setBodyHandler(BodyHandler bodyHandler) {
+    this.bodyHandler = bodyHandler;
+    return this;
+  }
+
+  protected List<Handler<RoutingContext>> getGlobalHandlers() {
+    return globalHandlers;
+  }
+
+  @Override
+  @Fluent
+  public RouterFactory addGlobalHandler(Handler<RoutingContext> globalHandler) {
+    this.globalHandlers.add(globalHandler);
+    return this;
+  }
+
+  protected Function<RoutingContext, JsonObject> getExtraOperationContextPayloadMapper() {
+    return extraOperationContextPayloadMapper;
+  }
+
+  @Override
+  @Fluent
+  public RouterFactory setExtraOperationContextPayloadMapper(Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper) {
+    this.extraOperationContextPayloadMapper = extraOperationContextPayloadMapper;
+    return this;
   }
 }

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.java
@@ -17,6 +17,7 @@ import io.vertx.ext.web.api.contract.RouterFactory;
 import io.vertx.ext.web.api.contract.RouterFactoryException;
 import io.vertx.ext.web.api.contract.openapi3.impl.OpenAPI3RouterFactoryImpl;
 import io.vertx.ext.web.api.contract.openapi3.impl.OpenApi3Utils;
+import io.vertx.ext.web.handler.BodyHandler;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
  * Usage example:
  * <pre>
  * {@code
- * OpenAPI3RouterFactory.createRouterFactoryFromFile(vertx, "src/resources/spec.yaml", asyncResult -> {
+ * OpenAPI3RouterFactory.create(vertx, "src/resources/spec.yaml", asyncResult -> {
  *  if (!asyncResult.succeeded()) {
  *     // IO failure or spec invalid
  *  } else {
@@ -44,6 +45,16 @@ import java.util.stream.Collectors;
  * });
  * }
  * </pre>
+ * <br/>
+ * Handlers are loaded in this order:<br/>
+ *  <ol>
+ *   <li>Body handler (Customizable with {@link this#setBodyHandler(BodyHandler)}</li>
+ *   <li>Custom global handlers configurable with {@link this#addGlobalHandler(Handler)}</li>
+ *   <li>Global security handlers defined in upper spec level</li>
+ *   <li>Operation specific security handlers</li>
+ *   <li>Generated validation handler</li>
+ *   <li>User handlers or "Not implemented" handler</li>
+ * </ol>
  *
  * @author Francesco Guardiani @slinkydeveloper
  */

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RouterFactoryImpl.java
@@ -262,9 +262,9 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
   public Router getRouter() {
     Router router = Router.router(vertx);
     Route globalRoute = router.route();
-    globalRoute.handler(options.getBodyHandler());
+    globalRoute.handler(this.getBodyHandler());
 
-    List<Handler<RoutingContext>> globalHandlers = this.getOptions().getGlobalHandlers();
+    List<Handler<RoutingContext>> globalHandlers = this.getGlobalHandlers();
     for (Handler<RoutingContext> globalHandler: globalHandlers) {
       globalRoute.handler(globalHandler);
     }
@@ -297,7 +297,7 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
       handlersToLoad.add(validationHandler);
 
       // Check validation failure handler
-      if (this.options.isMountValidationFailureHandler()) failureHandlersToLoad.add(this.options.getValidationFailureHandler());
+      if (this.options.isMountValidationFailureHandler()) failureHandlersToLoad.add(this.getValidationFailureHandler());
 
       // Check if path is set by user
       if (operation.isConfigured()) {
@@ -310,17 +310,17 @@ public class OpenAPI3RouterFactoryImpl extends BaseRouterFactory<OpenAPI> implem
               operation.getEbServiceAddress(),
               operation.getEbServiceMethodName(),
               operation.getEbServiceDeliveryOptions(),
-              options.getExtraOperationContextPayloadMapper()
+              this.getExtraOperationContextPayloadMapper()
             ) : RouteToEBServiceHandler.build(
               vertx.eventBus(),
               operation.getEbServiceAddress(),
               operation.getEbServiceMethodName(),
-              options.getExtraOperationContextPayloadMapper()
+              this.getExtraOperationContextPayloadMapper()
             )
           );
         }
       } else {
-        handlersToLoad.add(this.options.getNotImplementedFailureHandler());
+        handlersToLoad.add(this.getNotImplementedFailureHandler());
       }
 
       // Now add all handlers to route

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ParametersUnitTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ParametersUnitTest.java
@@ -62,9 +62,9 @@ public class OpenAPI3ParametersUnitTest extends WebTestValidationBase {
       new RouterFactoryOptions()
         .setRequireSecurityHandlers(false)
         .setMountValidationFailureHandler(true)
-        .setValidationFailureHandler(generateFailureHandler())
         .setMountNotImplementedHandler(false)
     );
+    routerFactory.setValidationFailureHandler(generateFailureHandler());
   }
 
   @Override

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -526,14 +526,13 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS
-          .setValidationFailureHandler(routingContext ->
-            routingContext
-              .response()
-              .setStatusCode(400)
-              .setStatusMessage("Very very Bad Request")
-              .end()
-          )
+        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS);
+        routerFactory.setValidationFailureHandler(routingContext ->
+          routingContext
+            .response()
+            .setStatusCode(400)
+            .setStatusMessage("Very very Bad Request")
+            .end()
         );
 
         routerFactory.addHandlerByOperationId("listPets", routingContext -> routingContext
@@ -618,13 +617,14 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
           new RouterFactoryOptions()
             .setMountNotImplementedHandler(true)
             .setRequireSecurityHandlers(false)
-            .setNotImplementedFailureHandler(routingContext ->
-              routingContext
-                .response()
-                .setStatusCode(501)
-                .setStatusMessage("We are too lazy to implement this operation")
-                .end()
-            )
+        );
+
+        routerFactory.setNotImplementedFailureHandler(routingContext ->
+          routingContext
+            .response()
+            .setStatusCode(501)
+            .setStatusMessage("We are too lazy to implement this operation")
+            .end()
         );
 
         latch.countDown();
@@ -662,18 +662,16 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(
-          new RouterFactoryOptions()
-            .setRequireSecurityHandlers(false)
-            .addGlobalHandler(rc -> {
-              rc.response().putHeader("header-from-global-handler", "some dummy data");
-              rc.next();
-            })
-            .addGlobalHandler(rc -> {
-              rc.response().putHeader("header-from-global-handler", "some more dummy data");
-              rc.next();
-            })
-        );
+        routerFactory.setOptions(new RouterFactoryOptions().setRequireSecurityHandlers(false));
+
+        routerFactory.addGlobalHandler(rc -> {
+          rc.response().putHeader("header-from-global-handler", "some dummy data");
+          rc.next();
+        });
+        routerFactory.addGlobalHandler(rc -> {
+            rc.response().putHeader("header-from-global-handler", "some more dummy data");
+            rc.next();
+        });
 
         routerFactory.addHandlerByOperationId("listPets", routingContext -> routingContext
           .response()
@@ -863,11 +861,9 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
           try {
             if (openAPI3RouterFactoryAsyncResult.succeeded()) {
               routerFactory = openAPI3RouterFactoryAsyncResult.result();
-              routerFactory.setOptions(
-                new RouterFactoryOptions()
-                  .setRequireSecurityHandlers(false)
-                  .setBodyHandler(BodyHandler.create("my-uploads"))
-              );
+              routerFactory.setOptions(new RouterFactoryOptions().setRequireSecurityHandlers(false));
+
+              routerFactory.setBodyHandler(BodyHandler.create("my-uploads"));
 
               routerFactory.addHandlerByOperationId("upload", (h) -> h.response().setStatusCode(201).end());
             } else {

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3SchemasTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3SchemasTest.java
@@ -71,9 +71,9 @@ public class OpenAPI3SchemasTest extends WebTestValidationBase {
         new RouterFactoryOptions()
         .setRequireSecurityHandlers(false)
         .setMountValidationFailureHandler(true)
-        .setValidationFailureHandler(FAILURE_HANDLER)
         .setMountNotImplementedHandler(false)
       );
+      routerFactory.setValidationFailureHandler(FAILURE_HANDLER);
       latch.countDown();
     });
     awaitLatch(latch);

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/router_factory_integration/OpenAPI3ServiceProxiesTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/router_factory_integration/OpenAPI3ServiceProxiesTest.java
@@ -502,7 +502,8 @@ public class OpenAPI3ServiceProxiesTest extends ApiWebTestBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/service_proxy_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS.setExtraOperationContextPayloadMapper(rc -> new JsonObject().put("username", "slinkydeveloper")));
+        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS);
+        routerFactory.setExtraOperationContextPayloadMapper(rc -> new JsonObject().put("username", "slinkydeveloper"));
 
         routerFactory.mountOperationToEventBus("extraPayload", "someAddress");
 


### PR DESCRIPTION
Moved from `RouterFactoryOptions` to `RouterFactory`:

- `setValidationFailureHandler(Handler<RoutingContext> validationFailureHandler)`
- `setNotImplementedFailureHandler(Handler<RoutingContext> notImplementedFailureHandler)`
- `setBodyHandler(BodyHandler bodyHandler)`
- `addGlobalHandler(Handler<RoutingContext> globalHandler)`
- `setExtraOperationContextPayloadMapper(Function<RoutingContext, JsonObject> extraOperationContextPayloadMapper)`