### PR TITLE
WebClient: moved jackson-databind from compile to test scope

### DIFF
--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -45,7 +45,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>io/vertx/ext/web/client/WebClientDatabindTest.java</exclude>
+            <exclude>io/vertx/ext/web/client/it/**/*.java</exclude>
           </excludes>
           <classpathDependencyExcludes>
             <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
@@ -66,7 +66,7 @@
             </goals>
             <configuration>
               <includes>
-                <include>io/vertx/ext/web/client/WebClientDatabindTest.java</include>
+                <include>io/vertx/ext/web/client/it/WebClientDatabindTest.java</include>
               </includes>
             </configuration>
           </execution>

--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -43,23 +43,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>io/vertx/ext/web/client/WebClientDatabindTest.java</exclude>
+          </excludes>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
         <executions>
           <execution>
-            <id>default-test</id>
-            <configuration>
-              <excludes>
-                <exclude>io/vertx/ext/web/client/WebClientDatabindTest.java</exclude>
-              </excludes>
-              <classpathDependencyExcludes>
-                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
-              </classpathDependencyExcludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>databind-test</id>
-            <phase>test</phase>
+            <id>databind-itest</id>
+            <phase>integration-test</phase>
             <goals>
-              <goal>test</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
             <configuration>
               <includes>

--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -24,11 +24,6 @@
       <artifactId>vertx-web-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -36,6 +31,45 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <configuration>
+              <excludes>
+                <exclude>io/vertx/ext/web/client/WebClientDatabindTest.java</exclude>
+              </excludes>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>databind-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/ext/web/client/WebClientDatabindTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientDatabindTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientDatabindTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.client;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.jackson.WineAndCheese;
+import io.vertx.ext.web.codec.BodyCodec;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class WebClientDatabindTest extends WebClientTestBase {
+
+  @Test
+  public void testResponseBodyAsJsonMapped() throws Exception {
+    JsonObject expected = new JsonObject().put("cheese", "Goat Cheese").put("wine", "Condrieu");
+    server.requestHandler(req -> req.response().end(expected.encode()));
+    startServer();
+    HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+    get
+      .as(BodyCodec.json(WineAndCheese.class))
+      .send(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        assertEquals(new WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.body());
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testResponseUnknownContentTypeBodyAsJsonMapped() throws Exception {
+    JsonObject expected = new JsonObject().put("cheese", "Goat Cheese").put("wine", "Condrieu");
+    testResponseBody(expected.encode(), onSuccess(resp -> {
+      assertEquals(200, resp.statusCode());
+      assertEquals(new WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.bodyAsJson(WineAndCheese.class));
+      testComplete();
+    }));
+  }
+
+  @Test
+  public void testSendJsonPojoBody() throws Exception {
+    testSendBody(new WineAndCheese().setCheese("roquefort").setWine("Chateauneuf Du Pape"),
+      (contentType, buff) -> {
+        assertEquals("application/json", contentType);
+        assertEquals(new JsonObject().put("wine", "Chateauneuf Du Pape").put("cheese", "roquefort"), buff.toJsonObject());
+      });
+  }
+}

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.client;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpTestBase;
+import io.vertx.core.json.JsonObject;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.function.BiConsumer;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class WebClientTestBase extends HttpTestBase {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  protected WebClient webClient;
+
+  @Override
+  protected VertxOptions getOptions() {
+    return super.getOptions().setAddressResolverOptions(new AddressResolverOptions().
+      setHostsValue(Buffer.buffer(
+        "127.0.0.1 somehost\n" +
+          "127.0.0.1 localhost")));
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8080).setDefaultHost("localhost"));
+    webClient = WebClient.wrap(client);
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST));
+  }
+
+  protected void testResponseBody(String body, Handler<AsyncResult<HttpResponse<Buffer>>> checker) throws Exception {
+    server.requestHandler(req -> req.response().end(body));
+    startServer();
+    HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+    get.send(checker);
+    await();
+  }
+
+  protected void testSendBody(Object body, BiConsumer<String, Buffer> checker) throws Exception {
+    waitFor(2);
+    server.requestHandler(req -> req.bodyHandler(buff -> {
+      checker.accept(req.getHeader("content-type"), buff);
+      complete();
+      req.response().end();
+    }));
+    startServer();
+    HttpRequest<Buffer> post = webClient.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+    if (body instanceof Buffer) {
+      post.sendBuffer((Buffer) body, onSuccess(resp -> complete()));
+    } else if (body instanceof JsonObject) {
+      post.sendJsonObject((JsonObject) body, onSuccess(resp -> complete()));
+    } else {
+      post.sendJson(body, onSuccess(resp -> complete()));
+    }
+    await();
+  }
+}

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/it/WebClientDatabindTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/it/WebClientDatabindTest.java
@@ -14,10 +14,12 @@
  * under the License.
  */
 
-package io.vertx.ext.web.client;
+package io.vertx.ext.web.client.it;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClientTestBase;
 import io.vertx.ext.web.client.jackson.WineAndCheese;
 import io.vertx.ext.web.codec.BodyCodec;
 import org.junit.Test;


### PR DESCRIPTION
Put databind dependent tests in separate execution