### PR TITLE
Allows to use returning Future function as DataFetcher

### DIFF
--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherCallback.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherCallback.java
@@ -1,0 +1,47 @@
+package io.vertx.ext.web.handler.graphql;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.vertx.core.Future;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+/**
+ * A {@link DataFetcher} that works well with Vert.x callback-based APIs.
+ *
+ * @author Thomas Segismont
+ */
+class VertxDataFetcherCallback<T> implements DataFetcher<CompletionStage<T>> {
+
+  private final BiConsumer<DataFetchingEnvironment, Future<T>> dataFetcher;
+
+  /**
+   * Create a new data fetcher.
+   * The provided function will be invoked with the following arguments:
+   * <ul>
+   * <li>the {@link DataFetchingEnvironment}</li>
+   * <li>a future that the implementor must complete after the data objects are fetched</li>
+   * </ul>
+   */
+  public VertxDataFetcherCallback(BiConsumer<DataFetchingEnvironment, Future<T>> dataFetcher) {
+    this.dataFetcher = dataFetcher;
+  }
+
+  @Override
+  public CompletionStage<T> get(DataFetchingEnvironment environment) throws Exception {
+    CompletableFuture<T> cf = new CompletableFuture<>();
+    Future<T> future = Future.future();
+    future.setHandler(ar -> {
+      if (ar.succeeded()) {
+        cf.complete(ar.result());
+      } else {
+        cf.completeExceptionally(ar.cause());
+      }
+    });
+    dataFetcher.accept(environment, future);
+    return cf;
+  }
+
+}

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherReturning.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherReturning.java
@@ -1,0 +1,46 @@
+package io.vertx.ext.web.handler.graphql;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.vertx.core.Future;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+/**
+ * A {@link DataFetcher} that works well with Vert.x Future API.
+ *
+ * @author Rogelio Orts
+ */
+class VertxDataFetcherReturning<T> implements DataFetcher<CompletionStage<T>> {
+
+  private final Function<DataFetchingEnvironment, Future<T>> dataFetcher;
+
+  /**
+   * Create a new data fetcher.
+   * The provided function will be invoked with the following arguments:
+   * <ul>
+   * <li>the {@link DataFetchingEnvironment}</li>
+   * </ul>
+   * The provided function will return a Future.
+   */
+  public VertxDataFetcherReturning(Function<DataFetchingEnvironment, Future<T>> dataFetcher) {
+    this.dataFetcher = dataFetcher;
+  }
+
+  @Override
+  public CompletionStage<T> get(DataFetchingEnvironment environment) throws Exception {
+    CompletableFuture<T> cf = new CompletableFuture<>();
+    Future<T> future = dataFetcher.apply(environment);
+    future.setHandler(ar -> {
+      if (ar.succeeded()) {
+        cf.complete(ar.result());
+      } else {
+        cf.completeExceptionally(ar.cause());
+      }
+    });
+    return cf;
+  }
+
+}

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherCallbackTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherCallbackTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.graphql;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import org.junit.Test;
+
+import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
+import static io.vertx.core.http.HttpMethod.GET;
+
+/**
+ * @author Thomas Segismont
+ */
+public class VertxDataFetcherCallbackTest extends GraphQLTestBase {
+
+  @Override
+  protected GraphQL graphQL() {
+    String schema = vertx.fileSystem().readFileBlocking("links.graphqls").toString();
+
+    SchemaParser schemaParser = new SchemaParser();
+    TypeDefinitionRegistry typeDefinitionRegistry = schemaParser.parse(schema);
+
+    RuntimeWiring runtimeWiring = newRuntimeWiring()
+      .type("Query", builder -> {
+        VertxDataFetcherCallback<Object> dataFetcher = new VertxDataFetcherCallback<>((env, fut) -> {
+          fut.complete(getAllLinks(env));
+        });
+        return builder.dataFetcher("allLinks", dataFetcher);
+      })
+      .build();
+
+    SchemaGenerator schemaGenerator = new SchemaGenerator();
+    GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeDefinitionRegistry, runtimeWiring);
+
+    return GraphQL.newGraphQL(graphQLSchema)
+      .build();
+  }
+
+  @Test
+  public void testSimpleGet() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setGraphQLQuery("query { allLinks { url } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkUrls(testData.urls(), body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimplePost() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setGraphQLQuery("query { allLinks { url } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkUrls(testData.urls(), body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+}

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherReturningTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/VertxDataFetcherReturningTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.graphql;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.vertx.core.Future;
+import org.junit.Test;
+
+import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
+import static io.vertx.core.http.HttpMethod.GET;
+
+/**
+ * @author Rogelio Orts
+ */
+public class VertxDataFetcherReturningTest extends GraphQLTestBase {
+
+  @Override
+  protected GraphQL graphQL() {
+    String schema = vertx.fileSystem().readFileBlocking("links.graphqls").toString();
+
+    SchemaParser schemaParser = new SchemaParser();
+    TypeDefinitionRegistry typeDefinitionRegistry = schemaParser.parse(schema);
+
+    RuntimeWiring runtimeWiring = newRuntimeWiring()
+      .type("Query", builder -> {
+        VertxDataFetcherReturning<Object> dataFetcher = new VertxDataFetcherReturning<>((env) -> {
+          Future<Object> fut = Future.future();
+          fut.complete(getAllLinks(env));
+          return fut;
+        });
+        return builder.dataFetcher("allLinks", dataFetcher);
+      })
+      .build();
+
+    SchemaGenerator schemaGenerator = new SchemaGenerator();
+    GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeDefinitionRegistry, runtimeWiring);
+
+    return GraphQL.newGraphQL(graphQLSchema)
+      .build();
+  }
+
+  @Test
+  public void testSimpleGet() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setGraphQLQuery("query { allLinks { url } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkUrls(testData.urls(), body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimplePost() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setGraphQLQuery("query { allLinks { url } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkUrls(testData.urls(), body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+}


### PR DESCRIPTION
With VertxDataFetcher it is possible to use Future as callback. This PR extends VertxDataFetcher to allow using Future as the returning value of data fetcher.

Thanks to the delegation pattern, VertxDataFetcher can be used for both programming styles (using callbacks and returning futures). No changes has to be made by those who are now using VertxDataFetcher with callback.