### PR TITLE
CSRFHandler: thrown a custom exception

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
@@ -20,6 +20,8 @@ import io.vertx.ext.web.handler.impl.CSRFHandlerImpl;
 @VertxGen
 public interface CSRFHandler extends Handler<RoutingContext> {
 
+  String ERROR_MESSAGE = "Invalid or missing csrf token";
+
   String DEFAULT_COOKIE_NAME = "XSRF-TOKEN";
 
   String DEFAULT_COOKIE_PATH = "/";

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
@@ -143,7 +143,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
         .setStatusCode(statusCode)
         .end(responseBody);
     } else {
-      ctx.fail(statusCode);
+      ctx.fail(new HttpStatusException(statusCode, ERROR_MESSAGE));
     }
   }
 


### PR DESCRIPTION
this way csrf errors can be handled specifically in 403 error handlers