### PR TITLE
Use route acceptableContentType as error mime type

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
@@ -91,6 +91,11 @@ public class ErrorHandlerImpl implements ErrorHandler {
     // does the response already set the mime type?
     String mime = context.response().headers().get(HttpHeaders.CONTENT_TYPE);
 
+    if(mime == null) {
+      // does the route have an acceptable content type?
+      mime = context.getAcceptableContentType();
+    }
+    
     return mime != null && sendError(context, mime, errorCode, errorMessage);
   }
 


### PR DESCRIPTION
Check if the route has matched an acceptable content type, when guessing a suitable error mime type.