### PR TITLE
Fix #1120 - Add null check to handle when no encoding is provided for…

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
@@ -505,7 +505,9 @@ public class OpenAPI3RequestValidationHandlerImpl extends HTTPOperationRequestVa
           mediaType.getValue().getSchema().getType().equals("object")) {
           for (Map.Entry<String, ? extends Schema> multipartProperty : ((Map<String, Schema>) mediaType.getValue().getSchema().getProperties())
             .entrySet()) {
-            Encoding encodingProperty = mediaType.getValue().getEncoding().get(multipartProperty.getKey());
+            Encoding encodingProperty = null;
+            if (mediaType.getValue().getEncoding() != null)
+              encodingProperty = mediaType.getValue().getEncoding().get(multipartProperty.getKey());
             String contentTypeRegex;
             if (encodingProperty != null && encodingProperty.getContentType() != null)
               contentTypeRegex = OpenApi3Utils.resolveContentTypeRegex(encodingProperty.getContentType());


### PR DESCRIPTION
Add defensive null check to handle when encoding is not present in openapi definition for multipart/form-data requestBody types

Fix for issue #1120 