### PR TITLE
Subsequent SockJS xhr/xhr_send causes IllegalStateException

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSAsyncHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSAsyncHandlerTest.java
@@ -1,30 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.vertx.ext.web.handler.sockjs;
 
+import io.vertx.ext.web.handler.BodyHandler;
 import org.junit.Test;
 
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.BodyHandler;
-
+/**
+ * @author Ben Ripkens
+ */
 public class SockJSAsyncHandlerTest extends SockJSTestBase {
 
-  public SockJSAsyncHandlerTest() {
+  @Override
+  public void setUp() throws Exception {
     // Use two servers so we test with HTTP request/response with load balanced SockJSSession access
     numServers = 2;
-  }
-
-  @Override
-  protected void addHandlersBeforeSockJSHandler(Router router) {
-    router.route().handler(BodyHandler.create());
-    // simulate an async handler
-    router.route().handler(rtx -> rtx.vertx().executeBlocking(f -> f.complete(true), r -> rtx.next()));
+    preSockJSHandlerSetup = router -> {
+      router.route().handler(BodyHandler.create());
+      // simulate an async handler
+      router.route().handler(rtx -> rtx.vertx().executeBlocking(f -> f.complete(true), r -> rtx.next()));
+    };
+    super.setUp();
   }
 
   @Test
-  public void testHandleMessageFromXhrTransportWithAsyncHandler() {
-    sockJSHandler.socketHandler(socket -> socket.handler(buf -> {
-      assertEquals("Hello World", buf.toString());
-      testComplete();
-    }));
+  public void testHandleMessageFromXhrTransportWithAsyncHandler() throws Exception {
+    socketHandler = () -> {
+      return socket -> {
+        socket.handler(buf -> {
+          assertEquals("Hello World", buf.toString());
+          testComplete();
+        });
+      };
+    };
+
+    startServers();
 
     client.post("/test/400/8ne8e94a/xhr", onSuccess(resp -> {
       assertEquals(200, resp.statusCode());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionContextTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionContextTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.sockjs;
+
+import io.vertx.core.json.JsonArray;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+
+/**
+ * @author Thomas Segismont
+ */
+public class SockJSSessionContextTest extends SockJSTestBase {
+
+  @Override
+  public void setUp() throws Exception {
+    numServers = 2;
+    super.setUp();
+  }
+
+  @Test
+  public void testHandleMessageFromXhrTransportWithAsyncHandler() throws Exception {
+    String msg = "Hello World";
+    socketHandler = () -> {
+      return socket -> {
+        socket.handler(buffer -> {
+          assertEquals(msg, buffer.toString());
+          socket.write(buffer);
+        });
+      };
+    };
+
+    startServers();
+
+    client.post("/test/400/8ne8e94a/xhr", onSuccess(resp -> {
+      assertEquals(200, resp.statusCode());
+
+      client.post("/test/400/8ne8e94a/xhr", onSuccess(resp2 -> {
+        assertEquals(200, resp.statusCode());
+
+        client.post("/test/400/8ne8e94a/xhr_send", onSuccess(respSend -> {
+          assertEquals(204, respSend.statusCode());
+
+          client.post("/test/400/8ne8e94a/xhr", onSuccess(resp3 -> {
+            assertEquals(200, resp.statusCode());
+            resp3.bodyHandler(buffer -> {
+              String body = buffer.toString();
+              assertThat(body, startsWith("a"));
+              JsonArray content = new JsonArray(body.substring(1));
+              assertEquals(1, content.size());
+              assertEquals(msg, content.getValue(0));
+              complete();
+            });
+          })).end();
+
+        })).end('"' + msg + '"');
+
+      })).end();
+
+    })).end();
+
+    await();
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionTest.java
@@ -30,20 +30,23 @@ import java.util.function.BooleanSupplier;
 public class SockJSSessionTest extends SockJSTestBase {
 
   @Test
-  public void testNoDeadlockWhenWritingFromAnotherThreadWithSseTransport() {
-    sockJSHandler.socketHandler(socket -> {
-      AtomicBoolean closed = new AtomicBoolean();
-      socket.endHandler(v -> {
-        closed.set(true);
-        testComplete();
-      });
-      new Thread(() -> {
-        while (!closed.get()) {
-          LockSupport.parkNanos(50);
-          socket.write(Buffer.buffer(TestUtils.randomAlphaString(256)));
-        }
-      }).start();
-    });
+  public void testNoDeadlockWhenWritingFromAnotherThreadWithSseTransport() throws Exception {
+    socketHandler = () -> {
+      return socket -> {
+        AtomicBoolean closed = new AtomicBoolean();
+        socket.endHandler(v -> {
+          closed.set(true);
+          testComplete();
+        });
+        new Thread(() -> {
+          while (!closed.get()) {
+            LockSupport.parkNanos(50);
+            socket.write(Buffer.buffer(TestUtils.randomAlphaString(256)));
+          }
+        }).start();
+      };
+    };
+    startServers();
     client.getNow("/test/400/8ne8e94a/eventsource", onSuccess(resp -> {
       AtomicInteger count = new AtomicInteger();
       resp.handler(msg -> {
@@ -56,26 +59,29 @@ public class SockJSSessionTest extends SockJSTestBase {
   }
 
   @Test
-  public void testNoDeadlockWhenWritingFromAnotherThreadWithWebsocketTransport() {
+  public void testNoDeadlockWhenWritingFromAnotherThreadWithWebsocketTransport() throws Exception {
     int numMsg = 4000;
     waitFor(1);
     AtomicInteger clientReceived = new AtomicInteger();
     AtomicInteger serverReceived = new AtomicInteger();
     BooleanSupplier shallStop = () -> clientReceived.get() > numMsg * 256 && serverReceived.get() > numMsg * 256;
-    sockJSHandler.socketHandler(socket -> {
-      socket.handler(msg -> serverReceived.addAndGet(msg.length()));
-      socket.write("hello");
-      new Thread(() -> {
-        while (!shallStop.getAsBoolean()) {
-          LockSupport.parkNanos(50);
-          try {
-            socket.write(Buffer.buffer(TestUtils.randomAlphaString(256)));
-          } catch (IllegalStateException e) {
-            // Websocket has been closed
+    socketHandler = () -> {
+      return socket -> {
+        socket.handler(msg -> serverReceived.addAndGet(msg.length()));
+        socket.write("hello");
+        new Thread(() -> {
+          while (!shallStop.getAsBoolean()) {
+            LockSupport.parkNanos(50);
+            try {
+              socket.write(Buffer.buffer(TestUtils.randomAlphaString(256)));
+            } catch (IllegalStateException e) {
+              // Websocket has been closed
+            }
           }
-        }
-      }).start();
-    });
+        }).start();
+      };
+    };
+    startServers();
     client.websocket("/test/400/8ne8e94a/websocket", ws -> ws.handler(msg -> {
       clientReceived.addAndGet(msg.length());
       ws.writeTextMessage("\"hello\"");
@@ -88,11 +94,14 @@ public class SockJSSessionTest extends SockJSTestBase {
   }
 
   @Test
-  public void testCombineMultipleFramesIntoASingleMessage() {
-    sockJSHandler.socketHandler(socket -> socket.handler(buf -> {
-      assertEquals("Hello World", buf.toString());
-      testComplete();
-    }));
+  public void testCombineMultipleFramesIntoASingleMessage() throws Exception {
+    socketHandler = () -> {
+      return socket -> socket.handler(buf -> {
+        assertEquals("Hello World", buf.toString());
+        testComplete();
+      });
+    };
+    startServers();
     client.websocket("/test/400/8ne8e94a/websocket", ws -> {
       ws.writeFrame(io.vertx.core.http.WebSocketFrame.textFrame("[\"Hello", false));
       ws.writeFrame(io.vertx.core.http.WebSocketFrame.continuationFrame(Buffer.buffer(" World\"]"), true));

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSStreamTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSStreamTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.sockjs;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Thomas Segismont
+ */
+public class SockJSStreamTest extends SockJSTestBase {
+
+  @Override
+  public void setUp() throws Exception {
+    numServers = 2;
+    super.setUp();
+  }
+
+  @Test
+  public void testStream() throws Exception {
+    AtomicReference<Context> sessionContext = new AtomicReference<>();
+    socketHandler = () -> {
+      return socket -> {
+        Context context = Vertx.currentContext();
+        assertNotNull(context);
+        assertTrue(sessionContext.compareAndSet(null, context));
+        socket.setWriteQueueMaxSize(5);
+        socket.write("Hello");
+        assertTrue(socket.writeQueueFull());
+        socket.drainHandler(v -> {
+          assertEquals(sessionContext.get(), Vertx.currentContext());
+          socket.write("World");
+        });
+      };
+    };
+
+    startServers();
+
+    List<String> messages = Collections.synchronizedList(new ArrayList<>());
+    fetchMessages(messages);
+    await();
+  }
+
+  private void fetchMessages(List<String> messages) {
+    client.post("/test/400/8ne8e94a/xhr", onSuccess(resp -> {
+      assertEquals(200, resp.statusCode());
+      resp.bodyHandler(buffer -> {
+        String body = buffer.toString();
+        if (body.startsWith("a")) {
+          JsonArray content = new JsonArray(body.substring(1));
+          messages.addAll(content.stream().map(Object::toString).collect(toList()));
+        }
+        if (messages.size() < 2) {
+          fetchMessages(messages);
+        } else {
+          assertEquals(Arrays.asList("Hello", "World"), messages);
+          testComplete();
+        }
+      });
+    })).end();
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.vertx.ext.web.handler.sockjs;
 
-import java.util.concurrent.CountDownLatch;
-
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.CookieHandler;
@@ -12,44 +29,59 @@ import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.test.core.VertxTestBase;
 
-public abstract class SockJSTestBase extends VertxTestBase {
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
-  protected int numServers = 1;
-  protected HttpClient client;
-  protected HttpServer[] servers;
-  protected SockJSHandler sockJSHandler;
+/**
+ * @author Ben Ripkens
+ */
+abstract class SockJSTestBase extends VertxTestBase {
 
-  protected Router createRouter() {
-    Router router = Router.router(vertx);
-    router.route().handler(CookieHandler.create());
-    router.route()
-      .handler(SessionHandler.create(LocalSessionStore.create(vertx))
-        .setNagHttps(false)
-        .setSessionTimeout(60 * 60 * 1000));
-    addHandlersBeforeSockJSHandler(router);
-    return router;
-  }
+  int numServers = 1;
+  HttpClient client;
+  Consumer<Router> preSockJSHandlerSetup;
+  Supplier<Handler<SockJSSocket>> socketHandler;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    servers = new HttpServer[numServers];
     client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8080).setKeepAlive(false));
-    SockJSHandlerOptions options = new SockJSHandlerOptions().setHeartbeatInterval(2000);
-    sockJSHandler = SockJSHandler.create(vertx, options);
-    for (int i = 0;i < servers.length;i++) {
-      Router router = createRouter();
-      router.route("/test/*").handler(sockJSHandler);
-      servers[i] = vertx
-        .createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"))
-        .requestHandler(router);
-      CountDownLatch latch = new CountDownLatch(1);
-      servers[i].listen(ar -> latch.countDown());
-      awaitLatch(latch);
-    }
   }
 
-  protected void addHandlersBeforeSockJSHandler(Router router) {
-    // no additional routing handlers by default
+  void startServers() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    vertx.deployVerticle(() -> new AbstractVerticle() {
+      @Override
+      public void start(Future<Void> startFuture) throws Exception {
+
+        Router router = Router.router(vertx);
+        router.route().handler(CookieHandler.create());
+        router.route()
+          .handler(SessionHandler.create(LocalSessionStore.create(vertx))
+            .setNagHttps(false)
+            .setSessionTimeout(60 * 60 * 1000));
+
+        if (preSockJSHandlerSetup != null) {
+          preSockJSHandlerSetup.accept(router);
+        }
+
+        SockJSHandlerOptions options = new SockJSHandlerOptions().setHeartbeatInterval(2000);
+        SockJSHandler sockJSHandler = SockJSHandler.create(vertx, options);
+        sockJSHandler.socketHandler(socketHandler.get());
+        router.route("/test/*").handler(sockJSHandler);
+
+        vertx.createHttpServer(new HttpServerOptions().setPort(8080).setHost("localhost"))
+          .requestHandler(router)
+          .listen(ar -> {
+            if (ar.succeeded()) {
+              startFuture.complete();
+            } else {
+              startFuture.fail(ar.cause());
+            }
+          });
+      }
+    }, new DeploymentOptions().setInstances(numServers), onSuccess(id -> latch.countDown()));
+    awaitLatch(latch);
   }
 }


### PR DESCRIPTION
Fixes #1135

InboundBuffer expects writes to happen on the creating context.
So it should be captured and use to queue buffers instead of the transport context.

Also, fixed an issue with listener which can be null.