### PR TITLE
Fix/1059

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ChainAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ChainAuthHandlerImpl.java
@@ -14,8 +14,6 @@ import java.util.Set;
 
 public class ChainAuthHandlerImpl extends AuthHandlerImpl implements ChainAuthHandler {
 
-  private String lastFailedAuthenticateHeader = null;
-
   private final List<AuthHandler> handlers = new ArrayList<>();
 
   public ChainAuthHandlerImpl() {
@@ -81,7 +79,6 @@ public class ChainAuthHandlerImpl extends AuthHandlerImpl implements ChainAuthHa
             case 401:
             case 403:
               // try again with next provider since we know what kind of error it is
-              lastFailedAuthenticateHeader = getLastFailedAuthenticateHeader(authHandler, ctx);
               iterate(idx + 1, ctx, exception, handler);
               return;
           }
@@ -98,17 +95,13 @@ public class ChainAuthHandlerImpl extends AuthHandlerImpl implements ChainAuthHa
     });
   }
 
-  private String getLastFailedAuthenticateHeader(AuthHandler authHandler, RoutingContext context) {
-    if (authHandler instanceof AuthHandlerImpl) {
-      return ((AuthHandlerImpl) authHandler).authenticateHeader(context);
-    }
-
-    return null;
-  }
-
   @Override
   protected String authenticateHeader(RoutingContext ctx) {
-    return lastFailedAuthenticateHeader;
+    AuthHandler authHandler = handlers.get(handlers.size()-1);
+    if (authHandler instanceof AuthHandlerImpl) {
+      return ((AuthHandlerImpl) authHandler).authenticateHeader(ctx);
+    }
+    return null;
   }
 }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerTest.java
@@ -26,8 +26,8 @@ public class ChainAuthHandlerTest extends WebTestBase {
 
     chain
       .append(JWTAuthHandler.create(null))
-      .append(BasicAuthHandler.create(authProvider))
-      .append(RedirectAuthHandler.create(authProvider));
+      .append(RedirectAuthHandler.create(authProvider))
+      .append(BasicAuthHandler.create(authProvider));
 
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
     router.route().handler(chain);
@@ -50,6 +50,6 @@ public class ChainAuthHandlerTest extends WebTestBase {
   @Test
   public void testWithBadAuthorization() throws Exception {
     // there is an authorization header, but the token is invalid it should be processed by the basic auth
-    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Basic dGltOmRlbGljaW91czpzYXVzYWdlcX=="),401, "Unauthorized", "Unauthorized");
+    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Basic dGltOmRlbGljaW91czpzYXVzYWdlcX=="), resp -> assertEquals("Basic realm=\"vertx-web\"", resp.getHeader("WWWW-Authenticate")),401, "Unauthorized", "Unauthorized");
   }
 }


### PR DESCRIPTION
# The fix
This PR is a fix for #1059. 

Given the specification, it changes `ChainAuthHandlerImpl` to correctly override `AuthHandlerImpl.authenticateHeader()`. Basically, it calls the last handler's `authenticateHeader()` in the chain when that handler implements the abstract class `AuthHandlerImpl`.

# Context
This method is called to create a `WWW-Authenticate` response header when the request is unauthorized. If the last authentication handler in the chain is a `BasicAuthHandler` implementation, this header should have the value: `Basic realm="vertx-web"`.

A test was added to verify this behaviour. 