### PR TITLE
Header name from Vert.x replaced with hard coded Content-Type header …

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -3,6 +3,7 @@ package io.vertx.ext.web.api.validation.impl;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.RequestParameter;
@@ -64,7 +65,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
         customValidator.validate(routingContext);
       }
 
-      String contentType = routingContext.request().getHeader("Content-Type");
+      String contentType = routingContext.request().getHeader(HttpHeaders.CONTENT_TYPE);
       if (contentType != null && contentType.length() != 0) {
         boolean isMultipart = contentType.contains("multipart/form-data");
 


### PR DESCRIPTION
…name for correcting match error of different cases.

According to  RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers" and RFC 7230: Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive. getHeader should get specified header case insensitively. As I can see from debug VertxHttpHeaders.java is used for get that is not case insensitive. I guess get method inside CaseInsensitiveHeaders.java should be used.