### PR TITLE
Basic access and bearer token authentication mechanisms

### DIFF
--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -210,6 +210,28 @@ You can also write headers using putHeader
 {@link examples.WebClientExamples#sendHeaders2(io.vertx.ext.web.client.WebClient)}
 ----
 
+=== Configure the request to add authentication.
+
+In basic HTTP authentication, a request contains a header field of the form `Authorization: Basic <credentials>`,
+where credentials is the base64 encoding of id and password joined by a colon.
+
+You can configure the request to add basic access authentication as follows:
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#addBasicAccessAuthentication(io.vertx.ext.web.client.WebClient)}
+----
+
+In OAuth 2.0, a request contains a header field of the form `Authorization: Bearer <bearerToken>`,
+where bearerToken is the bearer token issued by an authorization server to access protected resources.
+
+You can configure the request to add bearer token authentication as follows:
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#addBearerTokenAuthentication(io.vertx.ext.web.client.WebClient)}
+----
+
 === Reusing requests
 
 The {@link io.vertx.ext.web.client.HttpRequest#send(io.vertx.core.Handler)} method can be called multiple times

--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -212,6 +212,9 @@ You can also write headers using putHeader
 
 === Configure the request to add authentication.
 
+Authentication can be performed manually by setting the correct headers, or, using our predefined methods
+(We strongly suggest having HTTPS enabled, especially for authenticated requests):
+
 In basic HTTP authentication, a request contains a header field of the form `Authorization: Basic <credentials>`,
 where credentials is the base64 encoding of id and password joined by a colon.
 

--- a/vertx-web-client/src/main/java/examples/WebClientExamples.java
+++ b/vertx-web-client/src/main/java/examples/WebClientExamples.java
@@ -314,6 +314,16 @@ public class WebClientExamples {
     request.putHeader("other-header", "foo");
   }
 
+  public void addBasicAccessAuthentication(WebClient client) {
+    HttpRequest<Buffer> request = client.get(8080, "myserver.mycompany.com", "/some-uri")
+      .basicAuthentication("myid", "mypassword");
+  }
+
+  public void addBearerTokenAuthentication(WebClient client) {
+    HttpRequest<Buffer> request = client.get(8080, "myserver.mycompany.com", "/some-uri")
+      .bearerTokenAuthentication("myBearerToken");
+  }
+
   public void receiveResponse(WebClient client) {
     client
       .get(8080, "myserver.mycompany.com", "/some-uri")

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -147,7 +147,7 @@ public interface HttpRequest<T> {
   /**
    * Configure the request to add basic access authentication.
    * <p>
-   * In basic HTTP authentication, a request contains a header field of the form Authorization: 'Basic &#60;credentials&#62;',
+   * In basic HTTP authentication, a request contains a header field of the form 'Authorization: Basic &#60;credentials&#62;',
    * where credentials is the base64 encoding of id and password joined by a colon.
    * </p>
    *
@@ -161,7 +161,7 @@ public interface HttpRequest<T> {
   /**
    * Configure the request to add bearer token authentication.
    * <p>
-   * In OAuth 2.0, a request contains a header field of the form Authorization: 'Bearer &#60;bearerToken&#62;',
+   * In OAuth 2.0, a request contains a header field of the form 'Authorization: Bearer &#60;bearerToken&#62;',
    * where bearerToken is the bearer token issued by an authorization server to access protected resources.
    * </p>
    *

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -159,6 +159,20 @@ public interface HttpRequest<T> {
   HttpRequest<T> basicAuthentication(String id, String password);
 
   /**
+   * Configure the request to perform basic access authentication.
+   * <p>
+   * In basic HTTP authentication, a request contains a header field of the form 'Authorization: Basic &#60;credentials&#62;',
+   * where credentials is the base64 encoding of id and password joined by a colon.
+   * </p>
+   *
+   * @param id the id
+   * @param password the password
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> basicAuthentication(Buffer id, Buffer password);
+
+  /**
    * Configure the request to perform bearer token authentication.
    * <p>
    * In OAuth 2.0, a request contains a header field of the form 'Authorization: Bearer &#60;bearerToken&#62;',

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -144,6 +144,33 @@ public interface HttpRequest<T> {
   @CacheReturn
   MultiMap headers();
 
+  /**
+   * Configure the request to add basic access authentication.
+   * <p>
+   * In basic HTTP authentication, a request contains a header field of the form Authorization: 'Basic &#60;credentials&#62;',
+   * where credentials is the base64 encoding of id and password joined by a colon.
+   * </p>
+   *
+   * @param id the id
+   * @param password the password
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> basicAuthentication(String id, String password);
+
+  /**
+   * Configure the request to add bearer token authentication.
+   * <p>
+   * In OAuth 2.0, a request contains a header field of the form Authorization: 'Bearer &#60;bearerToken&#62;',
+   * where bearerToken is the bearer token issued by an authorization server to access protected resources.
+   * </p>
+   *
+   * @param bearerToken the bearer token
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> bearerTokenAuthentication(String bearerToken);
+
   @Fluent
   HttpRequest<T> ssl(boolean value);
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -145,7 +145,7 @@ public interface HttpRequest<T> {
   MultiMap headers();
 
   /**
-   * Configure the request to add basic access authentication.
+   * Configure the request to perform basic access authentication.
    * <p>
    * In basic HTTP authentication, a request contains a header field of the form 'Authorization: Basic &#60;credentials&#62;',
    * where credentials is the base64 encoding of id and password joined by a colon.
@@ -159,7 +159,7 @@ public interface HttpRequest<T> {
   HttpRequest<T> basicAuthentication(String id, String password);
 
   /**
-   * Configure the request to add bearer token authentication.
+   * Configure the request to perform bearer token authentication.
    * <p>
    * In OAuth 2.0, a request contains a header field of the form 'Authorization: Bearer &#60;bearerToken&#62;',
    * where bearerToken is the bearer token issued by an authorization server to access protected resources.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -148,7 +148,12 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
 
   @Override
   public HttpRequest<T> basicAuthentication(String id, String password) {
-    Buffer buff = Buffer.buffer(id).appendString("-").appendString(password);
+    return this.basicAuthentication(Buffer.buffer(id), Buffer.buffer(password));
+  }
+
+  @Override
+  public HttpRequest<T> basicAuthentication(Buffer id, Buffer password) {
+    Buffer buff = Buffer.buffer().appendBuffer(id).appendString("-").appendBuffer(password);
     String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
     return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -32,7 +32,6 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -149,8 +148,8 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
 
   @Override
   public HttpRequest<T> basicAuthentication(String id, String password) {
-    String joined = id + "-" + password;
-    String credentials =  Base64.getEncoder().encodeToString(joined.getBytes(StandardCharsets.UTF_8));
+    Buffer buff = Buffer.buffer(id).appendString("-").appendString(password);
+    String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
     return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -32,7 +32,9 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -143,6 +145,18 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
       headers = new CaseInsensitiveHeaders();
     }
     return headers;
+  }
+
+  @Override
+  public HttpRequest<T> basicAuthentication(String id, String password) {
+    String joined = id + "-" + password;
+    String credentials =  Base64.getEncoder().encodeToString(joined.getBytes(StandardCharsets.UTF_8));
+    return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
+  }
+
+  @Override
+  public HttpRequest<T> bearerTokenAuthentication(String bearerToken) {
+    return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + bearerToken);
   }
 
   @Override

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -95,6 +95,28 @@ public class WebClientTest extends HttpTestBase {
   }
 
   @Test
+  public void testBasicAuthentication() throws Exception {
+    testRequest(
+      client -> client.get("somehost", "somepath").basicAuthentication("someid", "somepassword"),
+      req -> {
+        String auth = req.headers().get(HttpHeaders.AUTHORIZATION);
+        assertEquals("Was expecting authorization header to contain a basic authentication string", "Basic c29tZWlkLXNvbWVwYXNzd29yZA==", auth);
+      }
+    );
+  }
+
+  @Test
+  public void testBearerTokenAuthentication() throws Exception {
+    testRequest(
+      client -> client.get("somehost", "somepath").bearerTokenAuthentication("sometoken"),
+      req -> {
+        String auth = req.headers().get(HttpHeaders.AUTHORIZATION);
+        assertEquals("Was expecting authorization header to contain a bearer token authentication string", "Bearer sometoken", auth);
+      }
+    );
+  }
+
+  @Test
   public void testCustomUserAgent() throws Exception {
     client = WebClient.wrap(super.client, new WebClientOptions().setUserAgent("smith"));
     testRequest(client -> client.get("somehost", "somepath"), req -> assertEquals(Collections.singletonList("smith"), req.headers().getAll(HttpHeaders.USER_AGENT)));

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -97,10 +97,10 @@ public class WebClientTest extends HttpTestBase {
   @Test
   public void testBasicAuthentication() throws Exception {
     testRequest(
-      client -> client.get("somehost", "somepath").basicAuthentication("someid", "somepassword"),
+      client -> client.get("somehost", "somepath").basicAuthentication("ém$¨=!$€", "&@#§$*éà#\"'"),
       req -> {
         String auth = req.headers().get(HttpHeaders.AUTHORIZATION);
-        assertEquals("Was expecting authorization header to contain a basic authentication string", "Basic c29tZWlkLXNvbWVwYXNzd29yZA==", auth);
+        assertEquals("Was expecting authorization header to contain a basic authentication string", "Basic w6ltJMKoPSEk4oKsLSZAI8KnJCrDqcOgIyIn", auth);
       }
     );
   }


### PR DESCRIPTION
Added to interface and implementation with tests:
- `HttpRequest.basicAuthentication(String id, String password)` to configure the request with basic access authentication.
- `HttpRequest.bearerTokenAuthentication(String bearerToken)` to configure the request with bearer token authentication.