### PR TITLE
pebble: add extension to resolve JsonArray and JsonObject

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-pebble/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
 	    <groupId>io.pebbletemplates</groupId>
 	    <artifactId>pebble</artifactId>
-	    <version>3.0.0</version>
+	    <version>3.0.9</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
@@ -39,7 +39,8 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   private final PebbleEngine pebbleEngine;
 
   public PebbleTemplateEngineImpl(Vertx vertx) {
-    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).cacheActive(false).build());
+    this(new PebbleEngine.Builder().loader(new PebbleVertxLoader(vertx)).extension(new PebbleVertxExtension())
+        .cacheActive(false).build());
   }
 
   public PebbleTemplateEngineImpl(PebbleEngine engine) {

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleVertxAttributeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleVertxAttributeResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.pebble.impl;
+
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.attributes.ResolvedAttribute;
+import com.mitchellbosecke.pebble.error.AttributeNotFoundException;
+import com.mitchellbosecke.pebble.node.ArgumentsNode;
+import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author Nicola Murino <nicola dot murino at gmail.com> 
+ */
+
+public class PebbleVertxAttributeResolver implements AttributeResolver {
+
+  @Override
+  public ResolvedAttribute resolve(Object instance, Object attributeNameValue, Object[] argumentValues,
+      ArgumentsNode args, EvaluationContextImpl context, String filename, int lineNumber) {
+
+    if (instance instanceof JsonObject) {
+      ResolvedAttribute resolvedAttribute = new ResolvedAttribute(null);
+
+      if (attributeNameValue != null && attributeNameValue instanceof String) {
+        JsonObject jsonObject = (JsonObject) instance;
+        resolvedAttribute = new ResolvedAttribute(jsonObject.getValue((String) attributeNameValue));
+      }
+      if (context.isStrictVariables() && resolvedAttribute.evaluatedValue == null) {
+        throw new AttributeNotFoundException(null,
+            String.format(
+                "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
+                attributeNameValue.toString(), instance.getClass().getName()),
+            attributeNameValue.toString(), lineNumber, filename);
+      }
+
+      return resolvedAttribute;
+    } else if (instance instanceof JsonArray) {
+      JsonArray jsonArray = (JsonArray) instance;
+      String attributeName = String.valueOf(attributeNameValue);
+      int index;
+      try {
+        index = Integer.parseInt(attributeName);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+      int length = jsonArray.size();
+
+      if (index < 0 || index >= length) {
+        if (context.isStrictVariables()) {
+          throw new AttributeNotFoundException(null,
+              "Index out of bounds while accessing JsonArray with strict variables on.", attributeName, lineNumber,
+              filename);
+        } else {
+          return new ResolvedAttribute(null);
+        }
+      }
+
+      return new ResolvedAttribute(jsonArray.getValue(index));
+    }
+
+    return null;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleVertxExtension.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleVertxExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. 
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.pebble.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.attributes.DefaultAttributeResolver;
+import com.mitchellbosecke.pebble.extension.AbstractExtension;
+
+/**
+ * @author Nicola Murino <nicola dot murino at gmail.com> 
+ */
+
+public class PebbleVertxExtension extends AbstractExtension {
+
+  @Override
+  public List<AttributeResolver> getAttributeResolver() {
+
+    List<AttributeResolver> attributeResolvers = new ArrayList<>();
+    attributeResolvers.add(new PebbleVertxAttributeResolver());
+    attributeResolvers.add(new DefaultAttributeResolver());
+    return attributeResolvers;
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template3.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/filesystemtemplates/test-pebble-template3.peb
@@ -1,2 +1,2 @@
 Hello {{foo}} and {{bar}}
-Request path is {{context.getString("path")}}
+Request path is {{context.path}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/somedir/test-pebble-template2.beb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/somedir/test-pebble-template2.beb
@@ -1,2 +1,2 @@
 Cheerio {{foo}} and {{bar}}
-Request path is {{context.getString("path")}}
+Request path is {{context.path}}

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/somedir/test-pebble-template2.peb
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/resources/somedir/test-pebble-template2.peb
@@ -1,2 +1,2 @@
 Hello {{foo}} and {{ bar }}
-Request path is {{context.getString("path")}}
+Request path is {{context.path}}


### PR DESCRIPTION
This way JsonObject and JsonArray can be accessed used dot notation in templates.

This is an incompatible change, see the changes for the test cases. To make it backward compatible we need to change the order in `getAttributeResolver`, this could result in  small performance penality.

I updated pebble to 3.0.9 too.
