### PR TITLE
Fix NPE on RoutingContext#getCurrentRoute()

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -66,6 +66,9 @@ public abstract class RoutingContextImplBase implements RoutingContext {
 
   @Override
   public Route currentRoute() {
+    if (currentRoute == null) {
+      return null;
+    }
     return currentRoute.getRoute();
   }
 


### PR DESCRIPTION
The currentRoute object can be null.
Previously `getCurrentRoute()` then returned a null, after 17860ef4 it triggers an NPE.