### PR TITLE
Correct status code when route matching fails

### DIFF
--- a/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
+++ b/vertx-web-api-contract/src/test/java/io/vertx/ext/web/api/contract/openapi3/OpenAPI3RouterFactoryTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.api.contract.openapi3;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.swagger.v3.oas.models.Operation;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -797,7 +798,7 @@ public class OpenAPI3RouterFactoryTest extends ApiWebTestBase {
     MultiMap form = MultiMap.caseInsensitiveMultiMap();
     form.add("name", "francesco");
     testRequestWithForm(HttpMethod.POST, "/consumesTest", FormType.FORM_URLENCODED, form, 200, "OK");
-    testRequestWithForm(HttpMethod.POST, "/consumesTest", FormType.MULTIPART, form, 404, "Not Found");
+    testRequestWithForm(HttpMethod.POST, "/consumesTest", FormType.MULTIPART, form, 415, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.reasonPhrase());
   }
 
   @Test

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -631,13 +631,17 @@ user understands, if you're only interested in the user prefered locale then the
 {@link io.vertx.ext.web.RoutingContext#preferredLocale} will return the 1st element of the list or `null` if no
 locale was provided by the user.
 
-== Default 404 Handling
+== Route match failures
 
-If no routes match for any particular request, Vert.x-Web will signal a 404 error.
+If no routes match for any particular request, Vert.x-Web will signal an error depending on match failure:
 
+* 404 If no route matches the path
+* 405 If a route matches the path but don't match the HTTP Method
+* 406 If a route matches the path and the method but It can't provide a response with a content type matching `Accept` header
+* 415 If a route matches the path and the method but It can't accept the `Content-type`
+* 400 If a route matches the path and the method but It can't accept an empty body
 
-A default 404 error handler is provided by Router. Anyway you can provide your own 404 error handler with
-{@link io.vertx.ext.web.Router#errorHandler}
+You can manually manage those failures using {@link io.vertx.ext.web.Router#errorHandler}
 
 == Error handling
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -135,19 +135,18 @@ public class RoutingContextImpl extends RoutingContextImplBase {
       // Send back FAILURE
       unhandledFailure(statusCode, failure, router);
     } else {
-      Handler<RoutingContext> handler = router.getErrorHandlerByStatusCode(404);
+      Handler<RoutingContext> handler = router.getErrorHandlerByStatusCode(this.matchFailure);
+      this.statusCode = this.matchFailure;
       if (handler == null) { // Default 404 handling
-        // Send back default 404
-        this.response()
-          .setStatusMessage("Not Found")
-          .setStatusCode(404);
-        if (this.request().method() == HttpMethod.HEAD) {
-          // HEAD responses don't have a body
-          this.response().end();
-        } else {
+        // Send back empty default response with status code
+        this.response().setStatusCode(matchFailure);
+        if (this.request().method() != HttpMethod.HEAD && matchFailure == 404) {
+          // If it's a 404 let's send a body too
           this.response()
             .putHeader(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8")
             .end("<html><body><h1>Resource not found</h1></body></html>");
+        } else {
+          this.response().end();
         }
       } else
         handler.handle(this);

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -16,6 +16,8 @@
 
 package io.vertx.ext.web;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -102,7 +104,7 @@ public class RouterTest extends WebTestBase {
     }
     for (HttpMethod meth : METHODS) {
       if (meth != method) {
-        testRequest(meth, path, 404, "Not Found");
+        testRequest(meth, path, HttpResponseStatus.METHOD_NOT_ALLOWED);
       }
     }
   }
@@ -155,7 +157,7 @@ public class RouterTest extends WebTestBase {
     String path = "/blah";
     router.route().path(path).method(HttpMethod.GET).handler(rc -> rc.response().setStatusCode(200).setStatusMessage(rc.request().path()).end());
     testPathExact(HttpMethod.GET, path);
-    testRequest(HttpMethod.POST, path, 404, "Not Found");
+    testRequest(HttpMethod.POST, path, HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -163,7 +165,7 @@ public class RouterTest extends WebTestBase {
     String path = "/blah";
     router.route().path(path + "*").method(HttpMethod.GET).handler(rc -> rc.response().setStatusCode(200).setStatusMessage(rc.request().path()).end());
     testPathBegin(HttpMethod.GET, path);
-    testRequest(HttpMethod.POST, path, 404, "Not Found");
+    testRequest(HttpMethod.POST, path, HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -172,7 +174,7 @@ public class RouterTest extends WebTestBase {
     router.route().path(path).method(HttpMethod.GET).method(HttpMethod.POST).handler(rc -> rc.response().setStatusCode(200).setStatusMessage(rc.request().path()).end());
     testPathExact(HttpMethod.GET, path);
     testPathExact(HttpMethod.POST, path);
-    testRequest(HttpMethod.PUT, path, 404, "Not Found");
+    testRequest(HttpMethod.PUT, path, HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -181,7 +183,7 @@ public class RouterTest extends WebTestBase {
     router.route().path(path + "*").method(HttpMethod.GET).method(HttpMethod.POST).handler(rc -> rc.response().setStatusCode(200).setStatusMessage(rc.request().path()).end());
     testPathBegin(HttpMethod.GET, path);
     testPathBegin(HttpMethod.POST, path);
-    testRequest(HttpMethod.PUT, path, 404, "Not Found");
+    testRequest(HttpMethod.PUT, path, HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   private void testPathBegin(String path) throws Exception {
@@ -254,7 +256,7 @@ public class RouterTest extends WebTestBase {
     testNoPath(meth);
     for (HttpMethod m : METHODS) {
       if (m != meth) {
-        testRequest(m, "/whatever", 404, "Not Found");
+        testRequest(m, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
       }
     }
   }
@@ -660,7 +662,7 @@ public class RouterTest extends WebTestBase {
   public void testPattern1WithMethod() throws Exception {
     router.route(HttpMethod.GET, "/:abc").handler(rc -> rc.response().setStatusMessage(rc.request().params().get("abc")).end());
     testPattern("/tim", "tim");
-    testRequest(HttpMethod.POST, "/tim", 404, "Not Found");
+    testRequest(HttpMethod.POST, "/tim", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -847,7 +849,7 @@ public class RouterTest extends WebTestBase {
       rc.response().setStatusMessage(params.get("param0") + params.get("param1")).end();
     });
     testPattern("/dog/cat", "dogcat");
-    testRequest(HttpMethod.POST, "/dog/cat", 404, "Not Found");
+    testRequest(HttpMethod.POST, "/dog/cat", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -888,8 +890,8 @@ public class RouterTest extends WebTestBase {
   public void testConsumes() throws Exception {
     router.route().consumes("text/html").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -899,15 +901,15 @@ public class RouterTest extends WebTestBase {
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo;itWorks", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=ya", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 415, "Unsupported Media Type");
   }
 
   @Test
   public void testConsumesWithParameter() throws Exception {
     router.route().consumes("text/html;boo=ya").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=ya", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -915,22 +917,22 @@ public class RouterTest extends WebTestBase {
     router.route().consumes("text/html;boo=\"yeah,right\"").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right\";itWorks=4real", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right\"", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right;itWorks=4real\"", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right;itWorks=4real\"", 415, "Unsupported Media Type");
     // this might look wrong but since there is only 1 entry per content-type, the comma has no semantic meaning
     // therefore it is ignored
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=yeah,right", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 415, "Unsupported Media Type");
   }
 
   @Test
   public void testConsumesWithQuotedParameterWithQuotes() throws Exception {
     router.route().consumes("text/html;boo=\"yeah\\\"right\"").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah\\\"right\"", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right\"", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=yeah,right", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=\"yeah,right\"", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=yeah,right", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -946,10 +948,10 @@ public class RouterTest extends WebTestBase {
     router.route().consumes("text/html").consumes("application/json").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "application/blah", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "application/blah", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -959,9 +961,9 @@ public class RouterTest extends WebTestBase {
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;works", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo;works", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;boo=done;it=works", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;yes=no;right", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/book;boo", 404, "Not Found");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/book;works=aright", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html;yes=no;right", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/book;boo", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/book;works=aright", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -971,7 +973,7 @@ public class RouterTest extends WebTestBase {
     testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -979,7 +981,7 @@ public class RouterTest extends WebTestBase {
     router.route().consumes("text/*").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/html", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -987,7 +989,7 @@ public class RouterTest extends WebTestBase {
     router.route().consumes("*/json").handler(rc -> rc.response().end());
     testRequestWithContentType(HttpMethod.GET, "/foo", "text/json", 200, "OK");
     testRequestWithContentType(HttpMethod.GET, "/foo", "application/json", 200, "OK");
-    testRequestWithContentType(HttpMethod.GET, "/foo", "application/html", 404, "Not Found");
+    testRequestWithContentType(HttpMethod.GET, "/foo", "application/html", 415, "Unsupported Media Type");
   }
 
   @Test
@@ -1017,15 +1019,15 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testConsumesNoContentType() throws Exception {
     router.route().consumes("text/html").handler(rc -> rc.response().end());
-    testRequest(HttpMethod.GET, "/foo", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/foo", HttpResponseStatus.BAD_REQUEST);
   }
 
   @Test
   public void testProduces() throws Exception {
     router.route().produces("text/html").handler(rc -> rc.response().end());
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 200, "OK");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 406, "Not Acceptable");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 406, "Not Acceptable");
     testRequest(HttpMethod.GET, "/foo", 200, "OK");
   }
 
@@ -1035,7 +1037,7 @@ public class RouterTest extends WebTestBase {
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo;itWorks", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo=ya", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo", 200, "OK");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 406, "Not Acceptable");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "*/*", 200, "OK");
   }
 
@@ -1043,8 +1045,8 @@ public class RouterTest extends WebTestBase {
   public void testProducesWithParameter() throws Exception {
     router.route().produces("text/html;boo=ya").handler(rc -> rc.response().end());
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo=ya", 200, "OK");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo", 404, "Not Found");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html;boo", 406, "Not Acceptable");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 406, "Not Acceptable");
   }
 
   @Test
@@ -1052,10 +1054,10 @@ public class RouterTest extends WebTestBase {
     router.route().produces("text/html").produces("application/json").handler(rc -> rc.response().end());
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/html", 200, "OK");
     testRequestWithAccepts(HttpMethod.GET, "/foo", "application/json", 200, "OK");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 404, "Not Found");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 404, "Not Found");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "application/blah", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 406, "Not Acceptable");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 406, "Not Acceptable");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text/json", 406, "Not Acceptable");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "application/blah", 406, "Not Acceptable");
   }
 
   @Test
@@ -1076,7 +1078,7 @@ public class RouterTest extends WebTestBase {
       rc.response().end();
     });
     testRequestWithAccepts(HttpMethod.GET, "/foo", "json", 200, "application/json");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "text", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "text", 406, "Not Acceptable");
   }
 
   @Test
@@ -1086,7 +1088,7 @@ public class RouterTest extends WebTestBase {
       rc.response().end();
     });
     testRequestWithAccepts(HttpMethod.GET, "/foo", "text/*", 200, "text/html");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "application/*", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "application/*", 406, "Not Acceptable");
   }
 
   @Test
@@ -1123,7 +1125,7 @@ public class RouterTest extends WebTestBase {
       rc.response().end();
     });
     testRequestWithAccepts(HttpMethod.GET, "/foo", "*/json", 200, "application/json");
-    testRequestWithAccepts(HttpMethod.GET, "/foo", "*/html", 404, "Not Found");
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "*/html", 406, "Not Acceptable");
   }
 
   @Test
@@ -1444,11 +1446,11 @@ public class RouterTest extends WebTestBase {
   public void testGet() throws Exception {
     router.get().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.GET, "/whatever", 200, "foo");
-    testRequest(HttpMethod.POST, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.POST, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1468,11 +1470,11 @@ public class RouterTest extends WebTestBase {
     router.get("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.GET, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.GET, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1480,22 +1482,22 @@ public class RouterTest extends WebTestBase {
     router.getWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.GET, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.GET, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
   public void testPost() throws Exception {
     router.post().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.POST, "/whatever", 200, "foo");
-    testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1515,11 +1517,11 @@ public class RouterTest extends WebTestBase {
     router.post("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.POST, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.POST, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1527,22 +1529,22 @@ public class RouterTest extends WebTestBase {
     router.postWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.POST, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.POST, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
   public void testPut() throws Exception {
     router.put().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.PUT, "/whatever", 200, "foo");
-    testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1562,11 +1564,11 @@ public class RouterTest extends WebTestBase {
     router.put("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.PUT, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.PUT, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1574,22 +1576,22 @@ public class RouterTest extends WebTestBase {
     router.putWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.PUT, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.PUT, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
   public void testDelete() throws Exception {
     router.delete().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.DELETE, "/whatever", 200, "foo");
-    testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1609,11 +1611,11 @@ public class RouterTest extends WebTestBase {
     router.delete("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.DELETE, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.DELETE, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1621,22 +1623,22 @@ public class RouterTest extends WebTestBase {
     router.deleteWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.DELETE, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.DELETE, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
   public void testOptions() throws Exception {
     router.options().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.OPTIONS, "/whatever", 200, "foo");
-    testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1656,11 +1658,11 @@ public class RouterTest extends WebTestBase {
     router.options("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.OPTIONS, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1668,22 +1670,22 @@ public class RouterTest extends WebTestBase {
     router.optionsWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.OPTIONS, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.HEAD, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.HEAD, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
   public void testHead() throws Exception {
     router.head().handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.HEAD, "/whatever", 200, "foo");
-    testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1703,11 +1705,11 @@ public class RouterTest extends WebTestBase {
     router.head("/somepath/*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.HEAD, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.HEAD, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -1715,11 +1717,11 @@ public class RouterTest extends WebTestBase {
     router.headWithRegex("\\/somepath\\/.*").handler(rc -> rc.response().setStatusMessage("foo").end());
     testRequest(HttpMethod.HEAD, "/somepath/whatever", 200, "foo");
     testRequest(HttpMethod.HEAD, "/otherpath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.PUT, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", 404, "Not Found");
-    testRequest(HttpMethod.DELETE, "/somepath/whatever", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.POST, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.PUT, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.OPTIONS, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
+    testRequest(HttpMethod.DELETE, "/somepath/whatever", HttpResponseStatus.METHOD_NOT_ALLOWED);
   }
 
   @Test
@@ -2450,5 +2452,30 @@ public class RouterTest extends WebTestBase {
     });
     req.end();
     latch.await();
+  }
+
+  @Test
+  public void testMethodNotAllowedCustomErrorHandler() throws Exception {
+    router.get("/path").handler(rc -> rc.response().end());
+    router.post("/path").handler(rc -> rc.response().end());
+    router.errorHandler(405, context -> context.response().setStatusCode(context.statusCode()).setStatusMessage("Dumb").end());
+
+    testRequest(HttpMethod.PUT, "/path", 405, "Dumb");
+  }
+
+  @Test
+  public void testNotAcceptableCustomErrorHandler() throws Exception {
+    router.route().produces("text/html").handler(rc -> rc.response().end());
+    router.errorHandler(406, context -> context.response().setStatusCode(context.statusCode()).setStatusMessage("Dumb").end());
+
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 406, "Dumb");
+  }
+
+  @Test
+  public void testUnsupportedMediaTypeCustomErrorHandler() throws Exception {
+    router.route().consumes("text/html").handler(rc -> rc.response().end());
+    router.errorHandler(415, context -> context.response().setStatusCode(context.statusCode()).setStatusMessage("Dumb").end());
+
+    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 415, "Dumb");
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -85,6 +86,10 @@ public class WebTestBase extends VertxTestBase {
       awaitLatch(latch);
     }
     super.tearDown();
+  }
+
+  protected void testRequest(HttpMethod method, String path, HttpResponseStatus statusCode) throws Exception {
+    testRequest(method, path, null, statusCode.code(), statusCode.reasonPhrase(), null);
   }
 
   protected void testRequest(HttpMethod method, String path, int statusCode, String statusMessage) throws Exception {


### PR DESCRIPTION
Manage route match failures using appropriates status code 400, 404, 405, 406 & 415

Fixes #456, #1301, #1295

Replaces #458 & #1298, Partially replaces #606

@pmlopes We want to target for 3.8 or 4?

Signed-off-by: slinkydeveloper <francescoguard@gmail.com>