### PR TITLE
Update basicAuthentication method so that it matches protocol standards

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -153,7 +153,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
 
   @Override
   public HttpRequest<T> basicAuthentication(Buffer id, Buffer password) {
-    Buffer buff = Buffer.buffer().appendBuffer(id).appendString("-").appendBuffer(password);
+    Buffer buff = Buffer.buffer().appendBuffer(id).appendString(":").appendBuffer(password);
     String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
     return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
   }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -100,7 +100,7 @@ public class WebClientTest extends HttpTestBase {
       client -> client.get("somehost", "somepath").basicAuthentication("ém$¨=!$€", "&@#§$*éà#\"'"),
       req -> {
         String auth = req.headers().get(HttpHeaders.AUTHORIZATION);
-        assertEquals("Was expecting authorization header to contain a basic authentication string", "Basic w6ltJMKoPSEk4oKsLSZAI8KnJCrDqcOgIyIn", auth);
+        assertEquals("Was expecting authorization header to contain a basic authentication string", "Basic w6ltJMKoPSEk4oKsOiZAI8KnJCrDqcOgIyIn", auth);
       }
     );
   }


### PR DESCRIPTION
#1168 

Change the delimiter in the basicAuthentication method from a hyphen to a colon.