### PR TITLE
digest auth: uri in authorization header must match request uri

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
@@ -125,6 +125,13 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
           }
           n.count = nc;
         }
+
+        final String uri = authInfo.getString("uri");
+
+        if (!uri.equalsIgnoreCase(context.request().uri())) {
+          handler.handle(Future.failedFuture(UNAUTHORIZED));
+          return;
+        }
       } catch (RuntimeException e) {
         handler.handle(Future.failedFuture(e));
       }


### PR DESCRIPTION
Currently if the uri inside the authorization header does not match the request uri the auth succeed. I think this is wrong, please review my patch