### PR TITLE
Fix for Route#matches status codes

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -126,7 +126,7 @@ public abstract class RoutingContextImplBase implements RoutingContext {
             handleInHandlerRuntimeFailure(route, failed, t);
           }
           return true;
-        } else {
+        } else if (matchResult != 404) {
           this.matchFailure = matchResult;
         }
       } catch (Throwable e) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2480,4 +2480,29 @@ public class RouterTest extends WebTestBase {
 
     testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 415, "Dumb");
   }
+
+  @Test
+  public void testMethodNotAllowedStatusCode() throws Exception {
+    router.get("/path").handler(rc -> rc.response().end());
+    router.post("/path").handler(rc -> rc.response().end());
+    router.put("/hello").handler(rc -> rc.response().end());
+
+    testRequest(HttpMethod.PUT, "/path", HttpResponseStatus.METHOD_NOT_ALLOWED);
+  }
+
+  @Test
+  public void testNotAcceptableStatusCode() throws Exception {
+    router.route().produces("text/html").handler(rc -> rc.response().end());
+    router.route("/hello").produces("something/html").handler(rc -> rc.response().end());
+
+    testRequestWithAccepts(HttpMethod.GET, "/foo", "something/html", 406, HttpResponseStatus.NOT_ACCEPTABLE.reasonPhrase());
+  }
+
+  @Test
+  public void testUnsupportedMediaTypeStatusCode() throws Exception {
+    router.route().consumes("text/html").handler(rc -> rc.response().end());
+    router.get("/hello").consumes("something/html").handler(rc -> rc.response().end());
+
+    testRequestWithContentType(HttpMethod.GET, "/foo", "something/html", 415, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.reasonPhrase());
+  }
 }


### PR DESCRIPTION
In PR #1305 I don't correctly handle various match failure status codes with multiple routes. This should fix it