### PR TITLE
EnumTypeValidator correctly accepts different types for allowedValues other than List<String>

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/openapi3/impl/OpenAPI3RequestValidationHandlerImpl.java
@@ -115,8 +115,10 @@ public class OpenAPI3RequestValidationHandlerImpl extends HTTPOperationRequestVa
       return ParameterType.GENERIC_STRING.validationMethod();
     }
     if (parseEnum && schema.getEnum() != null && schema.getEnum().size() != 0) {
-      return ParameterTypeValidator.createEnumTypeValidatorWithInnerValidator(new ArrayList(schema.getEnum()), this
-        .resolveInnerSchemaPrimitiveTypeValidator(schema, false));
+      return ParameterTypeValidator.createEnumTypeValidatorWithInnerValidator(
+        new ArrayList(schema.getEnum()),
+        this.resolveInnerSchemaPrimitiveTypeValidator(schema, false)
+      );
     }
     switch (schema.getType()) {
       case "integer":

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/impl/RequestParameterImpl.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/impl/RequestParameterImpl.java
@@ -59,6 +59,8 @@ public class RequestParameterImpl implements RequestParameter {
     this.value = value;
   }
 
+  public Object getValue() { return this.value; }
+
   @Override
   public @Nullable List<String> getObjectKeys() {
     return (isObject()) ? new ArrayList<>(((Map<String, RequestParameter>) value).keySet()) : null;

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/ParameterTypeValidator.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/ParameterTypeValidator.java
@@ -314,7 +314,7 @@ public interface ParameterTypeValidator {
    * @return
    */
   static ParameterTypeValidator createStringEnumTypeValidator(List<String> allowedValues) {
-    return new EnumTypeValidator(allowedValues, ParameterType.GENERIC_STRING.validationMethod());
+    return new EnumTypeValidator<>(allowedValues, ParameterType.GENERIC_STRING.validationMethod());
   }
 
   /**
@@ -325,9 +325,9 @@ public interface ParameterTypeValidator {
    *                      can be null
    * @return
    */
-  static ParameterTypeValidator createEnumTypeValidatorWithInnerValidator(List<String> allowedValues,
+  static ParameterTypeValidator createEnumTypeValidatorWithInnerValidator(List<Object> allowedValues,
                                                                           ParameterTypeValidator innerValidator) {
-    return new EnumTypeValidator(allowedValues, innerValidator);
+    return new EnumTypeValidator<>(allowedValues, innerValidator);
   }
 
   /**

--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/EnumTypeValidator.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/EnumTypeValidator.java
@@ -1,37 +1,36 @@
 package io.vertx.ext.web.api.validation.impl;
 
 import io.vertx.ext.web.api.RequestParameter;
+import io.vertx.ext.web.api.impl.RequestParameterImpl;
 import io.vertx.ext.web.api.validation.ParameterTypeValidator;
 import io.vertx.ext.web.api.validation.ValidationException;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Francesco Guardiani @slinkydeveloper
  */
-public class EnumTypeValidator extends SingleValueParameterTypeValidator<Object> {
+public class EnumTypeValidator<T> extends SingleValueParameterTypeValidator<T> {
 
-  private List<String> allowedValues;
+  private List<T> allowedValues;
+  private ParameterTypeValidator innerValidator;
 
-  public EnumTypeValidator(List<String> allowedValues, ParameterTypeValidator innerValidator) {
-    super((innerValidator != null) ? innerValidator.getDefault() : null);
+  @SuppressWarnings("unchecked")
+  public EnumTypeValidator(List<T> allowedValues, ParameterTypeValidator innerValidator) {
+    super((innerValidator != null) ? (T) innerValidator.getDefault() : null);
+    this.innerValidator = innerValidator;
     this.allowedValues = allowedValues;
-    if (innerValidator != null) {
-      for (String value : this.allowedValues) {
-        try {
-          innerValidator.isValid(value);
-        } catch (ValidationException e) {
-          throw new IllegalArgumentException("Value " + value + "of enum is invalid" + e.getMessage());
-        }
-      }
-    }
   }
 
   @Override
   public RequestParameter isValidSingleParam(String value) {
-    if (!allowedValues.contains(value))
+    RequestParameterImpl parsedValue = (RequestParameterImpl)(
+      (this.innerValidator != null) ? innerValidator.isValid(value) : RequestParameter.create(value)
+    );
+    if (!allowedValues.contains(parsedValue.getValue()))
       throw ValidationException.ValidationExceptionFactory.generateNotMatchValidationException("Value " + value + " "
         + "in not inside enum list " + allowedValues.toString());
-    else return RequestParameter.create(value);
+    else return parsedValue;
   }
 }

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3ValidationTest.java
@@ -439,8 +439,9 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
     loadHandlers("/multipart/complex", HttpMethod.POST, false, validationHandler, (routingContext) -> {
       RequestParameters params = routingContext.get("parsedParameters");
       assertNotNull(params.formParameter("param2").getJsonObject());
-      assertEquals(params.formParameter("param2").getJsonObject().getString("name"), "Willy");
-      assertEquals(params.formParameter("param4").getArray().size(), 4);
+      assertEquals("Willy", params.formParameter("param2").getJsonObject().getString("name"));
+      assertEquals(4, params.formParameter("param4").getArray().size());
+      assertEquals((Integer)2, params.formParameter("param5").getInteger());
       routingContext.response().setStatusMessage("ok").end();
     });
 
@@ -457,6 +458,7 @@ public class OpenAPI3ValidationTest extends WebTestValidationBase {
       .attribute("param2", pet.encode())
       .textFileUpload("param3", "random.csv", "src/test/resources/random.txt", "text/csv")
       .attribute("param4", serializeInCSVStringArray(valuesArray))
+      .attribute("param5", "2")
       .binaryFileUpload("param1Binary", "random-file", "src/test/resources/random-file", "text/plain");
 
     testRequestWithMultipartForm(HttpMethod.POST, "/multipart/complex", form, 200, "ok");

--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/impl/EnumTypeValidatorTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/validation/impl/EnumTypeValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -17,13 +18,20 @@ public class EnumTypeValidatorTest {
   @Test
   public void isValid() {
     List<String> strings = Arrays.asList("hello", "world", "im", "francesco", "and", "i", "dont", "like", "testing");
-    EnumTypeValidator enumTypeValidator = new EnumTypeValidator(strings, null);
+    EnumTypeValidator enumTypeValidator = new EnumTypeValidator<>(strings, null);
     strings.forEach((s) -> assertEquals(RequestParameter.create(s), enumTypeValidator.isValid(s)));
+  }
+
+  @Test
+  public void isValidEnumIntegers() {
+    List<String> strings = Arrays.asList("1", "2", "3", "4", "5");
+    EnumTypeValidator enumTypeValidator = new EnumTypeValidator<>(strings.stream().map(Integer::valueOf).collect(Collectors.toList()), new NumericTypeValidator(Integer.class));
+    strings.forEach((s) -> assertEquals(RequestParameter.create(Integer.valueOf(s)), enumTypeValidator.isValid(s)));
   }
 
   @Test(expected = ValidationException.class)
   public void isNotValid() {
-    EnumTypeValidator enumTypeValidator = new EnumTypeValidator(Arrays.asList("hello", "world"), null);
+    EnumTypeValidator enumTypeValidator = new EnumTypeValidator<>(Arrays.asList("hello", "world"), null);
     enumTypeValidator.isValid("francesco");
   }
 }

--- a/vertx-web-api-contract/src/test/resources/swaggers/validation_test.yaml
+++ b/vertx-web-api-contract/src/test/resources/swaggers/validation_test.yaml
@@ -411,6 +411,9 @@ paths:
               properties:
                 param1:
                   type: string
+                param1binary:
+                  type: string
+                  format: binary
                 param2:
                   $ref: "#/components/schemas/Pet"
                 param3:
@@ -420,9 +423,12 @@ paths:
                   items:
                     type: number
                     format: float
-                param1binary:
-                  type: string
-                  format: binary
+                param5:
+                  type: integer
+                  format: int32
+                  enum:
+                    - 1
+                    - 2
               required:
                 - param1
                 - param1Binary


### PR DESCRIPTION
Fixed issue #1219