### PR TITLE
BodyCodec: avoid unneccesary json/string conversion

### DIFF
--- a/vertx-web-common/src/main/java/io/vertx/ext/web/codec/impl/BodyCodecImpl.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/codec/impl/BodyCodecImpl.java
@@ -72,7 +72,7 @@ public class BodyCodecImpl<T> implements BodyCodec<T> {
   }
 
   public static <T> Function<Buffer, T> jsonDecoder(Class<T> type) {
-    return buff -> Json.decodeValue(buff.toString(), type);
+    return buff -> Json.decodeValue(buff, type);
   }
 
   private final Function<Buffer, T> decoder;


### PR DESCRIPTION
BodyCodec converts json buffer to string before decoding value to specified type.