### PR TITLE
Backport new date header parsing from master

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
@@ -27,9 +27,6 @@ import io.vertx.ext.web.handler.LoggerHandler;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.Utils;
 
-import java.text.DateFormat;
-import java.util.Date;
-
 /** # Logger
  *
  * Logger for request. There are 3 formats included:
@@ -47,10 +44,6 @@ import java.util.Date;
 public class LoggerHandlerImpl implements LoggerHandler {
 
   private final io.vertx.core.logging.Logger logger = LoggerFactory.getLogger(this.getClass());
-
-  /** The Date formatter (UTC JS compatible format)
-   */
-  private final DateFormat dateTimeFormat = Utils.createRFC1123DateTimeFormatter();
 
   /** log before request or after
    */
@@ -119,7 +112,7 @@ public class LoggerHandlerImpl implements LoggerHandler {
 
         message = String.format("%s - - [%s] \"%s %s %s\" %d %d \"%s\" \"%s\"",
           remoteClient,
-          dateTimeFormat.format(new Date(timestamp)),
+          Utils.formatRFC1123DateTime(timestamp),
           method,
           uri,
           versionFormatted,

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -32,6 +32,12 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -91,10 +97,19 @@ public class Utils extends io.vertx.core.impl.Utils {
     }
   }
 
-  public static DateFormat createRFC1123DateTimeFormatter() {
-    DateFormat dtf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
-    dtf.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return dtf;
+  private static final ZoneId ZONE_GMT = ZoneId.of("GMT");
+
+  public static String formatRFC1123DateTime(final long time) {
+    return DateTimeFormatter.RFC_1123_DATE_TIME.format(Instant.ofEpochMilli(time).atZone(ZONE_GMT));
+  }
+
+  public static long parseRFC1123DateTime(final String header) {
+    try {
+      return header == null || header.isEmpty() ? -1 :
+        LocalDateTime.parse(header, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant(ZoneOffset.UTC).toEpochMilli();
+    } catch (DateTimeParseException ex) {
+      return -1;
+    }
   }
 
   public static String pathOffset(String path, RoutingContext context) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CookieHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CookieHandlerTest.java
@@ -22,7 +22,6 @@ import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.WebTestBase;
 import org.junit.Test;
 
-import java.text.DateFormat;
 import java.util.*;
 
 /**
@@ -137,8 +136,8 @@ public class CookieHandlerTest extends WebTestBase {
     int startPos = encoded.indexOf("Expires=");
     int endPos = encoded.indexOf(';', startPos);
     String expiresDate = encoded.substring(startPos + 8, endPos);
-    Date d = dateTimeFormat.parse(expiresDate);
-    assertTrue(d.getTime() - now >= maxAge);
+    long d = Utils.parseRFC1123DateTime(expiresDate);
+    assertTrue(d - now >= maxAge);
 
     cookie.setMaxAge(Long.MIN_VALUE);
     cookie.setSecure(true);
@@ -146,6 +145,4 @@ public class CookieHandlerTest extends WebTestBase {
     cookie.setHttpOnly(true);
     assertEquals("foo=bar; Path=/somepath; Domain=foo.com; Secure; HTTPOnly", cookie.encode());
   }
-
-  private final DateFormat dateTimeFormat = Utils.createRFC1123DateTimeFormatter();
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SessionHandlerTestBase.java
@@ -19,13 +19,11 @@ package io.vertx.ext.web.handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.WebTestBase;
-import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.sstore.AbstractSession;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.Test;
 
-import java.text.DateFormat;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -359,8 +357,6 @@ public abstract class SessionHandlerTestBase extends WebTestBase {
 		testRequest(HttpMethod.GET, "/", req -> req.putHeader("cookie", sessionID.get()),
 				resp -> assertNull(resp.headers().get("set-cookie")), 200, "OK", null);
 	}
-
-	private final DateFormat dateTimeFormatter = Utils.createRFC1123DateTimeFormatter();
 
 	protected long doTestSessionRetryTimeout() throws Exception {
 		router.route().handler(SessionHandler.create(store));


### PR DESCRIPTION
In master date parsing was already using the new time API which is thread safe.
Fixes #1429 