### PR TITLE
fix default charset issue at `StaticHandlerTest#testContentHeadersSet`

### DIFF
--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <doc.skip>false</doc.skip>
+   <file.encoding>UTF-8</file.encoding>
+   <surefireArgLine>-Dfile.encoding=${file.encoding}</surefireArgLine>
   </properties>
 
   <dependencies>

--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -28,8 +28,6 @@
 
   <properties>
     <doc.skip>false</doc.skip>
-   <file.encoding>UTF-8</file.encoding>
-   <surefireArgLine>-Dfile.encoding=${file.encoding}</surefireArgLine>
   </properties>
 
   <dependencies>

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -141,6 +141,7 @@ public class StaticHandlerTest extends WebTestBase {
 
   @Test
   public void testContentHeadersSet() throws Exception {
+    stat.setDefaultContentEncoding("UTF-8");
     testRequest(HttpMethod.GET, "/otherpage.html", null, res -> {
       String contentType = res.headers().get("content-type");
       String contentLength = res.headers().get("content-length");


### PR DESCRIPTION
run test under non UTF-8 as default charset , will reproduce the problem
ie: `mvn test -Dtest=StaticHandlerTest#testContentHeadersSet -Dfile.encoding=GBK`
==>
```
Starting test: StaticHandlerTest#testContentHeadersSet
org.junit.ComparisonFailure: expected:<text/html;charset=[UTF-8]> but was:<text/html;charset=[GBK]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at io.vertx.test.core.AsyncTestBase.assertEquals(AsyncTestBase.java:354)
        at io.vertx.ext.web.handler.StaticHandlerTest.lambda$testContentHeadersSet$1(StaticHandlerTest.java:147)
```

Or should we add ` <surefireArgLine>-Dfile.encoding=UTF-8</surefireArgLine>` on vertx-parent pom.xml ? 
And where is the vertx-parent git repo?