### PR TITLE
fix: take into account new AsyncFile.setReadLength in WebClientTest

### DIFF
--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -791,6 +791,7 @@ public class WebClientTest extends HttpTestBase {
       public AsyncFile flush() { throw new UnsupportedOperationException(); }
       public AsyncFile flush(Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public AsyncFile setReadPos(long l) { throw new UnsupportedOperationException(); }
+      public AsyncFile setReadLength(long l) { throw new UnsupportedOperationException(); }
       public AsyncFile setWritePos(long l) { throw new UnsupportedOperationException(); }
       public AsyncFile setReadBufferSize(int i) { throw new UnsupportedOperationException(); }
       public AsyncFile exceptionHandler(Handler<Throwable> handler) {


### PR DESCRIPTION
Closes #1138