### PR TITLE
Fixes: #1212

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/DigestAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/DigestAuthHandler.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.handler;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Vertx;
 import io.vertx.ext.auth.htdigest.HtdigestAuth;
 import io.vertx.ext.web.handler.impl.DigestAuthHandlerImpl;
 
@@ -36,21 +37,23 @@ public interface DigestAuthHandler extends AuthHandler {
   /**
    * Create a digest auth handler
    *
+   * @param vertx        the vertx instance
    * @param authProvider the auth provider to use
    * @return the auth handler
    */
-  static DigestAuthHandler create(HtdigestAuth authProvider) {
-    return new DigestAuthHandlerImpl(authProvider, DEFAULT_NONCE_EXPIRE_TIMEOUT);
+  static DigestAuthHandler create(Vertx vertx, HtdigestAuth authProvider) {
+    return new DigestAuthHandlerImpl(vertx, authProvider, DEFAULT_NONCE_EXPIRE_TIMEOUT);
   }
 
   /**
    * Create a digest auth handler, specifying the expire timeout for nonces.
    *
+   * @param vertx              the vertx instance
    * @param authProvider       the auth service to use
    * @param nonceExpireTimeout the nonce expire timeout in milliseconds.
    * @return the auth handler
    */
-  static DigestAuthHandler create(HtdigestAuth authProvider, long nonceExpireTimeout) {
-    return new DigestAuthHandlerImpl(authProvider, nonceExpireTimeout);
+  static DigestAuthHandler create(Vertx vertx, HtdigestAuth authProvider, long nonceExpireTimeout) {
+    return new DigestAuthHandlerImpl(vertx, authProvider, nonceExpireTimeout);
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
@@ -19,7 +19,11 @@ package io.vertx.ext.web.handler.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Shareable;
+import io.vertx.ext.auth.VertxContextPRNG;
 import io.vertx.ext.auth.htdigest.HtdigestAuth;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
@@ -27,9 +31,6 @@ import io.vertx.ext.web.handler.DigestAuthHandler;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,13 +39,25 @@ import java.util.regex.Pattern;
  */
 public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements DigestAuthHandler {
 
-  private static class Nonce {
-    private final long createdAt;
-    private int count;
+  /**
+   * Default name for map used to store nonces
+   */
+  private static final String DEFAULT_NONCE_MAP_NAME = "htdigest.nonces";
 
-    Nonce() {
-      createdAt = System.currentTimeMillis();
-      count = 0;
+  /**
+   * Shareable objects should be immutable.
+   */
+  private static class Nonce implements Shareable {
+    private final long createdAt;
+    private final int count;
+
+    Nonce(int count) {
+      this(System.currentTimeMillis(), count);
+    }
+
+    Nonce(long createdAt, int count) {
+      this.createdAt = createdAt;
+      this.count = count;
     }
   }
 
@@ -61,15 +74,17 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
     }
   }
 
-  private final SecureRandom random = new SecureRandom();
-  private final Map<String, Nonce> nonces = new HashMap<>();
+  private final VertxContextPRNG random;
+  private final LocalMap<String, Nonce> nonces;
 
   private final long nonceExpireTimeout;
 
   private long lastExpireRun;
 
-  public DigestAuthHandlerImpl(HtdigestAuth authProvider, long nonceExpireTimeout) {
+  public DigestAuthHandlerImpl(Vertx vertx, HtdigestAuth authProvider, long nonceExpireTimeout) {
     super(authProvider, authProvider.realm(), Type.DIGEST);
+    random = VertxContextPRNG.current(vertx);
+    nonces = vertx.sharedData().getLocalMap(DEFAULT_NONCE_MAP_NAME);
     this.nonceExpireTimeout = nonceExpireTimeout;
   }
 
@@ -115,7 +130,7 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
           return;
         }
 
-        // check for nonce counter (prevent replay attack
+        // check for nonce counter (prevent replay attack)
         if (authInfo.containsKey("qop")) {
           int nc = Integer.parseInt(authInfo.getString("nc"));
           final Nonce n = nonces.get(nonce);
@@ -123,7 +138,8 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
             handler.handle(Future.failedFuture(UNAUTHORIZED));
             return;
           }
-          n.count = nc;
+          // update the nounce count
+          nonces.put(nonce, new Nonce(n.createdAt, nc));
         }
       } catch (RuntimeException e) {
         handler.handle(Future.failedFuture(e));
@@ -153,7 +169,7 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
     // generate nonce
     String nonce = md5(bytes);
     // save it
-    nonces.put(nonce, new Nonce());
+    nonces.put(nonce, new Nonce(0));
 
     // generate opaque
     String opaque = null;

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/DigestAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/DigestAuthHandlerTest.java
@@ -56,7 +56,7 @@ public class DigestAuthHandlerTest extends WebTestBase {
     };
 
     HtdigestAuth authProvider = HtdigestAuth.create(vertx);
-    router.route("/dir/*").handler(DigestAuthHandler.create(authProvider));
+    router.route("/dir/*").handler(DigestAuthHandler.create(vertx, authProvider));
 
     router.route("/dir/index.html").handler(handler);
 


### PR DESCRIPTION
Stores the nonces in a local shared data map. This allows scaling over a single verticle.

Needs to go as 4.0 because it breaks the factory method.