### PR TITLE
Removed all locks from the hotpath

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -18,11 +18,6 @@ package io.vertx.ext.web.impl;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
-import io.vertx.core.net.impl.URIDecoder;
-import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -41,40 +36,12 @@ import java.util.regex.Pattern;
  */
 public class RouteImpl implements Route {
 
-  private static final Logger log = LoggerFactory.getLogger(RouteImpl.class);
-
   private final RouterImpl router;
-  private final Set<HttpMethod> methods = new HashSet<>();
-  private final Set<MIMEHeader> consumes = new LinkedHashSet<>();
-  private boolean emptyBodyPermittedWithConsumes = false;
-  private final Set<MIMEHeader> produces = new LinkedHashSet<>();
-  private String path;
-  private int order;
-  private boolean enabled = true;
-  private List<Handler<RoutingContext>> contextHandlers;
-  private List<Handler<RoutingContext>> failureHandlers;
-  private boolean added;
-  private Pattern pattern;
-  private List<String> groups;
-  private boolean useNormalisedPath = true;
-  private Set<String> namedGroupsInRegex = new TreeSet<>();
-  private Pattern virtualHostPattern;
-  private boolean pathEndsWithSlash;
-
-  private boolean exclusive;
+  private volatile RouteState state;
 
   RouteImpl(RouterImpl router, int order) {
     this.router = router;
-    this.order = order;
-    this.contextHandlers = new ArrayList<>();
-    this.failureHandlers = new ArrayList<>();
-  }
-
-  RouteImpl(RouterImpl router, int order, HttpMethod method, String path) {
-    this(router, order);
-    methods.add(method);
-    checkPath(path);
-    setPath(path);
+    this.state = new RouteState(this, order);
   }
 
   RouteImpl(RouterImpl router, int order, String path) {
@@ -83,10 +50,11 @@ public class RouteImpl implements Route {
     setPath(path);
   }
 
-  RouteImpl(RouterImpl router, int order, HttpMethod method, String regex, boolean bregex) {
+  RouteImpl(RouterImpl router, int order, HttpMethod method, String path) {
     this(router, order);
-    methods.add(method);
-    setRegex(regex);
+    method(method);
+    checkPath(path);
+    setPath(path);
   }
 
   RouteImpl(RouterImpl router, int order, String regex, boolean bregex) {
@@ -94,65 +62,80 @@ public class RouteImpl implements Route {
     setRegex(regex);
   }
 
+  RouteImpl(RouterImpl router, int order, HttpMethod method, String regex, boolean bregex) {
+    this(router, order);
+    method(method);
+    setRegex(regex);
+  }
+
+  RouteState state() {
+    return state;
+  }
+
   @Override
   public synchronized Route method(HttpMethod method) {
-    methods.add(method);
+    state = state.addMethod(method);
     return this;
   }
 
   @Override
-  public synchronized Route path(String path) {
+  public Route path(String path) {
     checkPath(path);
     setPath(path);
     return this;
   }
 
   @Override
-  public synchronized Route pathRegex(String regex) {
+  public Route pathRegex(String regex) {
     setRegex(regex);
     return this;
   }
 
   @Override
   public synchronized Route produces(String contentType) {
-    ParsableMIMEValue value = new ParsableMIMEValue(contentType).forceParse();
-    produces.add(value);
+    state = state.addProduce(new ParsableMIMEValue(contentType).forceParse());
     return this;
   }
 
   @Override
   public synchronized Route consumes(String contentType) {
-    ParsableMIMEValue value = new ParsableMIMEValue(contentType).forceParse();
-    consumes.add(value);
+    state = state.addConsume(new ParsableMIMEValue(contentType).forceParse());
     return this;
   }
 
   @Override
-  public Route virtualHost(String hostnamePattern) {
-    this.virtualHostPattern = Pattern.compile(hostnamePattern.replaceAll("\\.", "\\\\.").replaceAll("[*]", "(.*?)"), Pattern.CASE_INSENSITIVE);
+  public synchronized Route virtualHost(String hostnamePattern) {
+    state = state
+      .setVirtualHostPattern(
+        Pattern.compile(
+          hostnamePattern
+            .replaceAll("\\.", "\\\\.")
+            .replaceAll("[*]", "(.*?)"), Pattern.CASE_INSENSITIVE));
+
     return this;
   }
 
   @Override
   public synchronized Route order(int order) {
-    if (added) {
+    if (state.isAdded()) {
       throw new IllegalStateException("Can't change order after route is active");
     }
-    this.order = order;
+    state = state.setOrder(order);
     return this;
   }
 
   @Override
-  public synchronized Route last() {
+  public Route last() {
     return order(Integer.MAX_VALUE);
   }
 
   @Override
   public synchronized Route handler(Handler<RoutingContext> contextHandler) {
-    if (exclusive) {
+    if (state.isExclusive()) {
       throw new IllegalStateException("This Route is exclusive for already mounted sub router.");
     }
-    this.contextHandlers.add(contextHandler);
+    state = state.addContextHandler(contextHandler);
+
     checkAdd();
     return this;
   }
@@ -163,18 +146,18 @@ public class RouteImpl implements Route {
   }
 
   @Override
-  public Route subRouter(Router subRouter) {
+  public synchronized Route subRouter(Router subRouter) {
 
     // The route path must end with a wild card
-    if (exactPath) {
+    if (state.isExactPath()) {
       throw new IllegalStateException("Sub router cannot be mounted on an exact path.");
     }
     // Parameters are allowed but full regex patterns not
-    if (path == null && pattern != null) {
+    if (state.getPath() == null && state.getPattern() != null) {
       throw new IllegalStateException("Sub router cannot be mounted on a regular expression path.");
     }
     // No other handler can be registered before or after this call (but they can on a new route object for the same path)
-    if (contextHandlers.size() > 0 || failureHandlers.size() > 0) {
+    if (state.getContextHandlersLength() > 0 || state.getFailureHandlersLength() > 0) {
       throw new IllegalStateException("Only one sub router per Route object is allowed.");
     }
 
@@ -187,322 +170,130 @@ public class RouteImpl implements Route {
     validateMount(subRouter);
 
     // mark the route as exclusive from now on
-    exclusive = true;
-
+    this.state = state.setExclusive(true);
     return this;
   }
 
   @Override
-  public synchronized Route blockingHandler(Handler<RoutingContext> contextHandler, boolean ordered) {
+  public Route blockingHandler(Handler<RoutingContext> contextHandler, boolean ordered) {
     return handler(new BlockingHandlerDecorator(contextHandler, ordered));
   }
 
   @Override
   public synchronized Route failureHandler(Handler<RoutingContext> exceptionHandler) {
-    if (exclusive) {
+    if (state.isExclusive()) {
       throw new IllegalStateException("This Route is exclusive for already mounted sub router.");
     }
-    this.failureHandlers.add(exceptionHandler);
+
+    state = state.addFailureHandler(exceptionHandler);
     checkAdd();
     return this;
   }
 
   @Override
-  public synchronized Route remove() {
+  public Route remove() {
     router.remove(this);
     return this;
   }
 
   @Override
   public synchronized Route disable() {
-    enabled = false;
+    state = state.setEnabled(false);
     return this;
   }
 
   @Override
   public synchronized Route enable() {
-    enabled = true;
+    state = state.setEnabled(true);
     return this;
   }
 
   @Override
-  public Route useNormalisedPath(boolean useNormalisedPath) {
-    this.useNormalisedPath = useNormalisedPath;
+  public synchronized Route useNormalisedPath(boolean useNormalisedPath) {
+    state = state.setUseNormalisedPath(useNormalisedPath);
     return this;
   }
 
   @Override
   public String getPath() {
-    return path;
+    return state.getPath();
   }
 
   @Override
   public boolean isRegexPath() {
-    return pattern != null;
+    return state.getPattern() != null;
   }
 
   @Override
   public Set<HttpMethod> methods() {
-    return this.methods;
+    return state.getMethods();
   }
 
   @Override
-  public Route setRegexGroupsNames(List<String> groups) {
-    this.groups = groups;
+  public synchronized Route setRegexGroupsNames(List<String> groups) {
+    state = state.setGroups(groups);
     return this;
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("Route[ ");
-    sb.append("path:").append(path);
-    sb.append(" pattern:").append(pattern);
-    sb.append(" handlers:").append(contextHandlers);
-    sb.append(" failureHandlers:").append(failureHandlers);
-    sb.append(" order:").append(order);
+    sb.append("path:").append(state.getPath());
+    sb.append(" pattern:").append(state.getPattern());
+    sb.append(" handlers:").append(state.getContextHandlers());
+    sb.append(" failureHandlers:").append(state.getFailureHandlers());
+    sb.append(" order:").append(state.getOrder());
     sb.append(" methods:[");
-    int cnt = 0;
-    for (HttpMethod method : methods) {
-      sb.append(method);
-      cnt++;
-      if (cnt < methods.size()) {
-        sb.append(",");
-      }
-    }
-    sb.append("]]@").append(System.identityHashCode(this));
-    return sb.toString();
-  }
-
-  void handleContext(RoutingContextImplBase context) {
-    Handler<RoutingContext> contextHandler;
-
-    synchronized (this) {
-      contextHandler = contextHandlers.get(context.currentRouteNextHandlerIndex() - 1);
-    }
-
-    contextHandler.handle(context);
-  }
-
-  void handleFailure(RoutingContextImplBase context) {
-    Handler<RoutingContext> failureHandler;
-
-    synchronized (this) {
-      failureHandler = failureHandlers.get(context.currentRouteNextFailureHandlerIndex() - 1);
-    }
-
-    failureHandler.handle(context);
-  }
-
-  /**
-   * @return 0 if route matches, otherwise it return the status code
-   */
-  synchronized int matches(RoutingContextImplBase context, String mountPoint, boolean failure) {
-
-    if (failure && !hasNextFailureHandler(context) || !failure && !hasNextContextHandler(context)) {
-      return 404;
-    }
-    if (!enabled) {
-      return 404;
-    }
-    HttpServerRequest request = context.request();
-    if (path != null && pattern == null && !pathMatches(mountPoint, context)) {
-      return 404;
-    }
-    if (pattern != null) {
-      String path = useNormalisedPath ? context.normalisedPath() : context.request().path();
-      if (mountPoint != null) {
-        path = path.substring(mountPoint.length());
-      }
-
-      Matcher m = pattern.matcher(path);
-      if (m.matches()) {
-
-        if (!methods.isEmpty() && !methods.contains(request.method())) {
-          // If I'm here path or path pattern matches, but the method is wrong
-          return 405;
+    if (state.getMethods() != null) {
+      int cnt = 0;
+      for (HttpMethod method : state.getMethods()) {
+        sb.append(method);
+        cnt++;
+        if (cnt < state.getMethods().size()) {
+          sb.append(",");
         }
-
-        context.matchRest = -1;
-        context.matchNormalized = useNormalisedPath;
-
-        if (m.groupCount() > 0) {
-          if (!exactPath) {
-            context.matchRest = m.start("rest");
-          }
-
-          if (groups != null) {
-            // Pattern - named params
-            // decode the path as it could contain escaped chars.
-            for (int i = 0; i < Math.min(groups.size(), m.groupCount()); i++) {
-              final String k = groups.get(i);
-              String undecodedValue;
-              // We try to take value in three ways:
-              // 1. group name of type p0, p1, pN (most frequent and used by vertx params)
-              // 2. group name inside the regex
-              // 3. No group name
-              try {
-                undecodedValue = m.group("p" + i);
-              } catch (IllegalArgumentException e) {
-                try {
-                  undecodedValue = m.group(k);
-                } catch (IllegalArgumentException e1) {
-                  // Groups starts from 1 (0 group is total match)
-                  undecodedValue = m.group(i + 1);
-                }
-              }
-              addPathParam(context, k, undecodedValue);
-            }
-          } else {
-            // Straight regex - un-named params
-            // decode the path as it could contain escaped chars.
-            for (String namedGroup : namedGroupsInRegex) {
-              String namedGroupValue = m.group(namedGroup);
-              if (namedGroupValue != null) {
-                addPathParam(context, namedGroup, namedGroupValue);
-              }
-            }
-            for (int i = 0; i < m.groupCount(); i++) {
-              String group = m.group(i + 1);
-              if (group != null) {
-                final String k = "param" + i;
-                addPathParam(context, k, group);
-              }
-            }
-          }
-        }
-      } else {
-        return 404;
       }
     } else {
-      // no pattern check for wrong method
-      if (!methods.isEmpty() && !methods.contains(request.method())) {
-        // If I'm here path or path pattern matches, but the method is wrong
-        return 405;
-      }
+      sb.append("all");
     }
 
-    if (!consumes.isEmpty()) {
-      // Can this route consume the specified content type
-      MIMEHeader contentType = context.parsedHeaders().contentType();
-      MIMEHeader consumal = contentType.findMatchedBy(consumes);
-      if (consumal == null && !(contentType.rawValue().isEmpty() && emptyBodyPermittedWithConsumes)) {
-        if (contentType.rawValue().isEmpty()) {
-          return 400;
-        } else {
-          return 415;
-        }
-      }
-    }
-    List<MIMEHeader> acceptableTypes = context.parsedHeaders().accept();
-    if (!produces.isEmpty() && !acceptableTypes.isEmpty()) {
-      MIMEHeader selectedAccept = context.parsedHeaders().findBestUserAcceptedIn(acceptableTypes, produces);
-      if (selectedAccept != null) {
-        context.setAcceptableContentType(selectedAccept.rawValue());
-      } else {
-        return 406;
-      }
-    }
-    if (!virtualHostMatches(context.request.host())) {
-      return 404;
-    }
-    return 0;
-  }
-
-  private void addPathParam(RoutingContext context, String name, String value) {
-    HttpServerRequest request = context.request();
-    final String decodedValue = URIDecoder.decodeURIComponent(value, false);
-    if (!request.params().contains(name)) {
-      request.params().add(name, decodedValue);
-    }
-    context.pathParams().put(name, decodedValue);
+    sb.append("]]@").append(System.identityHashCode(this));
+    return sb.toString();
   }
 
   RouterImpl router() {
     return router;
   }
 
-  private boolean pathMatches(String mountPoint, RoutingContext ctx) {
-    String thePath = mountPoint == null ? path : mountPoint + path;
-    String requestPath;
-
-    if (useNormalisedPath) {
-      // never null
-      requestPath = ctx.normalisedPath();
-    } else {
-      requestPath = ctx.request().path();
-      // can be null
-      if (requestPath == null) {
-        requestPath = "/";
-      }
-    }
-
-    if (exactPath) {
-      return pathMatchesExact(requestPath, thePath);
-    } else {
-      if (pathEndsWithSlash && (requestPath.charAt(requestPath.length() - 1) == '/'
-          ? requestPath.equals(thePath) : thePath.regionMatches(0, requestPath, 0, requestPath.length()))) {
-        return true;
-      }
-      return requestPath.startsWith(thePath);
-    }
-  }
-
-  private boolean virtualHostMatches(String host) {
-    if (virtualHostPattern == null) return true;
-    boolean match = false;
-    for (String h : host.split(":")) {
-      if (virtualHostPattern.matcher(h).matches()) {
-        match = true;
-        break;
-      }
-    }
-    return match;
-  }
-
-  private boolean pathMatchesExact(String path1, String path2) {
-    // Ignore trailing slash when matching paths
-    final int idx1 = path1.length() - 1;
-    return pathEndsWithSlash ?
-       (path1.charAt(idx1) == '/' ? path1.equals(path2) : path2.regionMatches(0, path1, 0, path1.length()))
-      :(path1.charAt(idx1) != '/' ? path1.equals(path2) : path1.regionMatches(0, path2, 0, path2.length()));
-  }
-
-
-  private void setPath(String path) {
+  private synchronized void setPath(String path) {
     // See if the path contains ":" - if so then it contains parameter capture groups and we have to generate
     // a regex for that
     if (path.charAt(path.length() - 1) != '*') {
-      exactPath = true;
-      this.path = path;
+      state = state.setExactPath(true);
+      state = state.setPath(path);
     } else {
-      exactPath = false;
-      this.path = path.substring(0, path.length() - 1);
+      state = state.setExactPath(false);
+      state = state.setPath(path.substring(0, path.length() - 1));
     }
 
     if (path.indexOf(':') != -1) {
       createPatternRegex(path);
     }
 
-    pathEndsWithSlash = this.path.endsWith("/");
+    state = state.setPathEndsWithSlash(state.getPath().endsWith("/"));
   }
 
-  private void setRegex(String regex) {
-    pattern = Pattern.compile(regex);
-    exactPath = true;
-    Set<String> namedGroups = findNamedGroups(pattern.pattern());
-    if (!namedGroups.isEmpty()) {
-      namedGroupsInRegex.addAll(namedGroups);
-    }
+  private synchronized void setRegex(String regex) {
+    state = state.setPattern(Pattern.compile(regex));
+    state = state.setExactPath(true);
+    findNamedGroups(state.getPattern().pattern());
   }
 
-  private Set<String> findNamedGroups(String path) {
-    Set<String> namedGroups = new TreeSet<>();
+  private synchronized void findNamedGroups(String path) {
     Matcher m = Pattern.compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>").matcher(path);
-
     while (m.find()) {
-      namedGroups.add(m.group(1));
+      state = state.addNamedGroupInRegex(m.group(1));
     }
-    return namedGroups;
   }
 
   // intersection of regex chars and https://tools.ietf.org/html/rfc3986#section-3.3
@@ -511,21 +302,21 @@ public class RouteImpl implements Route {
   // Pattern for :<token name> in path
   private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":([A-Za-z][A-Za-z0-9_]*)");
 
-  private void createPatternRegex(String path) {
+  private synchronized void createPatternRegex(String path) {
     // escape path from any regex special chars
     path = RE_OPERATORS_NO_STAR.matcher(path).replaceAll("\\\\$1");
     // allow usage of * at the end as per documentation
     if (path.charAt(path.length() - 1) == '*') {
       path = path.substring(0, path.length() - 1) + "(?<rest>.*)";
-      exactPath = false;
+      state = state.setExactPath(false);
     } else {
-      exactPath = true;
+      state = state.setExactPath(true);
     }
 
     // We need to search for any :<token name> tokens in the String and replace them with named capture groups
     Matcher m = RE_TOKEN_SEARCH.matcher(path);
     StringBuffer sb = new StringBuffer();
-    groups = new ArrayList<>();
+    List<String> groups = new ArrayList<>();
     int index = 0;
     while (m.find()) {
       String param = "p" + index;
@@ -539,7 +330,9 @@ public class RouteImpl implements Route {
     }
     m.appendTail(sb);
     path = sb.toString();
-    pattern = Pattern.compile(path);
+
+    state = state.setGroups(groups);
+    state = state.setPattern(Pattern.compile(path));
   }
 
   private void checkPath(String path) {
@@ -548,29 +341,15 @@ public class RouteImpl implements Route {
     }
   }
 
-  private boolean exactPath;
-
   int order() {
-    return order;
+    return state.getOrder();
   }
 
-  private void checkAdd() {
-    if (!added) {
+  private synchronized void checkAdd() {
+    if (!state.isAdded()) {
       router.add(this);
-      added = true;
+      state = state.setAdded(true);
     }
-  }
-
-  synchronized protected boolean hasNextContextHandler(RoutingContextImplBase context) {
-    return context.currentRouteNextHandlerIndex() < contextHandlers.size();
-  }
-
-  synchronized protected boolean hasNextFailureHandler(RoutingContextImplBase context) {
-    return context.currentRouteNextFailureHandlerIndex() < failureHandlers.size();
-  }
-
-  public void setEmptyBodyPermittedWithConsumes(boolean emptyBodyPermittedWithConsumes) {
-    this.emptyBodyPermittedWithConsumes = emptyBodyPermittedWithConsumes;
   }
 
   private void validateMount(Router router) {
@@ -583,7 +362,7 @@ public class RouteImpl implements Route {
 
       // escape path from any regex special chars
       combinedPath = RE_OPERATORS_NO_STAR
-        .matcher(path + (pathEndsWithSlash ? route.getPath().substring(1) : route.getPath()))
+        .matcher(state.getPath() + (state.isPathEndsWithSlash() ? route.getPath().substring(1) : route.getPath()))
         .replaceAll("\\\\$1");
 
       // We need to search for any :<token name> tokens in the String
@@ -599,3 +378,4 @@ public class RouteImpl implements Route {
     }
   }
 }
+

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -352,6 +352,11 @@ public class RouteImpl implements Route {
     }
   }
 
+  public synchronized RouteImpl setEmptyBodyPermittedWithConsumes(boolean emptyBodyPermittedWithConsumes) {
+    state = state.setEmptyBodyPermittedWithConsumes(emptyBodyPermittedWithConsumes);
+    return this;
+  }
+
   private void validateMount(Router router) {
     for (Route route : router.getRoutes()) {
       final String combinedPath;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -237,28 +237,11 @@ public class RouteImpl implements Route {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder("Route[ ");
-    sb.append("path:").append(state.getPath());
-    sb.append(" pattern:").append(state.getPattern());
-    sb.append(" handlers:").append(state.getContextHandlers());
-    sb.append(" failureHandlers:").append(state.getFailureHandlers());
-    sb.append(" order:").append(state.getOrder());
-    sb.append(" methods:[");
-    if (state.getMethods() != null) {
-      int cnt = 0;
-      for (HttpMethod method : state.getMethods()) {
-        sb.append(method);
-        cnt++;
-        if (cnt < state.getMethods().size()) {
-          sb.append(",");
-        }
-      }
-    } else {
-      sb.append("all");
-    }
-
-    sb.append("]]@").append(System.identityHashCode(this));
-    return sb.toString();
+    return "RouteImpl@" + System.identityHashCode(this) +
+      "{" +
+      "router=" + router +
+      ", state=" + state +
+      '}';
   }
 
   RouterImpl router() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 /**
  * This class encapsulates the route state, all mutations are atomic and return a new state with the mutation.
- *
+ * <p>
  * This class is thread-safe
  *
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
@@ -37,61 +37,68 @@ final class RouteState {
 
   private final RouteImpl route;
 
-  private String path;
-  private int order;
-  private boolean enabled;
-  private Set<HttpMethod> methods;
-  private Set<MIMEHeader> consumes;
-  private boolean emptyBodyPermittedWithConsumes;
-  private Set<MIMEHeader> produces;
-  private List<Handler<RoutingContext>> contextHandlers;
-  private List<Handler<RoutingContext>> failureHandlers;
-  private boolean added;
-  private Pattern pattern;
-  private List<String> groups;
-  private boolean useNormalisedPath;
-  private Set<String> namedGroupsInRegex;
-  private Pattern virtualHostPattern;
-  private boolean pathEndsWithSlash;
-  private boolean exclusive;
-  private boolean exactPath;
+  private final String path;
+  private final int order;
+  private final boolean enabled;
+  private final Set<HttpMethod> methods;
+  private final Set<MIMEHeader> consumes;
+  private final boolean emptyBodyPermittedWithConsumes;
+  private final Set<MIMEHeader> produces;
+  private final List<Handler<RoutingContext>> contextHandlers;
+  private final List<Handler<RoutingContext>> failureHandlers;
+  private final boolean added;
+  private final Pattern pattern;
+  private final List<String> groups;
+  private final boolean useNormalisedPath;
+  private final Set<String> namedGroupsInRegex;
+  private final Pattern virtualHostPattern;
+  private final boolean pathEndsWithSlash;
+  private final boolean exclusive;
+  private final boolean exactPath;
 
-  private RouteState(RouteImpl route) {
+  private RouteState(RouteImpl route, String path, int order, boolean enabled, Set<HttpMethod> methods, Set<MIMEHeader> consumes, boolean emptyBodyPermittedWithConsumes, Set<MIMEHeader> produces, List<Handler<RoutingContext>> contextHandlers, List<Handler<RoutingContext>> failureHandlers, boolean added, Pattern pattern, List<String> groups, boolean useNormalisedPath, Set<String> namedGroupsInRegex, Pattern virtualHostPattern, boolean pathEndsWithSlash, boolean exclusive, boolean exactPath) {
     this.route = route;
-    // route defaults
-    this.enabled = true;
-    this.useNormalisedPath = true;
+    this.path = path;
+    this.order = order;
+    this.enabled = enabled;
+    this.methods = methods;
+    this.consumes = consumes;
+    this.emptyBodyPermittedWithConsumes = emptyBodyPermittedWithConsumes;
+    this.produces = produces;
+    this.contextHandlers = contextHandlers;
+    this.failureHandlers = failureHandlers;
+    this.added = added;
+    this.pattern = pattern;
+    this.groups = groups;
+    this.useNormalisedPath = useNormalisedPath;
+    this.namedGroupsInRegex = namedGroupsInRegex;
+    this.virtualHostPattern = virtualHostPattern;
+    this.pathEndsWithSlash = pathEndsWithSlash;
+    this.exclusive = exclusive;
+    this.exactPath = exactPath;
   }
 
   RouteState(RouteImpl route, int order) {
-    this(route);
-    // custom state
-    this.order = order;
-  }
-
-  RouteState copy() {
-    RouteState other = new RouteState(this.route);
-
-    other.path = this.path;
-    other.order = this.order;
-    other.enabled = this.enabled;
-    other.methods = this.methods;
-    other.consumes = this.consumes;
-    other.emptyBodyPermittedWithConsumes = this.emptyBodyPermittedWithConsumes;
-    other.produces = this.produces;
-    other.contextHandlers = this.contextHandlers;
-    other.failureHandlers = this.failureHandlers;
-    other.added = this.added;
-    other.pattern = this.pattern;
-    other.groups = this.groups;
-    other.useNormalisedPath = this.useNormalisedPath;
-    other.namedGroupsInRegex = this.namedGroupsInRegex;
-    other.virtualHostPattern = this.virtualHostPattern;
-    other.pathEndsWithSlash = this.pathEndsWithSlash;
-    other.exclusive = this.exclusive;
-    other.exactPath = this.exactPath;
-
-    return other;
+    this(
+      route,
+      null,
+      order,
+      true,
+      null,
+      null,
+      false,
+      null,
+      null,
+      null,
+      false,
+      null,
+      null,
+      true,
+      null,
+      null,
+      false,
+      false,
+      false);
   }
 
   public RouteImpl getRoute() {
@@ -107,9 +114,26 @@ final class RouteState {
   }
 
   RouteState setPath(String path) {
-    RouteState newState = copy();
-    newState.path = path;
-    return newState;
+    return new RouteState(
+      this.route,
+      path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public int getOrder() {
@@ -117,9 +141,26 @@ final class RouteState {
   }
 
   RouteState setOrder(int order) {
-    RouteState newState = copy();
-    newState.order = order;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public boolean isEnabled() {
@@ -127,9 +168,26 @@ final class RouteState {
   }
 
   RouteState setEnabled(boolean enabled) {
-    RouteState newState = copy();
-    newState.enabled = enabled;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public Set<HttpMethod> getMethods() {
@@ -137,14 +195,50 @@ final class RouteState {
   }
 
   RouteState setMethods(Set<HttpMethod> methods) {
-    RouteState newState = copy();
-    newState.methods = new HashSet<>(methods);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public RouteState addMethod(HttpMethod method) {
-    RouteState newState = copy();
-    newState.methods = this.methods == null ? new HashSet<>() : new HashSet<>(this.methods);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods == null ? new HashSet<>() : new HashSet<>(this.methods),
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.methods.add(method);
     return newState;
   }
@@ -154,14 +248,50 @@ final class RouteState {
   }
 
   RouteState setConsumes(Set<MIMEHeader> consumes) {
-    RouteState newState = copy();
-    newState.consumes = new HashSet<>(consumes);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addConsume(MIMEHeader mime) {
-    RouteState newState = copy();
-    newState.consumes = this.consumes == null ? new HashSet<>() : new HashSet<>(this.consumes);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes == null ? new HashSet<>() : new HashSet<>(this.consumes),
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.consumes.add(mime);
     return newState;
   }
@@ -171,9 +301,26 @@ final class RouteState {
   }
 
   RouteState setEmptyBodyPermittedWithConsumes(boolean emptyBodyPermittedWithConsumes) {
-    RouteState newState = copy();
-    newState.emptyBodyPermittedWithConsumes = emptyBodyPermittedWithConsumes;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public Set<MIMEHeader> getProduces() {
@@ -181,14 +328,50 @@ final class RouteState {
   }
 
   RouteState setProduces(Set<MIMEHeader> produces) {
-    RouteState newState = copy();
-    newState.produces = new HashSet<>(produces);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addProduce(MIMEHeader mime) {
-    RouteState newState = copy();
-    newState.produces = this.produces == null ? new HashSet<>() : new HashSet<>(this.produces);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces == null ? new HashSet<>() : new HashSet<>(this.produces),
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.produces.add(mime);
     return newState;
   }
@@ -202,14 +385,50 @@ final class RouteState {
   }
 
   RouteState setContextHandlers(List<Handler<RoutingContext>> contextHandlers) {
-    RouteState newState = copy();
-    newState.contextHandlers = new ArrayList<>(contextHandlers);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addContextHandler(Handler<RoutingContext> contextHandler) {
-    RouteState newState = copy();
-    newState.contextHandlers = this.contextHandlers == null ? new ArrayList<>() : new ArrayList<>(this.contextHandlers);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers == null ? new ArrayList<>() : new ArrayList<>(this.contextHandlers),
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.contextHandlers.add(contextHandler);
     return newState;
   }
@@ -223,14 +442,50 @@ final class RouteState {
   }
 
   RouteState setFailureHandlers(List<Handler<RoutingContext>> failureHandlers) {
-    RouteState newState = copy();
-    newState.failureHandlers = new ArrayList<>(failureHandlers);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addFailureHandler(Handler<RoutingContext> failureHandler) {
-    RouteState newState = copy();
-    newState.failureHandlers = this.failureHandlers == null ? new ArrayList<>() : new ArrayList<>(this.failureHandlers);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers == null ? new ArrayList<>() : new ArrayList<>(this.failureHandlers),
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.failureHandlers.add(failureHandler);
     return newState;
   }
@@ -240,9 +495,26 @@ final class RouteState {
   }
 
   RouteState setAdded(boolean added) {
-    RouteState newState = copy();
-    newState.added = added;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public Pattern getPattern() {
@@ -250,9 +522,26 @@ final class RouteState {
   }
 
   RouteState setPattern(Pattern pattern) {
-    RouteState newState = copy();
-    newState.pattern = pattern;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public List<String> getGroups() {
@@ -260,14 +549,50 @@ final class RouteState {
   }
 
   RouteState setGroups(List<String> groups) {
-    RouteState newState = copy();
-    newState.groups = new ArrayList<>(groups);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addGroup(String group) {
-    RouteState newState = copy();
-    newState.groups = this.groups == null ? new ArrayList<>() : new ArrayList<>(groups);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups == null ? new ArrayList<>() : new ArrayList<>(groups),
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.groups.add(group);
     return newState;
   }
@@ -277,9 +602,26 @@ final class RouteState {
   }
 
   RouteState setUseNormalisedPath(boolean useNormalisedPath) {
-    RouteState newState = copy();
-    newState.useNormalisedPath = useNormalisedPath;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public Set<String> getNamedGroupsInRegex() {
@@ -287,14 +629,50 @@ final class RouteState {
   }
 
   RouteState setNamedGroupsInRegex(Set<String> namedGroupsInRegex) {
-    RouteState newState = copy();
-    newState.namedGroupsInRegex = new HashSet<>(namedGroupsInRegex);
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   RouteState addNamedGroupInRegex(String namedGroupInRegex) {
-    RouteState newState = copy();
-    newState.namedGroupsInRegex = this.namedGroupsInRegex == null ? new HashSet<>() : new HashSet<>(this.namedGroupsInRegex);
+    RouteState newState = new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex == null ? new HashSet<>() : new HashSet<>(this.namedGroupsInRegex),
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
+
     newState.namedGroupsInRegex.add(namedGroupInRegex);
     return newState;
   }
@@ -304,9 +682,26 @@ final class RouteState {
   }
 
   RouteState setVirtualHostPattern(Pattern virtualHostPattern) {
-    RouteState newState = copy();
-    newState.virtualHostPattern = virtualHostPattern;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public boolean isPathEndsWithSlash() {
@@ -314,9 +709,26 @@ final class RouteState {
   }
 
   RouteState setPathEndsWithSlash(boolean pathEndsWithSlash) {
-    RouteState newState = copy();
-    newState.pathEndsWithSlash = pathEndsWithSlash;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      pathEndsWithSlash,
+      this.exclusive,
+      this.exactPath);
   }
 
   public boolean isExclusive() {
@@ -324,9 +736,26 @@ final class RouteState {
   }
 
   RouteState setExclusive(boolean exclusive) {
-    RouteState newState = copy();
-    newState.exclusive = exclusive;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      exclusive,
+      this.exactPath);
   }
 
   public boolean isExactPath() {
@@ -334,9 +763,26 @@ final class RouteState {
   }
 
   RouteState setExactPath(boolean exactPath) {
-    RouteState newState = copy();
-    newState.exactPath = exactPath;
-    return newState;
+    return new RouteState(
+      this.route,
+      this.path,
+      this.order,
+      this.enabled,
+      this.methods,
+      this.consumes,
+      this.emptyBodyPermittedWithConsumes,
+      this.produces,
+      this.contextHandlers,
+      this.failureHandlers,
+      this.added,
+      this.pattern,
+      this.groups,
+      this.useNormalisedPath,
+      this.namedGroupsInRegex,
+      this.virtualHostPattern,
+      this.pathEndsWithSlash,
+      this.exclusive,
+      exactPath);
   }
 
   private static <T> boolean contains(Collection<T> collection, T value) {
@@ -537,5 +983,30 @@ final class RouteState {
     failureHandlers
       .get(context.currentRouteNextFailureHandlerIndex() - 1)
       .handle(context);
+  }
+
+  @Override
+  public String toString() {
+    return "RouteState{" +
+      "route=" + route +
+      ", path='" + path + '\'' +
+      ", order=" + order +
+      ", enabled=" + enabled +
+      ", methods=" + methods +
+      ", consumes=" + consumes +
+      ", emptyBodyPermittedWithConsumes=" + emptyBodyPermittedWithConsumes +
+      ", produces=" + produces +
+      ", contextHandlers=" + contextHandlers +
+      ", failureHandlers=" + failureHandlers +
+      ", added=" + added +
+      ", pattern=" + pattern +
+      ", groups=" + groups +
+      ", useNormalisedPath=" + useNormalisedPath +
+      ", namedGroupsInRegex=" + namedGroupsInRegex +
+      ", virtualHostPattern=" + virtualHostPattern +
+      ", pathEndsWithSlash=" + pathEndsWithSlash +
+      ", exclusive=" + exclusive +
+      ", exactPath=" + exactPath +
+      '}';
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.impl.URIDecoder;
+import io.vertx.ext.web.MIMEHeader;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class encapsulates the route state, all mutations are atomic and return a new state with the mutation.
+ *
+ * This class is thread-safe
+ *
+ * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
+ */
+final class RouteState {
+
+  private final RouteImpl route;
+
+  private String path;
+  private int order;
+  private boolean enabled;
+  private Set<HttpMethod> methods;
+  private Set<MIMEHeader> consumes;
+  private boolean emptyBodyPermittedWithConsumes;
+  private Set<MIMEHeader> produces;
+  private List<Handler<RoutingContext>> contextHandlers;
+  private List<Handler<RoutingContext>> failureHandlers;
+  private boolean added;
+  private Pattern pattern;
+  private List<String> groups;
+  private boolean useNormalisedPath;
+  private Set<String> namedGroupsInRegex;
+  private Pattern virtualHostPattern;
+  private boolean pathEndsWithSlash;
+  private boolean exclusive;
+  private boolean exactPath;
+
+  private RouteState(RouteImpl route) {
+    this.route = route;
+    // route defaults
+    this.enabled = true;
+    this.useNormalisedPath = true;
+  }
+
+  RouteState(RouteImpl route, int order) {
+    this(route);
+    // custom state
+    this.order = order;
+  }
+
+  RouteState copy() {
+    RouteState other = new RouteState(this.route);
+
+    other.path = this.path;
+    other.order = this.order;
+    other.enabled = this.enabled;
+    other.methods = this.methods;
+    other.consumes = this.consumes;
+    other.emptyBodyPermittedWithConsumes = this.emptyBodyPermittedWithConsumes;
+    other.produces = this.produces;
+    other.contextHandlers = this.contextHandlers;
+    other.failureHandlers = this.failureHandlers;
+    other.added = this.added;
+    other.pattern = this.pattern;
+    other.groups = this.groups;
+    other.useNormalisedPath = this.useNormalisedPath;
+    other.namedGroupsInRegex = this.namedGroupsInRegex;
+    other.virtualHostPattern = this.virtualHostPattern;
+    other.pathEndsWithSlash = this.pathEndsWithSlash;
+    other.exclusive = this.exclusive;
+    other.exactPath = this.exactPath;
+
+    return other;
+  }
+
+  public RouteImpl getRoute() {
+    return route;
+  }
+
+  public RouterImpl getRouter() {
+    return route.router();
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  RouteState setPath(String path) {
+    RouteState newState = copy();
+    newState.path = path;
+    return newState;
+  }
+
+  public int getOrder() {
+    return order;
+  }
+
+  RouteState setOrder(int order) {
+    RouteState newState = copy();
+    newState.order = order;
+    return newState;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  RouteState setEnabled(boolean enabled) {
+    RouteState newState = copy();
+    newState.enabled = enabled;
+    return newState;
+  }
+
+  public Set<HttpMethod> getMethods() {
+    return methods;
+  }
+
+  RouteState setMethods(Set<HttpMethod> methods) {
+    RouteState newState = copy();
+    newState.methods = new HashSet<>(methods);
+    return newState;
+  }
+
+  public RouteState addMethod(HttpMethod method) {
+    RouteState newState = copy();
+    newState.methods = this.methods == null ? new HashSet<>() : new HashSet<>(this.methods);
+    newState.methods.add(method);
+    return newState;
+  }
+
+  public Set<MIMEHeader> getConsumes() {
+    return consumes;
+  }
+
+  RouteState setConsumes(Set<MIMEHeader> consumes) {
+    RouteState newState = copy();
+    newState.consumes = new HashSet<>(consumes);
+    return newState;
+  }
+
+  RouteState addConsume(MIMEHeader mime) {
+    RouteState newState = copy();
+    newState.consumes = this.consumes == null ? new HashSet<>() : new HashSet<>(this.consumes);
+    newState.consumes.add(mime);
+    return newState;
+  }
+
+  public boolean isEmptyBodyPermittedWithConsumes() {
+    return emptyBodyPermittedWithConsumes;
+  }
+
+  RouteState setEmptyBodyPermittedWithConsumes(boolean emptyBodyPermittedWithConsumes) {
+    RouteState newState = copy();
+    newState.emptyBodyPermittedWithConsumes = emptyBodyPermittedWithConsumes;
+    return newState;
+  }
+
+  public Set<MIMEHeader> getProduces() {
+    return produces;
+  }
+
+  RouteState setProduces(Set<MIMEHeader> produces) {
+    RouteState newState = copy();
+    newState.produces = new HashSet<>(produces);
+    return newState;
+  }
+
+  RouteState addProduce(MIMEHeader mime) {
+    RouteState newState = copy();
+    newState.produces = this.produces == null ? new HashSet<>() : new HashSet<>(this.produces);
+    newState.produces.add(mime);
+    return newState;
+  }
+
+  public List<Handler<RoutingContext>> getContextHandlers() {
+    return contextHandlers;
+  }
+
+  public int getContextHandlersLength() {
+    return contextHandlers == null ? 0 : contextHandlers.size();
+  }
+
+  RouteState setContextHandlers(List<Handler<RoutingContext>> contextHandlers) {
+    RouteState newState = copy();
+    newState.contextHandlers = new ArrayList<>(contextHandlers);
+    return newState;
+  }
+
+  RouteState addContextHandler(Handler<RoutingContext> contextHandler) {
+    RouteState newState = copy();
+    newState.contextHandlers = this.contextHandlers == null ? new ArrayList<>() : new ArrayList<>(this.contextHandlers);
+    newState.contextHandlers.add(contextHandler);
+    return newState;
+  }
+
+  public List<Handler<RoutingContext>> getFailureHandlers() {
+    return failureHandlers;
+  }
+
+  public int getFailureHandlersLength() {
+    return failureHandlers == null ? 0 : failureHandlers.size();
+  }
+
+  RouteState setFailureHandlers(List<Handler<RoutingContext>> failureHandlers) {
+    RouteState newState = copy();
+    newState.failureHandlers = new ArrayList<>(failureHandlers);
+    return newState;
+  }
+
+  RouteState addFailureHandler(Handler<RoutingContext> failureHandler) {
+    RouteState newState = copy();
+    newState.failureHandlers = this.failureHandlers == null ? new ArrayList<>() : new ArrayList<>(this.failureHandlers);
+    newState.failureHandlers.add(failureHandler);
+    return newState;
+  }
+
+  public boolean isAdded() {
+    return added;
+  }
+
+  RouteState setAdded(boolean added) {
+    RouteState newState = copy();
+    newState.added = added;
+    return newState;
+  }
+
+  public Pattern getPattern() {
+    return pattern;
+  }
+
+  RouteState setPattern(Pattern pattern) {
+    RouteState newState = copy();
+    newState.pattern = pattern;
+    return newState;
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+  RouteState setGroups(List<String> groups) {
+    RouteState newState = copy();
+    newState.groups = new ArrayList<>(groups);
+    return newState;
+  }
+
+  RouteState addGroup(String group) {
+    RouteState newState = copy();
+    newState.groups = this.groups == null ? new ArrayList<>() : new ArrayList<>(groups);
+    newState.groups.add(group);
+    return newState;
+  }
+
+  public boolean isUseNormalisedPath() {
+    return useNormalisedPath;
+  }
+
+  RouteState setUseNormalisedPath(boolean useNormalisedPath) {
+    RouteState newState = copy();
+    newState.useNormalisedPath = useNormalisedPath;
+    return newState;
+  }
+
+  public Set<String> getNamedGroupsInRegex() {
+    return namedGroupsInRegex;
+  }
+
+  RouteState setNamedGroupsInRegex(Set<String> namedGroupsInRegex) {
+    RouteState newState = copy();
+    newState.namedGroupsInRegex = new HashSet<>(namedGroupsInRegex);
+    return newState;
+  }
+
+  RouteState addNamedGroupInRegex(String namedGroupInRegex) {
+    RouteState newState = copy();
+    newState.namedGroupsInRegex = this.namedGroupsInRegex == null ? new HashSet<>() : new HashSet<>(this.namedGroupsInRegex);
+    newState.namedGroupsInRegex.add(namedGroupInRegex);
+    return newState;
+  }
+
+  public Pattern getVirtualHostPattern() {
+    return virtualHostPattern;
+  }
+
+  RouteState setVirtualHostPattern(Pattern virtualHostPattern) {
+    RouteState newState = copy();
+    newState.virtualHostPattern = virtualHostPattern;
+    return newState;
+  }
+
+  public boolean isPathEndsWithSlash() {
+    return pathEndsWithSlash;
+  }
+
+  RouteState setPathEndsWithSlash(boolean pathEndsWithSlash) {
+    RouteState newState = copy();
+    newState.pathEndsWithSlash = pathEndsWithSlash;
+    return newState;
+  }
+
+  public boolean isExclusive() {
+    return exclusive;
+  }
+
+  RouteState setExclusive(boolean exclusive) {
+    RouteState newState = copy();
+    newState.exclusive = exclusive;
+    return newState;
+  }
+
+  public boolean isExactPath() {
+    return exactPath;
+  }
+
+  RouteState setExactPath(boolean exactPath) {
+    RouteState newState = copy();
+    newState.exactPath = exactPath;
+    return newState;
+  }
+
+  private static <T> boolean contains(Collection<T> collection, T value) {
+    return collection != null && !collection.isEmpty() && collection.contains(value);
+  }
+
+  private static <T> boolean isEmpty(Collection<T> collection) {
+    return collection == null || collection.isEmpty();
+  }
+
+  /**
+   * @return 0 if route matches, otherwise it return the status code
+   */
+  public int matches(RoutingContextImplBase context, String mountPoint, boolean failure) {
+
+    if (failure && !hasNextFailureHandler(context) || !failure && !hasNextContextHandler(context)) {
+      return 404;
+    }
+    if (!enabled) {
+      return 404;
+    }
+    HttpServerRequest request = context.request();
+    if (path != null && pattern == null && !pathMatches(mountPoint, context)) {
+      return 404;
+    }
+    if (pattern != null) {
+      String path = useNormalisedPath ? context.normalisedPath() : context.request().path();
+      if (mountPoint != null) {
+        path = path.substring(mountPoint.length());
+      }
+
+      Matcher m = pattern.matcher(path);
+      if (m.matches()) {
+
+        if (!isEmpty(methods) && !contains(methods, request.method())) {
+          // If I'm here path or path pattern matches, but the method is wrong
+          return 405;
+        }
+
+        context.matchRest = -1;
+        context.matchNormalized = useNormalisedPath;
+
+        if (m.groupCount() > 0) {
+          if (!exactPath) {
+            context.matchRest = m.start("rest");
+          }
+
+          if (!isEmpty(groups)) {
+            // Pattern - named params
+            // decode the path as it could contain escaped chars.
+            for (int i = 0; i < Math.min(groups.size(), m.groupCount()); i++) {
+              final String k = groups.get(i);
+              String undecodedValue;
+              // We try to take value in three ways:
+              // 1. group name of type p0, p1, pN (most frequent and used by vertx params)
+              // 2. group name inside the regex
+              // 3. No group name
+              try {
+                undecodedValue = m.group("p" + i);
+              } catch (IllegalArgumentException e) {
+                try {
+                  undecodedValue = m.group(k);
+                } catch (IllegalArgumentException e1) {
+                  // Groups starts from 1 (0 group is total match)
+                  undecodedValue = m.group(i + 1);
+                }
+              }
+              addPathParam(context, k, undecodedValue);
+            }
+          } else {
+            // Straight regex - un-named params
+            // decode the path as it could contain escaped chars.
+            if (!isEmpty(namedGroupsInRegex)) {
+              for (String namedGroup : namedGroupsInRegex) {
+                String namedGroupValue = m.group(namedGroup);
+                if (namedGroupValue != null) {
+                  addPathParam(context, namedGroup, namedGroupValue);
+                }
+              }
+            }
+            for (int i = 0; i < m.groupCount(); i++) {
+              String group = m.group(i + 1);
+              if (group != null) {
+                final String k = "param" + i;
+                addPathParam(context, k, group);
+              }
+            }
+          }
+        }
+      } else {
+        return 404;
+      }
+    } else {
+      // no pattern check for wrong method
+      if (!isEmpty(methods) && !contains(methods, request.method())) {
+        // If I'm here path or path pattern matches, but the method is wrong
+        return 405;
+      }
+    }
+
+    if (!isEmpty(consumes)) {
+      // Can this route consume the specified content type
+      MIMEHeader contentType = context.parsedHeaders().contentType();
+      MIMEHeader consumal = contentType.findMatchedBy(consumes);
+      if (consumal == null && !(contentType.rawValue().isEmpty() && emptyBodyPermittedWithConsumes)) {
+        if (contentType.rawValue().isEmpty()) {
+          return 400;
+        } else {
+          return 415;
+        }
+      }
+    }
+    List<MIMEHeader> acceptableTypes = context.parsedHeaders().accept();
+    if (!isEmpty(produces) && !acceptableTypes.isEmpty()) {
+      MIMEHeader selectedAccept = context.parsedHeaders().findBestUserAcceptedIn(acceptableTypes, produces);
+      if (selectedAccept != null) {
+        context.setAcceptableContentType(selectedAccept.rawValue());
+      } else {
+        return 406;
+      }
+    }
+    if (!virtualHostMatches(context.request.host())) {
+      return 404;
+    }
+    return 0;
+  }
+
+  private boolean pathMatches(String mountPoint, RoutingContext ctx) {
+    String thePath = mountPoint == null ? path : mountPoint + path;
+    String requestPath;
+
+    if (useNormalisedPath) {
+      // never null
+      requestPath = ctx.normalisedPath();
+    } else {
+      requestPath = ctx.request().path();
+      // can be null
+      if (requestPath == null) {
+        requestPath = "/";
+      }
+    }
+
+    if (exactPath) {
+      return pathMatchesExact(requestPath, thePath);
+    } else {
+      if (pathEndsWithSlash && (requestPath.charAt(requestPath.length() - 1) == '/'
+        ? requestPath.equals(thePath) : thePath.regionMatches(0, requestPath, 0, requestPath.length()))) {
+        return true;
+      }
+      return requestPath.startsWith(thePath);
+    }
+  }
+
+  private boolean virtualHostMatches(String host) {
+    if (virtualHostPattern == null) return true;
+    boolean match = false;
+    for (String h : host.split(":")) {
+      if (virtualHostPattern.matcher(h).matches()) {
+        match = true;
+        break;
+      }
+    }
+    return match;
+  }
+
+  private boolean pathMatchesExact(String path1, String path2) {
+    // Ignore trailing slash when matching paths
+    final int idx1 = path1.length() - 1;
+    return pathEndsWithSlash ?
+      (path1.charAt(idx1) == '/' ? path1.equals(path2) : path2.regionMatches(0, path1, 0, path1.length()))
+      : (path1.charAt(idx1) != '/' ? path1.equals(path2) : path1.regionMatches(0, path2, 0, path2.length()));
+  }
+
+  private void addPathParam(RoutingContext context, String name, String value) {
+    HttpServerRequest request = context.request();
+    final String decodedValue = URIDecoder.decodeURIComponent(value, false);
+    if (!request.params().contains(name)) {
+      request.params().add(name, decodedValue);
+    }
+    context.pathParams().put(name, decodedValue);
+  }
+
+  boolean hasNextContextHandler(RoutingContextImplBase context) {
+    return context.currentRouteNextHandlerIndex() < getContextHandlersLength();
+  }
+
+  boolean hasNextFailureHandler(RoutingContextImplBase context) {
+    return context.currentRouteNextFailureHandlerIndex() < getFailureHandlersLength();
+  }
+
+  void handleContext(RoutingContextImplBase context) {
+    contextHandlers
+      .get(context.currentRouteNextHandlerIndex() - 1)
+      .handle(context);
+  }
+
+  void handleFailure(RoutingContextImplBase context) {
+    failureHandlers
+      .get(context.currentRouteNextFailureHandlerIndex() - 1)
+      .handle(context);
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -338,5 +338,14 @@ public class RouterImpl implements Router {
       }
     }
   }
+
+  @Override
+  public String toString() {
+    return "RouterImpl@" + System.identityHashCode(this) +
+      "{" +
+      "vertx=" + vertx +
+      ", state=" + state +
+      '}';
+  }
 }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -27,9 +27,6 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class is thread-safe
@@ -38,70 +35,53 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RouterImpl implements Router {
 
-  private static final Comparator<RouteImpl> routeComparator = (RouteImpl o1, RouteImpl o2) -> {
-    // we keep a set of handlers ordered by its "order" property
-    final int compare = Integer.compare(o1.order(), o2.order());
-    // since we are defining the comparator to order the set we must be careful because the set
-    // will use the comparator to compare the identify of the handlers and if they are the same order
-    // are assumed to be the same comparator and therefore removed from the set.
-
-    // if the 2 routes being compared by its order have the same order property value,
-    // then do a more expensive equality check and if and only if the are the same we
-    // do return 0, meaning same order and same identity.
-    if (compare == 0) {
-      if (o1.equals(o2)) {
-        return 0;
-      }
-      // otherwise we return higher so if 2 routes have the same order the second one will be considered
-      // higher so it is added after the first.
-      return 1;
-    }
-    return compare;
-  };
-
   private static final Logger log = LoggerFactory.getLogger(RouterImpl.class);
 
   private final Vertx vertx;
-  private final Set<RouteImpl> routes = new ConcurrentSkipListSet<>(routeComparator);
-  private final AtomicInteger orderSequence = new AtomicInteger();
+
+  private volatile RouterState state;
 
   public RouterImpl(Vertx vertx) {
     this.vertx = vertx;
+    this.state = new RouterState(this);
   }
-
-  private Map<Integer, Handler<RoutingContext>> errorHandlers = new ConcurrentHashMap<>();
-  private Handler<Router> modifiedHandler;
 
   @Override
   public void handle(HttpServerRequest request) {
-    if (log.isTraceEnabled()) log.trace("Router: " + System.identityHashCode(this) +
-      " accepting request " + request.method() + " " + request.absoluteURI());
-    new RoutingContextImpl(null, this, request, routes).next();
+    if (log.isTraceEnabled()) {
+      log.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
+    }
+    new RoutingContextImpl(null, this, request, state.getRoutes()).next();
   }
 
   @Override
-  public Route route() {
-    return new RouteImpl(this, orderSequence.getAndIncrement());
+  public synchronized Route route() {
+    state = state.incrementOrderSequence();
+    return new RouteImpl(this, state.getOrderSequence());
   }
 
   @Override
-  public Route route(HttpMethod method, String path) {
-    return new RouteImpl(this, orderSequence.getAndIncrement(), method, path);
+  public synchronized Route route(HttpMethod method, String path) {
+    state = state.incrementOrderSequence();
+    return new RouteImpl(this, state.getOrderSequence(), method, path);
   }
 
   @Override
-  public Route route(String path) {
-    return new RouteImpl(this, orderSequence.getAndIncrement(), path);
+  public synchronized Route route(String path) {
+    state = state.incrementOrderSequence();
+    return new RouteImpl(this, state.getOrderSequence(), path);
   }
 
   @Override
-  public Route routeWithRegex(HttpMethod method, String regex) {
-    return new RouteImpl(this, orderSequence.getAndIncrement(), method, regex, true);
+  public synchronized Route routeWithRegex(HttpMethod method, String regex) {
+    state = state.incrementOrderSequence();
+    return new RouteImpl(this, state.getOrderSequence(), method, regex, true);
   }
 
   @Override
-  public Route routeWithRegex(String regex) {
-    return new RouteImpl(this, orderSequence.getAndIncrement(), regex, true);
+  public synchronized Route routeWithRegex(String regex) {
+    state = state.incrementOrderSequence();
+    return new RouteImpl(this, state.getOrderSequence(), regex, true);
   }
 
   @Override
@@ -241,34 +221,33 @@ public class RouterImpl implements Router {
 
   @Override
   public List<Route> getRoutes() {
-    return new ArrayList<>(routes);
+    return new ArrayList<>(state.getRoutes());
   }
 
   @Override
-  public Router clear() {
-    routes.clear();
+  public synchronized Router clear() {
+    state = state.clearRoutes();
     return this;
   }
 
   @Override
   public void handleContext(RoutingContext ctx) {
-    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), routes, ctx).next();
+    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), state.getRoutes(), ctx).next();
   }
 
   @Override
   public void handleFailure(RoutingContext ctx) {
-    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), routes, ctx).next();
+    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), state.getRoutes(), ctx).next();
   }
 
   @Override
-  public Router modifiedHandler(Handler<Router> handler) {
-    if (this.modifiedHandler == null) {
-      this.modifiedHandler = handler;
+  public synchronized Router modifiedHandler(Handler<Router> handler) {
+    if (state.getModifiedHandler() == null) {
+      state = state.setModifiedHandler(handler);
     } else {
       // chain the handler
-      final Handler<Router> previousHandler = this.modifiedHandler;
-
-      this.modifiedHandler = router -> {
+      final Handler<Router> previousHandler = state.getModifiedHandler();
+      state = state.setModifiedHandler(router -> {
         try {
           previousHandler.handle(router);
         } catch (RuntimeException e) {
@@ -280,7 +259,7 @@ public class RouterImpl implements Router {
         } catch (RuntimeException e) {
           log.error("Router modified notification failed", e);
         }
-      };
+      });
     }
     return this;
   }
@@ -307,25 +286,24 @@ public class RouterImpl implements Router {
   }
 
   @Override
-  public Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler) {
-    Objects.requireNonNull(errorHandler);
-    this.errorHandlers.put(statusCode, errorHandler);
+  public synchronized Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler) {
+    state = state.putErrorHandler(statusCode, errorHandler);
     return this;
   }
 
-  void add(RouteImpl route) {
-    routes.add(route);
+  synchronized void add(RouteImpl route) {
+    state = state.addRoute(route);
     // notify the listeners as the routes are changed
-    if (modifiedHandler != null) {
-      modifiedHandler.handle(this);
+    if (state.getModifiedHandler() != null) {
+      state.getModifiedHandler().handle(this);
     }
   }
 
-  void remove(RouteImpl route) {
-    routes.remove(route);
+  synchronized void remove(RouteImpl route) {
+    state = state.removeRoute(route);
     // notify the listeners as the routes are changed
-    if (modifiedHandler != null) {
-      modifiedHandler.handle(this);
+    if (state.getModifiedHandler() != null) {
+      state.getModifiedHandler().handle(this);
     }
   }
 
@@ -334,11 +312,11 @@ public class RouterImpl implements Router {
   }
 
   Iterator<RouteImpl> iterator() {
-    return routes.iterator();
+    return state.getRoutes().iterator();
   }
 
   Handler<RoutingContext> getErrorHandlerByStatusCode(int statusCode) {
-    return errorHandlers.get(statusCode);
+    return state.getErrorHandler(statusCode);
   }
 
   private String getAndCheckRoutePath(RoutingContext routingContext) {
@@ -361,3 +339,4 @@ public class RouterImpl implements Router {
     }
   }
 }
+

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterState.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.*;
+
+/**
+ * This class encapsulates the router state, all mutations are atomic and return a new state with the mutation.
+ *
+ * This class is thread-safe
+ *
+ * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
+ */
+final class RouterState {
+
+  private static final Comparator<RouteImpl> routeComparator = (RouteImpl o1, RouteImpl o2) -> {
+    // we keep a set of handlers ordered by its "order" property
+    final int compare = Integer.compare(o1.order(), o2.order());
+    // since we are defining the comparator to order the set we must be careful because the set
+    // will use the comparator to compare the identify of the handlers and if they are the same order
+    // are assumed to be the same comparator and therefore removed from the set.
+
+    // if the 2 routes being compared by its order have the same order property value,
+    // then do a more expensive equality check and if and only if the are the same we
+    // do return 0, meaning same order and same identity.
+    if (compare == 0) {
+      if (o1.equals(o2)) {
+        return 0;
+      }
+      // otherwise we return higher so if 2 routes have the same order the second one will be considered
+      // higher so it is added after the first.
+      return 1;
+    }
+    return compare;
+  };
+
+  private final RouterImpl router;
+
+  private Set<RouteImpl> routes;
+  private int orderSequence;
+  private Map<Integer, Handler<RoutingContext>> errorHandlers;
+  private Handler<Router> modifiedHandler;
+
+
+  public RouterState(RouterImpl router) {
+    this.router = router;
+  }
+
+  public RouterImpl router() {
+    return router;
+  }
+
+  public Set<RouteImpl> getRoutes() {
+    if (routes == null) {
+      return Collections.emptySet();
+    }
+    return routes;
+  }
+
+  RouterState setRoutes(Set<RouteImpl> routes) {
+    RouterState newState = copy();
+    newState.routes = new TreeSet<>(routeComparator);
+    newState.routes.addAll(routes);
+    return newState;
+  }
+
+  RouterState addRoute(RouteImpl route) {
+    RouterState newState = copy();
+    newState.routes = new TreeSet<>(routeComparator);
+    if (this.routes != null) {
+      newState.routes.addAll(this.routes);
+    }
+    newState.routes.add(route);
+    return newState;
+  }
+
+  RouterState clearRoutes() {
+    RouterState newState = copy();
+    newState.routes = new TreeSet<>(routeComparator);
+    return newState;
+  }
+
+  RouterState removeRoute(RouteImpl route) {
+    RouterState newState = copy();
+    newState.routes = new TreeSet<>(routeComparator);
+    newState.routes.addAll(this.routes);
+    newState.routes.remove(route);
+    return newState;
+  }
+
+  public int getOrderSequence() {
+    return orderSequence;
+  }
+
+  RouterState incrementOrderSequence() {
+    RouterState newState = copy();
+    newState.orderSequence++;
+    return newState;
+  }
+
+  RouterState setOrderSequence(int orderSequence) {
+    RouterState newState = copy();
+    newState.orderSequence = orderSequence;
+    return newState;
+  }
+
+  public Map<Integer, Handler<RoutingContext>> getErrorHandlers() {
+    return errorHandlers;
+  }
+
+  RouterState setErrorHandlers(Map<Integer, Handler<RoutingContext>> errorHandlers) {
+    RouterState newState = copy();
+    newState.errorHandlers = new HashMap<>(errorHandlers);
+    return newState;
+  }
+
+  Handler<RoutingContext> getErrorHandler(int errorCode) {
+    if (errorHandlers != null) {
+      return errorHandlers.get(errorCode);
+    }
+    return null;
+  }
+
+  RouterState putErrorHandler(int errorCode, Handler<RoutingContext> errorHandler) {
+    RouterState newState = copy();
+    newState.errorHandlers = this.errorHandlers == null ? new HashMap<>() : new HashMap<>(errorHandlers);
+    newState.errorHandlers.put(errorCode, errorHandler);
+    return newState;
+  }
+
+  public Handler<Router> getModifiedHandler() {
+    return modifiedHandler;
+  }
+
+  public RouterState setModifiedHandler(Handler<Router> modifiedHandler) {
+    RouterState newState = copy();
+    newState.modifiedHandler = modifiedHandler;
+    return newState;
+  }
+
+  RouterState copy() {
+    RouterState newState = new RouterState(this.router);
+
+    newState.routes = this.routes;
+    newState.orderSequence = this.orderSequence;
+    newState.errorHandlers = this.errorHandlers;
+    newState.modifiedHandler = this.modifiedHandler;
+
+    return newState;
+  }
+}


### PR DESCRIPTION
This PR will remove all locking from the hotpath by introducing a copy on write state for routes and routers.

All mutations are now more expensive (with synchronized blocks) however these should happen mostly all at startup and almost never at runtime.

At runtime the state is locked so all acesses do not need synchronized blocks or locking.