### PR TITLE
Support for "forwarded"-type headers

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -394,7 +394,7 @@ public interface Router extends Handler<HttpServerRequest> {
   /**
    * Set whether the router should parse "forwarded"-type headers
    *
-   * @param allow {@code false} to enable parsing of "forwarded"-type headers
+   * @param allow to enable parsing of "forwarded"-type headers
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -389,4 +389,14 @@ public interface Router extends Handler<HttpServerRequest> {
    */
   @Fluent
   Router modifiedHandler(Handler<Router> handler);
+
+
+  /**
+   * Set whether the router should parse "forwarded"-type headers
+   *
+   * @param allow {@code false} to enable parsing of "forwarded"-type headers
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Router allowForward(boolean allow);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -1,5 +1,22 @@
-//Heavily influenced from spring forward header parser
-//https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java#L849
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+// This code was Heavily influenced from spring forward header parser
+// https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java#L849
+
 package io.vertx.ext.web.impl;
 
 import io.netty.util.AsciiString;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -1,0 +1,177 @@
+//Heavily influenced from spring forward header parser
+//https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java#L849
+package io.vertx.ext.web.impl;
+
+import io.netty.util.AsciiString;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.SocketAddressImpl;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ForwardedParser {
+  private static final Logger log = LoggerFactory.getLogger(RouterImpl.class);
+
+  private static final String HTTP_SCHEME = "http";
+  private static final String HTTPS_SCHEME = "https";
+  private static final AsciiString FORWARDED = AsciiString.cached("Forwarded");
+  private static final AsciiString X_FORWARDED_SSL = AsciiString.cached("X-Forwarded-Ssl");
+  private static final AsciiString X_FORWARDED_PROTO = AsciiString.cached("X-Forwarded-Proto");
+  private static final AsciiString X_FORWARDED_HOST = AsciiString.cached("X-Forwarded-Host");
+  private static final AsciiString X_FORWARDED_PORT = AsciiString.cached("X-Forwarded-Port");
+  private static final AsciiString X_FORWARDED_FOR = AsciiString.cached("X-Forwarded-For");
+
+  private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?");
+  private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
+  private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
+
+  private final HttpServerRequest delegate;
+  private final boolean allowForward;
+
+  private boolean calculated;
+  private String host;
+  private int port = -1;
+  private String scheme;
+  private String absoluteURI;
+  private SocketAddress remoteAddress;
+
+  ForwardedParser(HttpServerRequest delegate, boolean allowForward) {
+    this.delegate = delegate;
+    this.allowForward = allowForward;
+  }
+
+  public String scheme() {
+    if (!calculated)
+      calculate();
+    return scheme;
+  }
+
+  String host() {
+    if (!calculated)
+      calculate();
+    return host;
+  }
+
+  boolean isSSL() {
+    if (!calculated)
+      calculate();
+
+    return scheme.equals(HTTPS_SCHEME);
+  }
+
+  String absoluteURI() {
+    if (!calculated)
+      calculate();
+
+    return absoluteURI;
+  }
+
+  SocketAddress remoteAddress() {
+    if (!calculated)
+      calculate();
+
+    return remoteAddress;
+  }
+
+  private void calculate() {
+    calculated = true;
+    remoteAddress = delegate.remoteAddress();
+    scheme = delegate.scheme();
+    setHostAndPort(delegate.host(), port);
+
+    if (allowForward) {
+      String forwardedSsl = delegate.getHeader(X_FORWARDED_SSL);
+      boolean isForwardedSslOn = forwardedSsl != null && forwardedSsl.equalsIgnoreCase("on");
+
+      String forwarded = delegate.getHeader(FORWARDED);
+      if (forwarded != null) {
+        String forwardedToUse = forwarded.split(",")[0];
+        Matcher matcher = FORWARDED_PROTO_PATTERN.matcher(forwardedToUse);
+        if (matcher.find()) {
+          scheme = (matcher.group(1).trim());
+          port = -1;
+        } else if (isForwardedSslOn) {
+          scheme = HTTPS_SCHEME;
+          port = -1;
+        }
+
+        matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
+        if (matcher.find()) {
+          setHostAndPort(matcher.group(1).trim(), port);
+        }
+
+        matcher = FORWARDED_FOR_PATTERN.matcher(forwardedToUse);
+        if (matcher.find()) {
+          remoteAddress = parseFor(matcher.group(1).trim(), remoteAddress.port());
+        }
+      } else {
+        String protocolHeader = delegate.getHeader(X_FORWARDED_PROTO);
+        if (protocolHeader != null) {
+          scheme = protocolHeader.split(",")[0];
+          port = -1;
+        } else if (isForwardedSslOn) {
+          scheme = HTTPS_SCHEME;
+          port = -1;
+        }
+
+        String hostHeader = delegate.getHeader(X_FORWARDED_HOST);
+        if (hostHeader != null) {
+          setHostAndPort(hostHeader.split(",")[0], port);
+        }
+
+        String portHeader = delegate.getHeader(X_FORWARDED_PORT);
+        if (portHeader != null) {
+          port = parsePort(portHeader.split(",")[0], port);
+        }
+
+        String forHeader = delegate.getHeader(X_FORWARDED_FOR);
+        if (forHeader != null) {
+          remoteAddress = parseFor(forHeader.split(",")[0], remoteAddress.port());
+        }
+      }
+    }
+
+    if (((scheme.equals(HTTP_SCHEME) && port == 80) || (scheme.equals(HTTPS_SCHEME) && port == 443))) {
+      port = -1;
+    }
+
+    host = host + (port >= 0 ? ":" + port : "");
+    absoluteURI = scheme + "://" + host + delegate.uri();
+  }
+
+  private void setHostAndPort(String hostToParse, int defaultPort) {
+    int portSeparatorIdx = hostToParse.lastIndexOf(':');
+    if (portSeparatorIdx > hostToParse.lastIndexOf(']')) {
+      host = hostToParse.substring(0, portSeparatorIdx);
+      port = parsePort(hostToParse.substring(portSeparatorIdx + 1), defaultPort);
+    } else {
+      host = hostToParse;
+      port = -1;
+    }
+  }
+
+  private SocketAddress parseFor(String forToParse, int defaultPort) {
+    String host = forToParse;
+    int port = defaultPort;
+    int portSeparatorIdx = forToParse.lastIndexOf(':');
+    if (portSeparatorIdx > forToParse.lastIndexOf(']')) {
+      host = forToParse.substring(0, portSeparatorIdx);
+      port = parsePort(forToParse.substring(portSeparatorIdx + 1), defaultPort);
+    }
+
+    return new SocketAddressImpl(port, host);
+  }
+
+
+  private int parsePort(String portToParse, int defaultPort) {
+    try {
+      return Integer.parseInt(portToParse);
+    } catch (NumberFormatException ignored) {
+      log.error("Failed to parse a port from \"forwarded\"-type headers.");
+      return defaultPort;
+    }
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -17,6 +17,7 @@ import java.util.Map;
 class HttpServerRequestWrapper implements HttpServerRequest {
 
   private final HttpServerRequest delegate;
+  private final ForwardedParser forwardedParser;
 
   private boolean modified;
 
@@ -27,8 +28,9 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   private String uri;
   private String absoluteURI;
 
-  HttpServerRequestWrapper(HttpServerRequest request) {
+  HttpServerRequestWrapper(HttpServerRequest request, boolean allowForward) {
     delegate = request;
+    forwardedParser = new ForwardedParser(delegate, allowForward);
   }
 
   void changeTo(HttpMethod method, String uri) {
@@ -186,7 +188,7 @@ class HttpServerRequestWrapper implements HttpServerRequest {
 
   @Override
   public SocketAddress remoteAddress() {
-    return delegate.remoteAddress();
+    return forwardedParser.remoteAddress();
   }
 
   @Override
@@ -207,11 +209,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   @Override
   public String absoluteURI() {
     if (!modified) {
-      return delegate.absoluteURI();
+      return forwardedParser.absoluteURI();
     } else {
       if (absoluteURI == null) {
-        String scheme = delegate.scheme();
-        String host = delegate.host();
+        String scheme = forwardedParser.scheme();
+        String host = forwardedParser.host();
 
         // if both are not null we can rebuild the uri
         if (scheme != null && host != null) {
@@ -227,12 +229,12 @@ class HttpServerRequestWrapper implements HttpServerRequest {
 
   @Override
   public String scheme() {
-    return delegate.scheme();
+    return forwardedParser.scheme();
   }
 
   @Override
   public String host() {
-    return delegate.host();
+    return forwardedParser.host();
   }
 
   @Override
@@ -293,7 +295,7 @@ class HttpServerRequestWrapper implements HttpServerRequest {
 
   @Override
   public boolean isSSL() {
-    return delegate.isSSL();
+    return forwardedParser.isSSL();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -909,7 +909,7 @@ final class RouteState {
         return 406;
       }
     }
-    if (!virtualHostMatches(context.request.host())) {
+    if (!virtualHostMatches(context.request().host())) {
       return 404;
     }
     return 0;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -40,6 +40,7 @@ public class RouterImpl implements Router {
   private final Vertx vertx;
 
   private volatile RouterState state;
+  private boolean allowForward;
 
   public RouterImpl(Vertx vertx) {
     this.vertx = vertx;
@@ -51,7 +52,7 @@ public class RouterImpl implements Router {
     if (log.isTraceEnabled()) {
       log.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
     }
-    new RoutingContextImpl(null, this, request, state.getRoutes()).next();
+    new RoutingContextImpl(null, this, request, state.getRoutes(), allowForward).next();
   }
 
   @Override
@@ -232,12 +233,12 @@ public class RouterImpl implements Router {
 
   @Override
   public void handleContext(RoutingContext ctx) {
-    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), state.getRoutes(), ctx).next();
+    new RoutingContextWrapper(getAndCheckRoutePath(ctx), state.getRoutes(), ctx).next();
   }
 
   @Override
   public void handleFailure(RoutingContext ctx) {
-    new RoutingContextWrapper(getAndCheckRoutePath(ctx), ctx.request(), state.getRoutes(), ctx).next();
+    new RoutingContextWrapper(getAndCheckRoutePath(ctx), state.getRoutes(), ctx).next();
   }
 
   @Override
@@ -261,6 +262,12 @@ public class RouterImpl implements Router {
         }
       });
     }
+    return this;
+  }
+
+  @Override
+  public Router allowForward(boolean allow) {
+    this.allowForward = allow;
     return this;
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RoutingContextImpl extends RoutingContextImplBase {
 
   private final RouterImpl router;
+  private final HttpServerRequest request;
   private Map<String, Object> data;
   private Map<String, String> pathParams;
   private MultiMap queryParams;
@@ -61,9 +62,10 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private Session session;
   private User user;
 
-  public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes) {
-    super(mountPoint, request, routes);
+  public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes, boolean allowForward) {
+    super(mountPoint, routes);
     this.router = router;
+    this.request = new HttpServerRequestWrapper(request, allowForward);
 
     fillParsedHeaders(request);
     if (request.path().length() == 0) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -39,7 +39,6 @@ public abstract class RoutingContextImplBase implements RoutingContext {
   private final Set<RouteImpl> routes;
 
   protected final String mountPoint;
-  protected final HttpServerRequest request;
   protected Iterator<RouteImpl> iter;
   protected RouteState currentRoute;
   private AtomicInteger currentRouteNextHandlerIndex;
@@ -51,9 +50,8 @@ public abstract class RoutingContextImplBase implements RoutingContext {
   int matchRest = -1;
   boolean matchNormalized;
 
-  RoutingContextImplBase(String mountPoint, HttpServerRequest request, Set<RouteImpl> routes) {
+  RoutingContextImplBase(String mountPoint, Set<RouteImpl> routes) {
     this.mountPoint = mountPoint;
-    this.request = new HttpServerRequestWrapper(request);
     this.routes = routes;
     this.iter = routes.iterator();
     this.currentRouteNextHandlerIndex = new AtomicInteger(0);

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -42,8 +42,8 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   protected final RoutingContext inner;
   private final String mountPoint;
 
-  public RoutingContextWrapper(String mountPoint, HttpServerRequest request, Set<RouteImpl> iter, RoutingContext inner) {
-    super(mountPoint, request, iter);
+  public RoutingContextWrapper(String mountPoint, Set<RouteImpl> iter, RoutingContext inner) {
+    super(mountPoint, iter);
     this.inner = inner;
     String parentMountPoint = inner.mountPoint();
     if (parentMountPoint == null) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web;
+
+import io.vertx.core.http.HttpMethod;
+import org.junit.Test;
+
+public class ForwardedTest extends WebTestBase {
+
+  @Test
+  public void testXForwardSSL() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Ssl", "On");
+  }
+
+  @Test
+  public void testForwardedProto() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "proto=https");
+  }
+
+  @Test
+  public void testForwardedHostAlongWithXForwardSSL() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "host=" + host, "X-Forwarded-Ssl", "On");
+  }
+
+  @Test
+  public void testMultipleForwarded() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "proto=https,proto=http");
+  }
+
+  @Test
+  public void testForwardedProtoAlongWIthXForwardSSL() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertFalse(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "http");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "proto=http", "X-Forwarded-Ssl", "On");
+  }
+
+  @Test
+  public void testForwardedHost() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("Forwarded", "host=" + host);
+  }
+
+  @Test
+  public void testForwardedHostAndPort() throws Exception {
+    String host = "vertx.io:1234";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("Forwarded", "host=" + host);
+  }
+
+  @Test
+  public void testForwardedHostAndPortAndProto() throws Exception {
+    String host = "vertx.io:1234";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "host=" + host + ";proto=https");
+  }
+
+  @Test
+  public void testXForwardedProto() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("x-forwarded-proto", "https");
+  }
+
+  @Test
+  public void testXForwardedProtoAlongWIthXForwardSSL() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertFalse(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "http");
+      rc.end();
+    });
+
+    testRequest("x-FORWARDED-proto", "http", "X-Forwarded-Ssl", "On");
+  }
+
+
+  @Test
+  public void testXForwardedHost() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host);
+  }
+
+  @Test
+  public void testXForwardedHostAndPort() throws Exception {
+    String host = "vertx.io:4321";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host);
+  }
+
+  @Test
+  public void testXForwardedHostRemovesCommonPort() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host + ":80");
+  }
+
+  @Test
+  public void testXForwardedHostMultiple() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertEquals(rc.request().host(), host);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host + "," + "www.google.com");
+  }
+
+  @Test
+  public void testXForwardedPort() throws Exception {
+    String port = "1234";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().host().endsWith(":" + port));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Port", port);
+  }
+
+  @Test
+  public void testXForwardedPortAndHost() throws Exception {
+    String host = "vertx.io";
+    String port = "1234";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().host().equals(host + ":" + port));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host, "X-Forwarded-Port", port);
+  }
+
+  @Test
+  public void testXForwardedPortAndHostWithPort() throws Exception {
+    String host = "vertx.io";
+    String port = "1234";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().host().equals(host + ":" + port));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Host", host + ":4321", "X-Forwarded-Port", port);
+  }
+
+  @Test
+  public void testIllegalPort() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().host().endsWith(":8080"));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Port", "illegal");
+  }
+
+  @Test
+  public void testXForwardedFor() throws Exception {
+    String host = "1.2.3.4";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-For", host);
+  }
+
+  @Test
+  public void testXForwardedForWithPort() throws Exception {
+    String host = "1.2.3.4";
+    int port = 1111;
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      assertTrue(rc.request().remoteAddress().port() == port);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-For", host + ":" + port);
+  }
+
+  @Test
+  public void testForwardedFor() throws Exception {
+    String host = "1.2.3.4";
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      rc.end();
+    });
+
+    testRequest("Forwarded", "for=" + host);
+  }
+
+  @Test
+  public void testForwardedForIpv6() throws Exception {
+    String host = "[2001:db8:cafe::17]";
+    int port = 4711;
+
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      assertTrue(rc.request().remoteAddress().port() == port);
+      rc.end();
+    });
+
+    testRequest("Forwarded", "for=\"" + host + ":" + port + "\"");
+  }
+
+  @Test
+  public void testNoForwarded() throws Exception {
+    router.allowForward(true).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals("127.0.0.1"));
+      assertTrue(rc.request().host().equals("localhost:8080"));
+      assertTrue(rc.request().scheme().equals("http"));
+      assertFalse(rc.request().isSSL());
+      rc.end();
+    });
+
+    testRequest();
+  }
+
+  @Test
+  public void testForwardedDisabled() throws Exception {
+    router.allowForward(false).route("/").handler(rc -> {
+      assertFalse(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "http");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "proto=https");
+  }
+
+
+  private void testRequest(String... headers) throws Exception {
+    testRequest(HttpMethod.GET, "/", req -> {
+      int i = 0;
+      while (i < headers.length)
+        req.putHeader(headers[i++], headers[i++]);
+    }, 200, "OK", null);
+  }
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2389,6 +2389,7 @@ public class RouterTest extends WebTestBase {
         HttpServerResponse response = mock(HttpServerResponse.class);
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.rawMethod()).thenReturn("GET");
+        when(request.scheme()).thenReturn("http");
         when(request.uri()).thenReturn("http://localhost/path");
         when(request.absoluteURI()).thenReturn("http://localhost/path");
         when(request.host()).thenReturn("localhost");


### PR DESCRIPTION
Signed-off-by: zenios <dimitris.zenios@gmail.com>

This PR adds support for the following "forward" type headers

- Forwarded host,
- Forwarded proto
- Forwarded for
- X-Forwarded-Ssl
- X-Forwarded-Proto
- X-Forwarded-Host
- X-Forwarded-Port
- X-Forwarded-For

parsing can be enabled / disabled (Disabled by default) through a fluent function on Router 

While implementing that, i found out that RoutingContextImplBase which is extended from RoutingContextWrapper and RoutingContextImpl was creating a new instance of HttpServerRequestWrapper on its constructor but RoutingContextWrapper does not need it. So i refactored that part also
