### PR TITLE
digest auth: parse nonce count as hex

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
@@ -117,7 +117,7 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
 
         // check for nonce counter (prevent replay attack
         if (authInfo.containsKey("qop")) {
-          int nc = Integer.parseInt(authInfo.getString("nc"));
+          int nc = Integer.parseInt(authInfo.getString("nc"),16);
           final Nonce n = nonces.get(nonce);
           if (nc <= n.count) {
             handler.handle(Future.failedFuture(UNAUTHORIZED));


### PR DESCRIPTION
nonce count is an hex number so parse as such