### PR TITLE
Deprecate set/introduce add auth provider

### DIFF
--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/router_factory_integration/OpenAPI3ServiceProxiesTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/router_factory_integration/OpenAPI3ServiceProxiesTest.java
@@ -451,6 +451,11 @@ public class OpenAPI3ServiceProxiesTest extends ApiWebTestBase {
         routerFactory.addHandlerByOperationId("testUser", rc -> {
           rc.setUser(new User() {
             @Override
+            public String providerId() {
+              return "dummy";
+            }
+
+            @Override
             public User isAuthorized(String s, Handler<AsyncResult<Boolean>> handler) {
               return null;
             }

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -744,7 +744,7 @@ public class WebExamples {
 
   public void example38(Vertx vertx, AuthProvider authProvider, Router router) {
 
-    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).setAuthProvider(authProvider));
+    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).addAuthProvider(authProvider));
 
     AuthHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
 
@@ -769,7 +769,7 @@ public class WebExamples {
 
   public void example39(Vertx vertx, AuthProvider authProvider, Router router) {
 
-    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).setAuthProvider(authProvider));
+    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).addAuthProvider(authProvider));
 
     AuthHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
 
@@ -1267,7 +1267,7 @@ public class WebExamples {
     // We need a user session handler too to make sure
     // the user is stored in the session between requests
     router.route()
-      .handler(SessionHandler.create(LocalSessionStore.create(vertx)).setAuthProvider(authProvider));
+      .handler(SessionHandler.create(LocalSessionStore.create(vertx)).addAuthProvider(authProvider));
     // we now protect the resource under the path "/protected"
     router.route("/protected").handler(
       OAuth2AuthHandler.create(authProvider)

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -164,9 +164,24 @@ public interface SessionHandler extends Handler<RoutingContext> {
   /**
    * Set an auth provider that will allow retrieving the User object from the session to the current routing context.
    *
+   * @deprecated use the {@link #addAuthProvider(AuthProvider)} instead.
    * @param authProvider any auth provider.
    * @return a reference to this, so the API can be used fluently
    */
 	@Fluent
-  SessionHandler setAuthProvider(AuthProvider authProvider);
+  @Deprecated
+  default SessionHandler setAuthProvider(AuthProvider authProvider) {
+	  return addAuthProvider(authProvider);
+  }
+
+  /**
+   * Adds an auth provider that will allow retrieving the User object from the session to the current routing context.
+   *
+   * Multiple providers can be added to the handler for applications that support multiple security providers.
+   *
+   * @param authProvider any auth provider.
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  SessionHandler addAuthProvider(AuthProvider authProvider);
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -90,7 +90,7 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
 
     JsonObject authConfig = new JsonObject().put("properties_path", "classpath:login/loginusers.properties");
     AuthProvider authProvider = ShiroAuth.create(vertx, new ShiroAuthOptions().setType(ShiroAuthRealmType.PROPERTIES).setConfig(authConfig));
-    router.route().handler(SessionHandler.create(store).setAuthProvider(authProvider));
+    router.route().handler(SessionHandler.create(store).addAuthProvider(authProvider));
     router.route("/protected/*").handler(BasicAuthHandler.create(authProvider));
 
     AtomicReference<String> sessionID = new AtomicReference<>();

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
@@ -155,7 +155,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
   public void testRedirectWithParams() throws Exception {
     router.route().handler(BodyHandler.create());
     SessionStore store = LocalSessionStore.create(vertx);
-    router.route().handler(SessionHandler.create(store).setAuthProvider(authProvider));
+    router.route().handler(SessionHandler.create(store).addAuthProvider(authProvider));
     AuthHandler authHandler = RedirectAuthHandler.create(authProvider);
 
     router.route("/protected/*").handler(authHandler);
@@ -243,7 +243,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
   private void doLoginCommon(Handler<RoutingContext> handler, Set<String> authorities) throws Exception {
     router.route().handler(BodyHandler.create());
     SessionStore store = LocalSessionStore.create(vertx);
-    router.route().handler(SessionHandler.create(store).setAuthProvider(authProvider));
+    router.route().handler(SessionHandler.create(store).addAuthProvider(authProvider));
     AuthHandler authHandler = RedirectAuthHandler.create(authProvider);
     if (authorities != null) {
       authHandler.addAuthorities(authorities);


### PR DESCRIPTION
Depends on https://github.com/vert-x3/vertx-auth/pull/303

This deprecation allows the session handler to match user objects back to providers. While this was already the case it only allowed 1 provider per application. This PR changes it to allow multiple providers per application.