### PR TITLE
Pause() before getSession, resume() before context.next()

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -114,7 +114,9 @@ public class SessionHandlerImpl implements SessionHandler {
 			String sessionID = cookie.getValue();
 			if (sessionID != null && sessionID.length() > minLength) {
 				// we passed the OWASP min length requirements
-        context.request().pause();
+        if (context.vertx().isClustered()){
+          context.request().pause();
+        }
 				getSession(context.vertx(), sessionID, res -> {
 					if (res.succeeded()) {
 						Session session = res.result();
@@ -134,7 +136,9 @@ public class SessionHandlerImpl implements SessionHandler {
 					} else {
 						context.fail(res.cause());
 					}
-          context.request().resume();
+          if (context.vertx().isClustered()){
+            context.request().resume();
+          }
 					context.next();
 				});
 				return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -114,6 +114,7 @@ public class SessionHandlerImpl implements SessionHandler {
 			String sessionID = cookie.getValue();
 			if (sessionID != null && sessionID.length() > minLength) {
 				// we passed the OWASP min length requirements
+        context.request().pause();
 				getSession(context.vertx(), sessionID, res -> {
 					if (res.succeeded()) {
 						Session session = res.result();
@@ -133,6 +134,7 @@ public class SessionHandlerImpl implements SessionHandler {
 					} else {
 						context.fail(res.cause());
 					}
+          context.request().resume();
 					context.next();
 				});
 				return;


### PR DESCRIPTION
This will fix the `Request has already been read` problem encountered in cluster mode.

Signed-off-by: Liu Rui <lovearuis@gmail.com>