### PR TITLE
Swagger parser version dump for 3.8

### DIFF
--- a/vertx-web-api-contract/pom.xml
+++ b/vertx-web-api-contract/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser-v3</artifactId>
-      <version>2.0.11</version>
+      <version>2.0.15</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Depends on https://github.com/vert-x3/vertx-camel-bridge/pull/31