### PR TITLE
API Contract error handlers adapted to new Router error handling

### DIFF
--- a/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/dataobjects.adoc
@@ -44,8 +44,8 @@ Get request principal user as routingContext.user().principal(), null if no user
 |===
 ^|Name | Type ^| Description
 |[[mountNotImplementedHandler]]`@mountNotImplementedHandler`|`Boolean`|+++
-Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
- You can change the "not implemented handler" with link
+If true, Router Factory will automatically mount an handler that return HTTP 501 status code for each operation where you didn't specify an handler.
+ You can customize the response with link
 +++
 |[[mountResponseContentTypeHandler]]`@mountResponseContentTypeHandler`|`Boolean`|+++
 If true, when required, the factory will mount a link

--- a/vertx-web-api-contract/src/main/asciidoc/index.adoc
+++ b/vertx-web-api-contract/src/main/asciidoc/index.adoc
@@ -29,7 +29,7 @@ dependencies {
 }
 ----
 
-== HTTP Requests validation without OpenAPI 3
+== HTTP Requests validation
 
 Vert.x provides a validation framework that will validate requests for you and will put results of validation inside a container. To define a {@link io.vertx.ext.web.api.validation.HTTPRequestValidationHandler}:
 
@@ -45,7 +45,8 @@ Then you can mount your validation handler:
 {@link examples.ValidationExamples#example2}
 ----
 
-If validation succeeds, It returns request parameters inside {@link io.vertx.ext.web.api.RequestParameters}, otherwise It will throw a {@link io.vertx.ext.web.api.validation.ValidationException}
+If validation succeeds, It returns request parameters inside {@link io.vertx.ext.web.api.RequestParameters},
+otherwise It will throw a fail inside `RoutingContext` with 400 status code and {@link io.vertx.ext.web.api.validation.ValidationException} failure.
 
 === Types of request parameters
 Every parameter has a type validator, a class that describes the expected type of parameter.
@@ -70,35 +71,41 @@ As you can see, every parameter is mapped in respective language objects. You ca
 {@link examples.ValidationExamples#example4}
 ----
 
+=== Manage validation failures
+A validation error fails the `RoutingContext` with 400 status code and {@link io.vertx.ext.web.api.validation.ValidationException} failure.
+You can manage these failures both at route level using {@link io.vertx.ext.web.Route#failureHandler} or at router level using {@link io.vertx.ext.web.Router#errorHandler}:
+
+[source,$lang]
+----
+{@link examples.ValidationExamples#example5}
+----
+
 == OpenAPI 3
+Vert.x allows you to use your OpenAPI 3 specification directly inside your code using the design first approach. Vert.x-Web API Contract provides:
 
-Vert.x allows you to use your OpenApi 3 specification directly inside your code using the design first approach. Vert.x-Web provides:
-
-* OpenAPI 3 compliant API specification validation with automatic*loading of external Json schemas**
+* OpenAPI 3 compliant API specification validation with automatic **loading of external Json schemas**
 * Automatic request validation
 * Automatic mount of security validation handlers
-* Automatic 501 response for not implemented operations
-* Router factory to provide all these features to users
 
-You can also use the community project https://github.com/pmlopes/slush-vertx[`slush-vertx`] to generate server code from your OpenAPI 3 specification.
+You can also use the community project https://github.com/pmlopes/vertx-starter[`vertx-starter`] to generate server code from your OpenAPI 3 specification.
 
-=== The router factory
-You can create your web service based on OpenAPI3 specification with {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory}.
+=== The Router Factory
+You can create your web service based on OpenAPI 3 specification with {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory}.
 This class, as name says, is a router factory based on your OpenAPI 3 specification.
-{@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory} is intended to give you a really simple user interface to use OpenAPI 3 support. It includes:
+{@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory} is intended to give you a really simple user interface to use OpenAPI 3 related features. It includes:
 
 * Async loading of specification and its schema dependencies
 * Mount path with operationId or with combination of path and HTTP method
-* Automatic request parameters validation
-* Automatic convert OpenAPI style paths to Vert.x style paths
-* Lazy methods: operations (combination of paths and HTTP methods) are mounted in declaration order inside specification
-* Automatic mount of security validation handlers
+* Automatic generation of validation handlers
+* Automatic conversion between OpenAPI style paths and Vert.x style paths
+* Lazy methods: operations are mounted in declaration order inside specification
+* Automatic mount of security handlers
 
 === Create a new router factory
-To create a new router factory, Use method {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#create(io.vertx.core.Vertx, java.lang.String, io.vertx.core.Handler)}.
+To create a new router factory, use method {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#create(io.vertx.core.Vertx, java.lang.String, io.vertx.core.Handler)}.
 As location It accepts absolute paths, local paths and local or remote URLs (HTTP or file protocol).
 
-For example:
+For example to load a spec from the local filesystem:
 
 [source,$lang]
 ----
@@ -120,17 +127,13 @@ Or, you can also access a private remote spec by passing one or more https://git
 ----
 
 You can also modify the behaviours of the router factory with {@link io.vertx.ext.web.api.contract.RouterFactoryOptions}.
-For example you can ask to router factory to mount the validation failure handler but to not mount the not implemented handler as follows:
-
-[source,$lang]
-----
-{@link examples.OpenAPI3Examples#mountOptions}
-----
 
 === Mount the handlers
-Now load your first operation handlers. To load an handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}. To load a failure handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}
+Now load your first operation handlers.
+To load an handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}.
+To load a failure handler use {@link io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory#addFailureHandlerByOperationId(java.lang.String, io.vertx.core.Handler)}
 
-You can, of course,*add multiple handlers to same operation**, without overwrite the existing ones.
+You can, of course, **add multiple handlers to same operation**, without overwrite the existing ones.
 
 For example:
 
@@ -139,12 +142,9 @@ For example:
 {@link examples.OpenAPI3Examples#addRoute}
 ----
 
-.Add operations with operationId
-IMPORTANT: Usage of combination of path and HTTP method is allowed, but it's better to add operations handlers with operationId, for performance reasons and to avoid paths nomenclature errors
-
 Now you can use parameter values as described above
 
-== Define security handlers
+=== Define security handlers
 A security handler is defined by a combination of schema name and scope. You can mount only one security handler for a combination.
 For example:
 
@@ -160,15 +160,43 @@ You can of course use included Vert.x security handlers, for example:
 {@link examples.OpenAPI3Examples#addJWT}
 ----
 
-=== Customize the router factory behaviours
-The router factory allows you to customize some behaviours during router generation with
-{@link io.vertx.ext.web.api.contract.RouterFactoryOptions}. Router factory can:
+When you generate the {@link io.vertx.ext.web.Router} the Router Factory fails if For debugging/testing purpose
 
-* Mount a 501 `Not Implemented` handler for operations where you haven't mounted any handler
-* Mount a 400 `Bad Request` handler that manages `ValidationException`
-* Mount the {@link io.vertx.ext.web.handler.ResponseContentTypeHandler} handler when needed
+=== Not Implemented Error
+Router Factory automatically mounts a default handler for operations without a specified handler.
+This default handler fails the routing context with 501 `Not Implemented` error.
+You can enable/disable it with {@link io.vertx.ext.web.api.contract.RouterFactoryOptions#setMountNotImplementedHandler}
+and you can customize this error handling with {@link io.vertx.ext.web.Router#errorHandler}
 
-Give a deeper look at {@link io.vertx.ext.web.api.contract.RouterFactoryOptions} documentation
+=== Response Content Type Handler
+Router Factory automatically mounts a {@link io.vertx.ext.web.handler.ResponseContentTypeHandler} handler when contract requires it.
+You can disable this feature with {@link io.vertx.ext.web.api.contract.RouterFactoryOptions#setMountResponseContentTypeHandler}
+
+=== Operation model
+If you need to access to your operation contract while handling the request,
+you can configure the router factory to push it inside the `RoutingContext` with {@link io.vertx.ext.web.api.contract.RouterFactoryOptions#setOperationModelKey}. For example:
+
+[source,$lang]
+----
+{@link examples.OpenAPI3Examples#addOperationModelKey}
+----
+
+=== Body Handler
+Router Factory automatically mounts a {@link io.vertx.ext.web.handler.BodyHandler} to manage request bodies.
+You can configure the instance of {@link io.vertx.ext.web.handler.BodyHandler} (e.g. to change upload directory) with {@link io.vertx.ext.web.api.contract.RouterFactory#setBodyHandler}.
+
+=== Custom global handlers
+If you need to mount handlers that must be executed for each operationin your router before the operation specific handlers, you can use {@link io.vertx.ext.web.api.contract.RouterFactory#addGlobalHandler}
+
+=== Router factory handlers mount order
+Handlers are loaded by the router factory in this order:
+
+1. Body handler
+2. Custom global handlers
+3. Global security handlers defined in upper spec level
+4. Operation specific security handlers
+5. Generated validation handler
+6. User handlers or "Not implemented" handler (if enabled)
 
 === Generate the router
 When you are ready, generate the router and use it:
@@ -177,6 +205,8 @@ When you are ready, generate the router and use it:
 ----
 {@link examples.OpenAPI3Examples#generateRouter}
 ----
+
+This method can fail with a {@link io.vertx.ext.web.api.contract.RouterFactoryException} if you didn't provide the required security handlers.
 
 ifeval::["$lang" == "java"]
 include::override/rxjava2.adoc[]

--- a/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
+++ b/vertx-web-api-contract/src/main/java/examples/OpenAPI3Examples.java
@@ -1,5 +1,6 @@
 package examples;
 
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -70,17 +71,6 @@ public class OpenAPI3Examples {
       });
   }
 
-  public void mountOptions(AsyncResult<OpenAPI3RouterFactory> ar) {
-    OpenAPI3RouterFactory routerFactory = ar.result();
-    // Create and mount options to router factory
-    RouterFactoryOptions options =
-      new RouterFactoryOptions()
-      .setMountNotImplementedHandler(true)
-      .setMountValidationFailureHandler(false);
-
-    routerFactory.setOptions(options);
-  }
-
   public void addRoute(Vertx vertx, OpenAPI3RouterFactory routerFactory) {
     routerFactory.addHandlerByOperationId("awesomeOperation", routingContext -> {
       RequestParameters params = routingContext.get("parsedParameters");
@@ -99,6 +89,24 @@ public class OpenAPI3Examples {
 
   public void addJWT(OpenAPI3RouterFactory routerFactory, JWTAuth jwtAuthProvider) {
     routerFactory.addSecurityHandler("jwt_auth", JWTAuthHandler.create(jwtAuthProvider));
+  }
+
+  public void addOperationModelKey(OpenAPI3RouterFactory routerFactory, RouterFactoryOptions options) {
+    // Configure the operation model key and set options in router factory
+    options.setOperationModelKey("operationPOJO");
+    routerFactory.setOptions(options);
+
+    // Add an handler that uses the operation model
+    routerFactory.addHandlerByOperationId("listPets", routingContext -> {
+      io.swagger.v3.oas.models.Operation operation = routingContext.get("operationPOJO");
+
+      routingContext
+        .response()
+        .setStatusCode(200)
+        .setStatusMessage("OK")
+        // Write the response with operation id "listPets"
+        .end(operation.getOperationId());
+    });
   }
 
   public void generateRouter(Vertx vertx, OpenAPI3RouterFactory routerFactory) {

--- a/vertx-web-api-contract/src/main/java/examples/ValidationExamples.java
+++ b/vertx-web-api-contract/src/main/java/examples/ValidationExamples.java
@@ -71,5 +71,34 @@ public class ValidationExamples {
       JsonObject jsonBody = body.getJsonObject();
     }
   }
+
+  public void example5(Vertx vertx, Router router, HTTPRequestValidationHandler validationHandler) {
+    router.get("/awesome/:pathParam")
+      // Mount validation handler
+      .handler(validationHandler)
+      //Mount your handler
+      .handler((routingContext) -> {
+        // Your logic
+      })
+      //Mount your failure handler to manage the validation failure at path level
+      .failureHandler((routingContext) -> {
+        Throwable failure = routingContext.failure();
+        if (failure instanceof ValidationException) {
+          // Something went wrong during validation!
+          String validationErrorMessage = failure.getMessage();
+        }
+      });
+
+    // Manage the validation failure for all routes in the router
+    router.errorHandler(400, routingContext -> {
+      if (routingContext.failure() instanceof ValidationException) {
+        // Something went wrong during validation!
+        String validationErrorMessage = routingContext.failure().getMessage();
+      } else {
+        // Unknown 400 failure happened
+        routingContext.response().setStatusCode(400).end();
+      }
+    });
+  }
 }
 

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactory.java
@@ -54,7 +54,10 @@ public interface RouterFactory<Specification> {
    */
   Router getRouter();
 
-
+  /**
+   * @deprecated Router Factory won't manage the validation errors anymore. You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 400 error
+   */
+  @Deprecated
   Handler<RoutingContext> getValidationFailureHandler();
 
   /**
@@ -63,8 +66,10 @@ public interface RouterFactory<Specification> {
    *
    * @param validationFailureHandler
    * @return this object
+   * @deprecated Router Factory won't manage the validation errors anymore. You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 400 error
    */
   @Fluent
+  @Deprecated
   RouterFactory setValidationFailureHandler(Handler<RoutingContext> validationFailureHandler);
 
   /**
@@ -74,8 +79,10 @@ public interface RouterFactory<Specification> {
    *
    * @param notImplementedFailureHandler
    * @return this object
+   * @deprecated You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 501 error
    */
   @Fluent
+  @Deprecated
   RouterFactory setNotImplementedFailureHandler(Handler<RoutingContext> notImplementedFailureHandler);
 
   /**

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/RouterFactoryOptions.java
@@ -19,9 +19,11 @@ import java.util.function.Function;
 public class RouterFactoryOptions {
 
   /**
-   * By default, RouterFactory loads validation failure handler
+   * By default, RouterFactory doesn't mount validation failure handler
+   * @deprecated Router Factory won't manage the validation errors anymore. You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 400 error
    */
-  public final static boolean DEFAULT_MOUNT_VALIDATION_FAILURE_HANDLER = true;
+  @Deprecated
+  public final static boolean DEFAULT_MOUNT_VALIDATION_FAILURE_HANDLER = false;
 
   /**
    * By default, RouterFactory mounts Not Implemented handler
@@ -81,6 +83,11 @@ public class RouterFactoryOptions {
     this.operationModelKey = DEFAULT_OPERATION_MODEL_KEY;
   }
 
+  /**
+   * @deprecated Router Factory won't manage the validation errors anymore. You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 400 error
+   * @return
+   */
+  @Deprecated
   public boolean isMountValidationFailureHandler() {
     return mountValidationFailureHandler;
   }
@@ -92,8 +99,10 @@ public class RouterFactoryOptions {
    *
    * @param mountGlobalValidationFailureHandler
    * @return this object
+   * @deprecated Router Factory won't manage the validation errors anymore. You must use {@link io.vertx.ext.web.Router#errorHandler(int, Handler)} with 400 error
    */
   @Fluent
+  @Deprecated
   public RouterFactoryOptions setMountValidationFailureHandler(boolean mountGlobalValidationFailureHandler) {
     this.mountValidationFailureHandler = mountGlobalValidationFailureHandler;
     return this;
@@ -104,8 +113,8 @@ public class RouterFactoryOptions {
   }
 
   /**
-   * Automatic mount handlers that return HTTP 501 status code for operations where you didn't specify an handler.
-   * You can change the "not implemented handler" with {@link RouterFactory#setNotImplementedFailureHandler(Handler)}
+   * If true, Router Factory will automatically mount an handler that return HTTP 501 status code for each operation where you didn't specify an handler.
+   * You can customize the response with {@link io.vertx.ext.web.Router#errorHandler(int, Handler)}
    *
    * @param mountOperationsWithoutHandler
    * @return this object

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -94,7 +94,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
       routingContext.next();
 
     } catch (ValidationException e) {
-      routingContext.fail(e);
+      routingContext.fail(400, e);
     }
   }
 

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -501,7 +501,7 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS);
+        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS.setMountValidationFailureHandler(true));
 
         routerFactory.addHandlerByOperationId("listPets", routingContext -> routingContext
           .response()
@@ -525,7 +525,7 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
     OpenAPI3RouterFactory.create(this.vertx, "src/test/resources/swaggers/router_factory_test.yaml",
       openAPI3RouterFactoryAsyncResult -> {
         routerFactory = openAPI3RouterFactoryAsyncResult.result();
-        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS);
+        routerFactory.setOptions(HANDLERS_TESTS_OPTIONS.setMountValidationFailureHandler(true));
         routerFactory.setValidationFailureHandler(routingContext ->
           routingContext
             .response()


### PR DESCRIPTION
I've deprecated methods inside `RouterFactory` to manage failures. Now users should use new `Router.errorHandler()` method.

Also reworked the documentation to explain validation error handling and other options of router factory

@pmlopes Do you think it's fine to change the default option of mount validation error handler? It's a breaking change but if I don't change it users must explicitly set false this option to use new router method https://github.com/vert-x3/vertx-web/compare/api_contract_error_handlers?expand=1#diff-a17269788004fa9cad18b88e36172080R26

