### PR TITLE
fix: router handle failure of closed responses

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -157,7 +157,7 @@ public abstract class RoutingContextImplBase implements RoutingContext {
         log.error("Error in error handler", t);
       }
     }
-    if (!response().ended()) {
+    if (!response().ended() && !response().closed()) {
       try {
         response().setStatusCode(code);
       } catch (IllegalArgumentException e) {


### PR DESCRIPTION
When a request is closed while it is being processed, the router should
not try to write a 500 Internal Server error, as this will trigger a new
failure.