### PR TITLE
Sub router and mount fix for parameterized paths

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -195,6 +195,12 @@ public interface Route {
   String getPath();
 
   /**
+   * Returns true of the path is a regular expression, this includes expression paths.
+   * @return true if backed by a pattern.
+   */
+  boolean isRegexPath();
+
+  /**
    * @return the http methods accepted by this route
    */
   Set<HttpMethod> methods();

--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -127,6 +127,22 @@ public interface Route {
   Route blockingHandler(Handler<RoutingContext> requestHandler);
 
   /**
+   * Use a (sub) {@link Router} as a handler. There are several requirements to be fulfilled for this
+   * to be accepted.
+   *
+   * <ul>
+   *     <li>The route path must end with a wild card</li>
+   *     <li>Parameters are allowed but full regex patterns not</li>
+   *     <li>No other handler can be registered before or after this call (but they can on a new route object for the same path)</li>
+   *     <li>Only 1 router per path object</li>
+   * </ul>
+   * @param subRouter the router to add
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Route subRouter(Router subRouter);
+
+  /**
    * Specify a blocking request handler for the route.
    * This method works just like {@link #handler(Handler)} excepted that it will run the blocking handler on a worker thread
    * so that it won't block the event loop. Note that it's safe to call context.next() from the

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -379,6 +379,7 @@ public interface Router extends Handler<HttpServerRequest> {
    * @param errorHandler error handler. Note: You <b>must not</b> use {@link RoutingContext#next()} inside the provided handler
    * @return a reference to this, so the API can be used fluently
    */
+  @Fluent
   Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler);
 
   /**
@@ -395,4 +396,13 @@ public interface Router extends Handler<HttpServerRequest> {
    */
   void handleFailure(RoutingContext context);
 
+  /**
+   * When a Router routes are changed this handler is notified.
+   * This is useful for routes that depend on the state of the router.
+   *
+   * @param handler a notification handler that will receive this router as argument
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Router modifiedHandler(Handler<Router> handler);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Represents the context for the handling of a request in Vert.x-Web.
  * <p>
  * A new instance is created for each HTTP request that is received in the
- * {@link Router#handle(HttpServerRequest)} of the router.
+ * {@link Router#handle(Object)} of the router.
  * <p>
  * The same instance is passed to any matching request or failure handlers during the routing of the request or
  * failure.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
@@ -16,10 +16,10 @@
 
 package io.vertx.ext.web.handler.sockjs;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.sockjs.impl.SockJSHandlerImpl;
 
@@ -62,10 +62,9 @@ public interface SockJSHandler extends Handler<RoutingContext> {
    * is made from a client
    *
    * @param handler  the handler
-   * @return a reference to this, so the API can be used fluently
+   * @return a router to be mounted on an existing router
    */
-  @Fluent
-  SockJSHandler socketHandler(Handler<SockJSSocket> handler);
+  Router socketHandler(Handler<SockJSSocket> handler);
 
   /**
    * Bridge the SockJS handler to the Vert.x event bus. This basically installs a built-in SockJS socket handler
@@ -73,19 +72,23 @@ public interface SockJSHandler extends Handler<RoutingContext> {
    * Vert.x event bus to browsers
    *
    * @param bridgeOptions  options to configure the bridge with
-   * @return a reference to this, so the API can be used fluently
+   * @return a router to be mounted on an existing router
    */
-  @Fluent
-  SockJSHandler bridge(BridgeOptions bridgeOptions);
+  Router bridge(BridgeOptions bridgeOptions);
 
   /**
    * Like {@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(BridgeOptions)} but specifying a handler
    * that will receive bridge events.
    * @param bridgeOptions  options to configure the bridge with
    * @param bridgeEventHandler  handler to receive bridge events
-   * @return a reference to this, so the API can be used fluently
+   * @return a router to be mounted on an existing router
    */
-  @Fluent
-  SockJSHandler bridge(BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler);
+  Router bridge(BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler);
 
+  /**
+   * @deprecated mount the router as a sub-router instead. This method will not properly handle errors.
+   * @param routingContext the rounting context
+   */
+  @Deprecated
+  void handle(RoutingContext routingContext);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -83,6 +83,7 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
   }
 
   @Override
+  @Deprecated
   public void handle(RoutingContext context) {
     if (log.isTraceEnabled()) {
       log.trace("Got request in sockjs server: " + context.request().uri());
@@ -91,19 +92,17 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
   }
 
   @Override
-  public SockJSHandler bridge(BridgeOptions bridgeOptions) {
+  public Router bridge(BridgeOptions bridgeOptions) {
     return bridge(bridgeOptions, null);
   }
 
   @Override
-  public SockJSHandler bridge(BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
-    socketHandler(new EventBusBridgeImpl(vertx, bridgeOptions, bridgeEventHandler));
-    return this;
+  public Router bridge(BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
+    return socketHandler(new EventBusBridgeImpl(vertx, bridgeOptions, bridgeEventHandler));
   }
 
   @Override
-  public SockJSHandler socketHandler(Handler<SockJSSocket> sockHandler) {
-
+  public Router socketHandler(Handler<SockJSSocket> sockHandler) {
     router.route("/").useNormalisedPath(false).handler(rc -> {
       if (log.isTraceEnabled()) log.trace("Returning welcome response");
       rc.response().putHeader("Content-Type", "text/plain; charset=UTF-8").end("Welcome to SockJS!\n");
@@ -158,7 +157,7 @@ public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext>
       new RawWebSocketTransport(vertx, router, sockHandler);
     }
 
-    return this;
+    return router;
   }
 
   private Handler<RoutingContext> createChunkingTestHandler() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -167,20 +167,24 @@ public class RouteImpl implements Route {
 
     // The route path must end with a wild card
     if (exactPath) {
-      throw new IllegalArgumentException("Sub router cannot be mounted on an exact path.");
+      throw new IllegalStateException("Sub router cannot be mounted on an exact path.");
     }
     // Parameters are allowed but full regex patterns not
     if (path == null && pattern != null) {
-      throw new IllegalArgumentException("Sub router cannot be mounted on a regular expression path.");
+      throw new IllegalStateException("Sub router cannot be mounted on a regular expression path.");
     }
 
     // No other handler can be registered before or after this call (but they can on a new route object for the same path)
     if (contextHandlers.size() > 0 || failureHandlers.size() > 0) {
-      throw new IllegalArgumentException("Only one sub router per Route object is allowed.");
+      throw new IllegalStateException("Only one sub router per Route object is allowed.");
     }
 
     handler(subRouter::handleContext);
     failureHandler(subRouter::handleFailure);
+
+    // mark the route as exclusive from now on
+    exclusive = true;
+
     return this;
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -198,6 +198,11 @@ public class RouteImpl implements Route {
   }
 
   @Override
+  public boolean isRegexPath() {
+    return pattern != null;
+  }
+
+  @Override
   public Set<HttpMethod> methods() {
     return this.methods;
   }
@@ -272,11 +277,18 @@ public class RouteImpl implements Route {
 
       Matcher m = pattern.matcher(path);
       if (m.matches()) {
+        context.matchRest = -1;
+        context.matchNormalized = useNormalisedPath;
+
         if (m.groupCount() > 0) {
+          if (!exactPath) {
+            context.matchRest = m.start("rest");
+          }
+
           if (groups != null) {
             // Pattern - named params
             // decode the path as it could contain escaped chars.
-            for (int i = 0; i < groups.size(); i++) {
+            for (int i = 0; i < Math.min(groups.size(), m.groupCount()); i++) {
               final String k = groups.get(i);
               String undecodedValue;
               // We try to take value in three ways:
@@ -422,12 +434,13 @@ public class RouteImpl implements Route {
         exactPath = false;
         this.path = path.substring(0, path.length() - 1);
       }
+      pathEndsWithSlash = this.path.endsWith("/");
     }
-    pathEndsWithSlash = this.path.endsWith("/");
   }
 
   private void setRegex(String regex) {
     pattern = Pattern.compile(regex);
+    exactPath = true;
     Set<String> namedGroups = findNamedGroups(pattern.pattern());
     if (!namedGroups.isEmpty()) {
       namedGroupsInRegex.addAll(namedGroups);
@@ -455,8 +468,12 @@ public class RouteImpl implements Route {
     path = RE_OPERATORS_NO_STAR.matcher(path).replaceAll("\\\\$1");
     // allow usage of * at the end as per documentation
     if (path.charAt(path.length() - 1) == '*') {
-      path = path.substring(0, path.length() - 1) + ".*";
+      path = path.substring(0, path.length() - 1) + "(?<rest>.*)";
+      exactPath = false;
+    } else {
+      exactPath = true;
     }
+
     // We need to search for any :<token name> tokens in the String and replace them with named capture groups
     Matcher m = RE_TOKEN_SEARCH.matcher(path);
     StringBuffer sb = new StringBuffer();

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -266,8 +266,7 @@ public class RouterImpl implements Router {
     }
 
     route(mountPoint + "*")
-      .handler(subRouter::handleContext)
-      .failureHandler(subRouter::handleFailure);
+      .subRouter(subRouter);
 
     return this;
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -47,6 +47,9 @@ public abstract class RoutingContextImplBase implements RoutingContext {
   // When Route#matches executes, if it returns != 0 this flag is configured
   // to write the correct status code at the end of routing process
   protected int matchFailure;
+  // the current path matched string
+  protected int matchRest = -1;
+  protected boolean matchNormalized;
 
   protected RoutingContextImplBase(String mountPoint, HttpServerRequest request, Set<RouteImpl> routes) {
     this.mountPoint = mountPoint;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -42,8 +42,7 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   protected final RoutingContext inner;
   private final String mountPoint;
 
-  public RoutingContextWrapper(String mountPoint, HttpServerRequest request, Set<RouteImpl> iter,
-                               RoutingContext inner) {
+  public RoutingContextWrapper(String mountPoint, HttpServerRequest request, Set<RouteImpl> iter, RoutingContext inner) {
     super(mountPoint, request, iter);
     this.inner = inner;
     String parentMountPoint = inner.mountPoint();
@@ -127,7 +126,7 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
 
   @Override
   public void setSession(Session session) {
-   inner.setSession(session);
+    inner.setSession(session);
   }
 
   @Override
@@ -280,7 +279,9 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public MultiMap queryParams() { return inner.queryParams(); }
+  public MultiMap queryParams() {
+    return inner.queryParams();
+  }
 
   @Override
   public @Nullable List<String> queryParam(String query) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -502,4 +502,24 @@ public class SubRouterTest extends WebTestBase {
       .handler(ctx -> {})
       .subRouter(subRouter);
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSubRouterDuplicateVariable() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/:id").handler(null);
+
+    router.route("/v/:id*")
+      .subRouter(subRouter);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSubRouterDuplicateVariableLaterStage() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    router.route("/v/:id*")
+      .subRouter(subRouter);
+
+    subRouter.get("/:id").handler(null);
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -468,4 +468,38 @@ public class SubRouterTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/v/1/files/2/info", 200, "OK");
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSubRouterExclusive() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/files/:id/info").handler(ctx -> {
+      // version is extracted from the root router
+      assertEquals("1", ctx.pathParam("version"));
+      // version is extracted from this router
+      assertEquals("2", ctx.pathParam("id"));
+      ctx.response().end();
+    });
+
+    router.route("/v/:version/*")
+      .subRouter(subRouter)
+      .handler(ctx -> {});
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSubRouterExclusive2() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/files/:id/info").handler(ctx -> {
+      // version is extracted from the root router
+      assertEquals("1", ctx.pathParam("version"));
+      // version is extracted from this router
+      assertEquals("2", ctx.pathParam("id"));
+      ctx.response().end();
+    });
+
+    router.route("/v/:version/*")
+      .handler(ctx -> {})
+      .subRouter(subRouter);
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -371,8 +371,8 @@ public class SubRouterTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/subpath/foo/bar", 557, "Chipmunks");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testSubRoutePattern() throws Exception {
+  @Test
+  public void testSubRoutePattern() {
     Router subRouter = Router.router(vertx);
     router.mountSubRouter("/foo/:abc/bar", subRouter);
   }
@@ -450,5 +450,22 @@ public class SubRouterTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/v1/files/some-file-id/info", 200, "OK");
     testRequest(HttpMethod.GET, "/v1/files//info", 404, "Not Found");
+  }
+
+  @Test
+  public void testSimpleWithParams() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/files/:id/info").handler(ctx -> {
+      // version is extracted from the root router
+      assertEquals("1", ctx.pathParam("version"));
+      // version is extracted from this router
+      assertEquals("2", ctx.pathParam("id"));
+      ctx.response().end();
+    });
+
+    router.mountSubRouter("/v/:version", subRouter);
+
+    testRequest(HttpMethod.GET, "/v/1/files/2/info", 200, "OK");
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -168,10 +168,10 @@ public class SockJSHandlerTest extends WebTestBase {
     AtomicInteger receivedReplies = new AtomicInteger(0);
     WebSocket ws = setupRawWebsocketClient(serverPath);
     ws.handler(replyBuffer -> {
-              totalReplyBuffer.appendBuffer(replyBuffer);
-              receivedReplies.incrementAndGet();
+      totalReplyBuffer.appendBuffer(replyBuffer);
+      receivedReplies.incrementAndGet();
 
-            });
+    });
 
     ws.writeFrame(WebSocketFrame.binaryFrame(Buffer.buffer("hello"), true));
 
@@ -272,8 +272,8 @@ public class SockJSHandlerTest extends WebTestBase {
     Buffer expectedReplyBuffer = Buffer.buffer("a[\"").appendBuffer(largeReplyBuffer).appendBuffer(Buffer.buffer("\"]"));
     Buffer clientReplyBuffer = combineReplies(receivedMessages.subList(0, receivedMessages.size() - 1));
     assertEquals(String.format("Combined reply on client (length %s) should equal message from server (%s)",
-            clientReplyBuffer.length(), expectedReplyBuffer.length()),
-            expectedReplyBuffer, clientReplyBuffer);
+      clientReplyBuffer.length(), expectedReplyBuffer.length()),
+      expectedReplyBuffer, clientReplyBuffer);
 
     Buffer finalMessage = receivedMessages.get(receivedMessages.size() - 1);
     assertEquals("Final message should have been a close", SOCKJS_CLOSE_REPLY, finalMessage);
@@ -295,20 +295,19 @@ public class SockJSHandlerTest extends WebTestBase {
   }
 
   private void setupSockJsServer(String serverPath, BiConsumer<SockJSSocket, Buffer> serverBufferHandler) {
-    String path = serverPath + "/*";
-    router.route(path).handler(SockJSHandler.create(vertx)
-            .socketHandler(sock -> {
-              sock.handler(buffer -> serverBufferHandler.accept(sock, buffer));
-              sock.exceptionHandler(this::fail);
-            }));
+    String path = serverPath;
+    router.mountSubRouter(path, SockJSHandler.create(vertx)
+      .socketHandler(sock -> {
+        sock.handler(buffer -> serverBufferHandler.accept(sock, buffer));
+        sock.exceptionHandler(this::fail);
+      }));
   }
 
   /**
    * This sets up a handler on the websocket
    */
   private WebSocket setupSockJsClient(String serverPath, List<Buffer> receivedMessagesCollector)
-          throws InterruptedException
-  {
+    throws InterruptedException {
     String requestURI = serverPath + "/000/000/websocket";
 
     AtomicReference<WebSocket> openedWebSocketReference = new AtomicReference<>();
@@ -336,8 +335,7 @@ public class SockJSHandlerTest extends WebTestBase {
    * This does not set up a handler on the websocket
    */
   private WebSocket setupRawWebsocketClient(String serverPath)
-          throws InterruptedException
-  {
+    throws InterruptedException {
     String requestURI = serverPath + "/websocket";
 
     AtomicReference<WebSocket> openedWebSocketReference = new AtomicReference<>();
@@ -362,14 +360,14 @@ public class SockJSHandlerTest extends WebTestBase {
 
   @Test
   public void testCookiesRemoved() throws Exception {
-    router.route("/cookiesremoved/*").handler(SockJSHandler.create(vertx)
-          .socketHandler(sock -> {
-            MultiMap headers = sock.headers();
-            String cookieHeader = headers.get("cookie");
-            assertNotNull(cookieHeader);
-            assertEquals("JSESSIONID=wibble", cookieHeader);
-            testComplete();
-          }));
+    router.mountSubRouter("/cookiesremoved", SockJSHandler.create(vertx)
+      .socketHandler(sock -> {
+        MultiMap headers = sock.headers();
+        String cookieHeader = headers.get("cookie");
+        assertNotNull(cookieHeader);
+        assertEquals("JSESSIONID=wibble", cookieHeader);
+        testComplete();
+      }));
     MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("cookie", "JSESSIONID=wibble");
     headers.add("cookie", "flibble=floob");
@@ -387,7 +385,7 @@ public class SockJSHandlerTest extends WebTestBase {
 
   @Test
   public void testTimeoutCloseCode() {
-    router.route("/ws-timeout/*").handler(SockJSHandler
+    router.mountSubRouter("/ws-timeout", SockJSHandler
       .create(vertx)
       .bridge(new BridgeOptions().setPingTimeout(1))
     );
@@ -404,7 +402,7 @@ public class SockJSHandlerTest extends WebTestBase {
 
   @Test
   public void testInvalidMessageCode() {
-    router.route("/ws-timeout/*").handler(SockJSHandler
+    router.mountSubRouter("/ws-timeout", SockJSHandler
       .create(vertx)
       .bridge(new BridgeOptions().addInboundPermitted(new PermittedOptions().setAddress("SockJSHandlerTest.testInvalidMessageCode")))
     );

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
@@ -65,51 +65,74 @@ public class SockJSProtocolTest {
 
     // These applications are required by the SockJS protocol and QUnit tests
 
-    router.route("/echo/*").handler(SockJSHandler.create(vertx,
-      new SockJSHandlerOptions().setMaxBytesStreaming(4096)).socketHandler(sock -> sock.handler(sock::write)));
-    router.route("/close/*").handler(SockJSHandler.create(vertx,
-      new SockJSHandlerOptions().setMaxBytesStreaming(4096)).socketHandler(sock -> {
-        // Close with a small delay so the opening sockjs frame "o" is not aggregated in the same TCP frame
-        // than the SockJS close frame "c[3000,"Go away!"]"
-        vertx.setTimer(10, id -> sock.close(3000, "Go away!"));
-    }));
-    router.route("/disabled_websocket_echo/*").handler(SockJSHandler.create(vertx, new SockJSHandlerOptions()
-      .setMaxBytesStreaming(4096).addDisabledTransport("WEBSOCKET")).socketHandler(sock -> sock.handler(sock::write)));
-    router.route("/ticker/*").handler(SockJSHandler.create(vertx,
-      new SockJSHandlerOptions().setMaxBytesStreaming(4096)).socketHandler(sock -> {
-      long timerID = vertx.setPeriodic(1000, tid -> sock.write(buffer("tick!")));
-      sock.endHandler(v -> vertx.cancelTimer(timerID));
-    }));
-    router.route("/amplify/*").handler(SockJSHandler.create(vertx,
-      new SockJSHandlerOptions().setMaxBytesStreaming(4096)).socketHandler(sock -> sock.handler(data -> {
-      String str = data.toString();
-      int n = Integer.valueOf(str);
-      if (n < 0 || n > 19) {
-        n = 1;
-      }
-      int num = (int) Math.pow(2, n);
-      Buffer buff = buffer(num);
-      for (int i = 0; i < num; i++) {
-        buff.appendByte((byte) 'x');
-      }
-      sock.write(buff);
-    })));
-    router.route("/broadcast/*").handler(SockJSHandler.create(vertx,
-      new SockJSHandlerOptions().setMaxBytesStreaming(4096)).socketHandler(new Handler<SockJSSocket>() {
-      Set<String> connections = new HashSet<>();
+    router.mountSubRouter(
+      "/echo",
+      SockJSHandler.create(
+        vertx,
+        new SockJSHandlerOptions().setMaxBytesStreaming(4096))
+        .socketHandler(sock -> sock.handler(sock::write)));
 
-      public void handle(SockJSSocket sock) {
-        connections.add(sock.writeHandlerID());
-        sock.handler(buffer -> {
-          for (String actorID : connections) {
-            vertx.eventBus().publish(actorID, buffer);
+    router.mountSubRouter(
+      "/close",
+      SockJSHandler.create(vertx,
+        new SockJSHandlerOptions().setMaxBytesStreaming(4096))
+        .socketHandler(sock -> {
+          // Close with a small delay so the opening sockjs frame "o" is not aggregated in the same TCP frame
+          // than the SockJS close frame "c[3000,"Go away!"]"
+          vertx.setTimer(10, id -> sock.close(3000, "Go away!"));
+        }));
+    router.mountSubRouter(
+      "/disabled_websocket_echo",
+      SockJSHandler.create(vertx, new SockJSHandlerOptions()
+        .setMaxBytesStreaming(4096).addDisabledTransport("WEBSOCKET"))
+        .socketHandler(sock -> sock.handler(sock::write)));
+    router.mountSubRouter(
+      "/ticker",
+      SockJSHandler.create(vertx,
+        new SockJSHandlerOptions().setMaxBytesStreaming(4096))
+        .socketHandler(sock -> {
+          long timerID = vertx.setPeriodic(1000, tid -> sock.write(buffer("tick!")));
+          sock.endHandler(v -> vertx.cancelTimer(timerID));
+        }));
+    router.mountSubRouter(
+      "/amplify",
+      SockJSHandler.create(vertx,
+        new SockJSHandlerOptions().setMaxBytesStreaming(4096))
+        .socketHandler(sock -> sock.handler(data -> {
+          String str = data.toString();
+          int n = Integer.valueOf(str);
+          if (n < 0 || n > 19) {
+            n = 1;
           }
-        });
-        sock.endHandler(v -> connections.remove(sock.writeHandlerID()));
-      }
-    }));
-    router.route("/cookie_needed_echo/*").handler(SockJSHandler.create(vertx, new SockJSHandlerOptions().
-      setMaxBytesStreaming(4096).setInsertJSESSIONID(true)).socketHandler(sock -> sock.handler(sock::write)));
+          int num = (int) Math.pow(2, n);
+          Buffer buff = buffer(num);
+          for (int i = 0; i < num; i++) {
+            buff.appendByte((byte) 'x');
+          }
+          sock.write(buff);
+        })));
+    router.mountSubRouter(
+      "/broadcast",
+      SockJSHandler.create(vertx,
+        new SockJSHandlerOptions().setMaxBytesStreaming(4096))
+        .socketHandler(new Handler<SockJSSocket>() {
+          Set<String> connections = new HashSet<>();
+
+          public void handle(SockJSSocket sock) {
+            connections.add(sock.writeHandlerID());
+            sock.handler(buffer -> {
+              for (String actorID : connections) {
+                vertx.eventBus().publish(actorID, buffer);
+              }
+            });
+            sock.endHandler(v -> connections.remove(sock.writeHandlerID()));
+          }
+        }));
+    router.mountSubRouter(
+      "/cookie_needed_echo",
+      SockJSHandler.create(vertx, new SockJSHandlerOptions().
+        setMaxBytesStreaming(4096).setInsertJSESSIONID(true))
+        .socketHandler(sock -> sock.handler(sock::write)));
   }
 
   /*
@@ -125,8 +148,8 @@ public class SockJSProtocolTest {
     if (res == 0) {
       File dir = new File("src/test/sockjs-protocol");
       p = Runtime
-          .getRuntime()
-          .exec("python sockjs-protocol.py", new String[]{"SOCKJS_URL=http://localhost:8081"}, dir);
+        .getRuntime()
+        .exec("python sockjs-protocol.py", new String[]{"SOCKJS_URL=http://localhost:8081"}, dir);
 
       try (BufferedReader input = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
         String line;


### PR DESCRIPTION
This is an alternative to: #1376 

The differences are subtle, while the previous approach was merging routers, this approach is more conservative. It still keeps routers independent and fixes mounting on parameterized paths.

For example:

```java
root.mountSubRouter("/prefix/:var", subRouter)
```

Will work as well as adding routes to `subRouter` later on. However there are a few caveats:

~~1. the whole path is not verified at build time root: `/:id` + `/child/:id` will be allowed and cause problems at runtime (this wouldn't happen with the previous approach)~~
2. pure regex paths will not work: `/.*` + `/:id` can't be handled (worked with the previous approach)
3. the matching method now requires a few extra steps to keep the location of the end of the root router
4. the `mountPoint` is not guaranteed to be properly decoded as the matching happens at the `route` level where it can be either normalized or not (so it's a best effort).
5. this approach allows keeping the current sockjs handler working (although deprecated as it doesn't properly handle errors at the sockjs router)

