### PR TITLE
Significant final slash applies to all kinds of routes

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -66,7 +66,7 @@ import static io.vertx.core.buffer.Buffer.*;
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-public class SockJSHandlerImpl implements SockJSHandler, Handler<RoutingContext> {
+public class SockJSHandlerImpl implements SockJSHandler {
 
   private static final Logger log = LoggerFactory.getLogger(SockJSHandlerImpl.class);
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -267,7 +267,7 @@ public class RouterImpl implements Router {
   @Override
   public Router mountSubRouter(String mountPoint, Router subRouter) {
     if (mountPoint.endsWith("*")) {
-      throw new IllegalArgumentException("Don't include * when mounting subrouter");
+      throw new IllegalArgumentException("Don't include * when mounting a sub router");
     }
 
     route(mountPoint + "*")

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -46,11 +46,18 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
     super(mountPoint, request, iter);
     this.inner = inner;
     String parentMountPoint = inner.mountPoint();
-    if (mountPoint.charAt(mountPoint.length() - 1) == '/') {
-      // Remove the trailing slash or we won't match
-      mountPoint = mountPoint.substring(0, mountPoint.length() - 1);
+    if (parentMountPoint == null) {
+      // just use the override
+      this.mountPoint = mountPoint;
+    } else {
+      if (parentMountPoint.charAt(parentMountPoint.length() - 1) == '/') {
+        // Remove the trailing slash or we won't match
+        this.mountPoint = parentMountPoint.substring(0, parentMountPoint.length() - 1) + mountPoint;
+      } else {
+        // slashes are ok, just concat
+        this.mountPoint = parentMountPoint + mountPoint;
+      }
     }
-    this.mountPoint = parentMountPoint == null ? mountPoint : parentMountPoint + mountPoint;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -112,6 +112,10 @@ public class Utils extends io.vertx.core.impl.Utils {
     String mountPoint = context.mountPoint();
     if (mountPoint != null) {
       prefixLen = mountPoint.length();
+      // special case we need to verify if a trailing slash  is present and exclude
+      if (mountPoint.charAt(mountPoint.length() - 1) == '/') {
+        prefixLen--;
+      }
     }
     String routePath = context.currentRoute().getPath();
     if (routePath != null) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1459,6 +1459,7 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testGetWithPathExact() throws Exception {
     router.get("/somepath/").handler(rc -> rc.response().setStatusMessage("foo").end());
+    testRequest(HttpMethod.GET, "/somepath", 404, "Not Found");
     testRequest(HttpMethod.GET, "/somepath/", 200, "foo");
     testRequest(HttpMethod.GET, "/otherpath/whatever", 404, "Not Found");
     testRequest(HttpMethod.POST, "/somepath/whatever", 404, "Not Found");
@@ -1752,7 +1753,8 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testRouteNormalised2() throws Exception {
     router.route("/foo/").handler(rc -> rc.response().setStatusMessage("socks").end());
-    testRequest(HttpMethod.GET, "/foo", 200, "socks");
+    // note that the final slash is significant
+    testRequest(HttpMethod.GET, "/foo", 404, "Not Found");
     testRequest(HttpMethod.GET, "/foo/", 200, "socks");
     testRequest(HttpMethod.GET, "//foo/", 200, "socks");
     testRequest(HttpMethod.GET, "//foo//", 200, "socks");

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -70,7 +70,7 @@ public class SubRouterTest extends WebTestBase {
     router.mountSubRouter("/subpath/", subRouter);
 
     subRouter.route("/foo").handler(rc -> {
-      assertEquals("/subpath", rc.mountPoint());
+      assertEquals("/subpath/", rc.mountPoint());
       rc.response().setStatusMessage(rc.request().path()).end();
     });
 


### PR DESCRIPTION
Fixes #1441 

This PR ensures that the concept of significant final slash applies to all kinds of routes:

* simple `/p/a/t/h/`
* wildcard `/p/a/t/h/*`
* variable/pattern `/p/:a/:t/:h/`
* sub-routes `/sub/*`

This way the usage is consistent across all kinds of uses.