### PR TITLE
Change delimiter in basicAuthentication

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -153,7 +153,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
 
   @Override
   public HttpRequest<T> basicAuthentication(Buffer id, Buffer password) {
-    Buffer buff = Buffer.buffer().appendBuffer(id).appendString("-").appendBuffer(password);
+    Buffer buff = Buffer.buffer().appendBuffer(id).appendString(":").appendBuffer(password);
     String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
     return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
   }


### PR DESCRIPTION
#1168 

Change delimiter in basicAuthentication from hyphen to colon to match basic authorization protocol.