### PR TITLE
[WIP] Add SSE Support

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/EventSource.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/EventSource.java
@@ -1,0 +1,39 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.ext.web.handler.sse.impl.EventSourceImpl;
+
+public interface EventSource {
+
+	static EventSource create(Vertx vertx, HttpClientOptions options) {
+		return new EventSourceImpl(vertx, options);
+	}
+
+	@Fluent
+  EventSource connect(String path, Handler<AsyncResult<Void>> handler);
+
+	@Fluent
+	default EventSource close() {
+		return null;
+	}
+
+	@Fluent
+  EventSource connect(String path, String lastEventId, Handler<AsyncResult<Void>> handler);
+
+	@Fluent
+  EventSource onMessage(Handler<String> messageHandler);
+
+	@Fluent
+  EventSource onEvent(String eventName, Handler<String> handler);
+
+	@Fluent
+	default EventSource onClose(Handler<Void> handler) {
+		return null;
+	}
+
+	String lastId();
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEConnection.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEConnection.java
@@ -1,0 +1,68 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.sse.impl.SSEConnectionImpl;
+
+import java.util.List;
+
+@VertxGen
+public interface SSEConnection {
+
+	static SSEConnection create(RoutingContext context) {
+		return new SSEConnectionImpl(context);
+	}
+
+	@Fluent
+  SSEConnection forward(String address);
+
+	@Fluent
+  SSEConnection forward(List<String> addresses);
+
+	@Fluent
+  SSEConnection reject(int code);
+
+	@Fluent
+  SSEConnection reject(int code, String reason);
+
+	@Fluent
+  SSEConnection comment(String comment);
+
+	@Fluent
+  SSEConnection retry(Long delay, List<String> data);
+
+	@Fluent
+  SSEConnection retry(Long delay, String data);
+
+	@Fluent
+  SSEConnection data(List<String> data);
+
+	@Fluent
+  SSEConnection data(String data);
+
+	@Fluent
+  SSEConnection event(String eventName, List<String> data);
+
+	@Fluent
+  SSEConnection event(String eventName, String data);
+
+	@Fluent
+  SSEConnection id(String id, List<String> data);
+
+	@Fluent
+  SSEConnection id(String id, String data);
+
+	@Fluent
+  SSEConnection close();
+
+	boolean rejected();
+
+	String lastId();
+
+	@GenIgnore
+  HttpServerRequest request();
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEHandler.java
@@ -1,0 +1,21 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.sse.impl.SSEHandlerImpl;
+
+@VertxGen
+public interface SSEHandler extends Handler<RoutingContext> {
+
+	static SSEHandler create() {
+		return new SSEHandlerImpl();
+	}
+
+	@Fluent
+	public SSEHandler connectHandler(Handler<SSEConnection> connection);
+
+	@Fluent
+	public SSEHandler closeHandler(Handler<SSEConnection> connection);
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEHeaders.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/SSEHeaders.java
@@ -1,0 +1,16 @@
+package io.vertx.ext.web.handler.sse;
+
+/**
+ * This is a final class to match io.vertx.core.HttpHeaders
+ * Since maybe enums can cause trouble with codegen ? idk
+ */
+public final class SSEHeaders {
+
+    private SSEHeaders() {}
+
+    public static final String EVENT = "event";
+    public static final String ID = "id";
+    public static final String RETRY = "retry";
+    public static final String LAST_EVENT_ID = "Last-Event-ID";
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/EventSourceImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/EventSourceImpl.java
@@ -1,0 +1,137 @@
+package io.vertx.ext.web.handler.sse.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.handler.sse.EventSource;
+import io.vertx.ext.web.handler.sse.SSEHeaders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventSourceImpl implements EventSource {
+
+	private HttpClient client;
+	private boolean connected;
+	private String lastId;
+	private Handler<String> messageHandler;
+	private final Map<String, Handler<String>> eventHandlers;
+	private SSEPacket currentPacket;
+	private final Vertx vertx;
+	private final HttpClientOptions options;
+	private Handler<Void> closeHandler;
+
+	public EventSourceImpl(Vertx vertx, HttpClientOptions options) {
+		options.setKeepAlive(true);
+		this.vertx = vertx;
+		this.options = options;
+		eventHandlers = new HashMap<>();
+	}
+
+	@Override
+	public EventSource connect(String path, Handler<AsyncResult<Void>> handler) {
+		return connect(path, null, handler);
+	}
+
+	@Override
+	public EventSource connect(String path, String lastEventId, Handler<AsyncResult<Void>> handler) {
+		if (connected) {
+			throw new VertxException("SSEConnection already connected");
+		}
+		if (client == null) {
+			client = vertx.createHttpClient(options);
+		}
+		HttpClientRequest request = client.get(path, result -> {
+		  if (result.failed()) {
+		    handler.handle(Future.failedFuture(result.cause()));
+		    return;
+      }
+      HttpClientResponse response = result.result();
+			if (response.statusCode() != 200) {
+				handler.handle(Future.failedFuture(new VertxException("Could not connect EventSource, the server answered with status " + response.statusCode())));
+			} else {
+				connected = true;
+				response.handler(this::handleMessage);
+				if (closeHandler != null) {
+					response.endHandler(closeHandler);
+				}
+				handler.handle(Future.succeededFuture());
+			}
+		});
+		if (lastEventId != null) {
+			request.headers().add("Last-Event-ID", lastEventId);
+		}
+		request.setChunked(true);
+		request.headers().add(HttpHeaders.ACCEPT, "text/event-stream");
+		request.end();
+		return this;
+	}
+
+	@Override
+	public EventSource close() {
+		client.close();
+		client = null;
+		connected = false;
+		return this;
+	}
+
+	@Override
+	public EventSource onMessage(Handler<String> messageHandler) {
+		this.messageHandler = messageHandler;
+		return this;
+	}
+
+	@Override
+	public EventSource onEvent(String eventName, Handler<String> handler) {
+		eventHandlers.put(eventName, handler);
+		return this;
+	}
+
+	@Override
+	public EventSource onClose(Handler<Void> closeHandler) {
+		this.closeHandler = closeHandler;
+		return this;
+	}
+
+	@Override
+	public String lastId() {
+		return lastId;
+	}
+
+	private void handleMessage(Buffer buffer) {
+		if (currentPacket == null) {
+			currentPacket = new SSEPacket();
+		}
+		boolean terminated = currentPacket.append(buffer);
+		if (terminated) {
+			// choose the right handler and call it
+			Handler<String> handler = messageHandler;
+			String header = currentPacket.headerName;
+			if (header == null) {
+				messageHandler.handle(currentPacket.toString());
+			} else {
+				switch (currentPacket.headerName) {
+					case SSEHeaders.EVENT:
+						handler = eventHandlers.get(currentPacket.headerValue);
+						break;
+					case SSEHeaders.ID:
+						lastId = currentPacket.headerValue;
+						break;
+					case SSEHeaders.RETRY:
+				}
+				if (handler != null) {
+					handler.handle(currentPacket.toString());
+				}
+			}
+			currentPacket = null;
+		}
+	}
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEConnectionImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEConnectionImpl.java
@@ -1,0 +1,182 @@
+package io.vertx.ext.web.handler.sse.impl;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.VertxException;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.sse.SSEConnection;
+import io.vertx.ext.web.handler.sse.SSEHeaders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class SSEConnectionImpl implements SSEConnection {
+
+	private static final String MSG_SEPARATOR = "\n";
+	private static final String PACKET_SEPARATOR = "\n\n";
+
+	private final RoutingContext context;
+	private boolean rejected;
+	private List<MessageConsumer> consumers = new ArrayList<>();
+
+	public SSEConnectionImpl(RoutingContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public SSEConnection forward(String address) {
+		consumers.add(context.vertx().eventBus().consumer(address, this::ebMsgHandler));
+		return this;
+	}
+
+	@Override
+	public SSEConnection forward(List<String> addresses) {
+		consumers = addresses.stream().map(address ->
+			context.vertx().eventBus().consumer(address, this::ebMsgHandler)
+		).collect(toList());
+		return this;
+	}
+
+	@Override
+	public SSEConnection reject(int code) {
+		return reject(code, null);
+	}
+
+	@Override
+	public SSEConnection reject(int code, String reason) {
+		rejected = true;
+		HttpServerResponse response = context.response();
+		response.setStatusCode(code);
+		if (reason != null) {
+			response.setStatusMessage(reason);
+		}
+		response.end();
+		return this;
+	}
+
+	@Override
+	public SSEConnection comment(String comment) {
+		context.response().write("comment: " + comment + PACKET_SEPARATOR);
+		return this;
+	}
+
+	@Override
+	public SSEConnection retry(Long delay, List<String> data) {
+		return withHeader(SSEHeaders.RETRY, delay.toString(), data);
+	}
+
+	@Override
+	public SSEConnection retry(Long delay, String data) {
+		return withHeader(SSEHeaders.RETRY, delay.toString(), data);
+	}
+
+	@Override
+	public SSEConnection data(List<String> data) {
+		return appendData(data);
+	}
+
+	@Override
+	public SSEConnection data(String data) {
+		return writeData(data);
+	}
+
+	@Override
+	public SSEConnection event(String eventName, List<String> data) {
+		return withHeader(SSEHeaders.EVENT, eventName, data);
+	}
+
+	@Override
+	public SSEConnection event(String eventName, String data) {
+		return withHeader(SSEHeaders.EVENT, eventName, data);
+	}
+
+	@Override
+	public SSEConnection id(String id, List<String> data) {
+		return withHeader(SSEHeaders.ID, id, data);
+	}
+
+	@Override
+	public SSEConnection id(String id, String data) {
+		return withHeader(SSEHeaders.ID, id, data);
+	}
+
+	@Override
+	public SSEConnection close() {
+		try {
+			context.response().end(); // best effort
+		} catch(VertxException | IllegalStateException e) {
+			// connection has already been closed by the browser
+			// do not log to avoid performance issues (ddos issue if client opening and closing alot of connections abruptly)
+		}
+		if (!consumers.isEmpty()) {
+			consumers.forEach(MessageConsumer::unregister);
+		}
+		return this;
+	}
+
+	@Override
+	public HttpServerRequest request() {
+		return context.request();
+	}
+
+	@Override
+	public String lastId() {
+		return request().getHeader("Last-Event-ID");
+	}
+
+	@Override
+	public boolean rejected() {
+		return rejected;
+	}
+
+	private SSEConnection withHeader(String headerName, String headerValue, String data) {
+		writeHeader(headerName, headerValue);
+		writeData(data);
+		return this;
+	}
+
+	private SSEConnection withHeader(String headerName, String headerValue, List<String> data) {
+		writeHeader(headerName, headerValue);
+		appendData(data);
+		return this;
+	}
+
+	private SSEConnection writeHeader(String headerName, String headerValue) {
+		context.response().write(headerName + ": " + headerValue + MSG_SEPARATOR);
+		return this;
+	}
+
+	private SSEConnection writeData(String data) {
+		context.response().write("data: " + data + PACKET_SEPARATOR);
+		return this;
+	}
+
+	private SSEConnection appendData(List<String> data) {
+		for (int i = 0; i < data.size(); i++) {
+			String separator = i == data.size() - 1 ? PACKET_SEPARATOR : MSG_SEPARATOR;
+			context.response().write("data: " + data.get(i) + separator);
+		}
+		return this;
+	}
+
+	private void ebMsgHandler(Message<?> msg) {
+		MultiMap headers = msg.headers();
+		String eventName = headers.get(SSEHeaders.EVENT);
+		String id = headers.get(SSEHeaders.ID);
+		String data = msg.body() == null ? "" : msg.body().toString();
+		if (eventName != null) {
+			this.event(eventName, data);
+		}
+		if (id != null) {
+			this.id(id, data);
+		}
+		if (eventName == null && id == null) {
+			this.data(data);
+		}
+	}
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEHandlerImpl.java
@@ -1,0 +1,65 @@
+package io.vertx.ext.web.handler.sse.impl;
+
+import io.netty.buffer.Unpooled;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.sse.SSEConnection;
+import io.vertx.ext.web.handler.sse.SSEHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SSEHandlerImpl implements SSEHandler {
+
+	// README: DO NOT MUTATE THIS! (using EMPTY_BUFFER.appendBuffer(...) for instance)
+	private static final Buffer EMPTY_BUFFER = Buffer.buffer(Unpooled.EMPTY_BUFFER);
+
+	private final List<Handler<SSEConnection>> connectHandlers;
+	private final List<Handler<SSEConnection>> closeHandlers;
+
+	public SSEHandlerImpl() {
+		connectHandlers = new ArrayList<>();
+		closeHandlers = new ArrayList<>();
+	}
+
+	@Override
+	public void handle(RoutingContext context) {
+		HttpServerRequest request = context.request();
+		HttpServerResponse response = context.response();
+		response.setChunked(true);
+		SSEConnection connection = SSEConnection.create(context);
+		String accept = request.getHeader("Accept");
+		if (accept != null && !accept.contains("text/event-stream")) {
+			connection.reject(406, "Not acceptable");
+			return;
+		}
+		response.closeHandler(aVoid -> {
+			closeHandlers.forEach(closeHandler -> closeHandler.handle(connection));
+			connection.close();
+		});
+		response.headers().add("Content-Type", "text/event-stream");
+		response.headers().add("Cache-Control", "no-cache");
+		response.headers().add("Connection", "keep-alive");
+		connectHandlers.forEach(handler -> handler.handle(connection));
+		if (!connection.rejected()) {
+			response.setStatusCode(200);
+			response.setChunked(true);
+			response.write(EMPTY_BUFFER);
+		}
+	}
+
+	@Override
+	public SSEHandler connectHandler(Handler<SSEConnection> handler) {
+		connectHandlers.add(handler);
+		return this;
+	}
+
+	@Override
+	public SSEHandler closeHandler(Handler<SSEConnection> handler) {
+		closeHandlers.add(handler);
+		return this;
+	}
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEPacket.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sse/impl/SSEPacket.java
@@ -1,0 +1,45 @@
+package io.vertx.ext.web.handler.sse.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+class SSEPacket {
+
+	private static final String END_OF_PACKET = "\n\n";
+	private static final String LINE_SEPARATOR = "\n";
+	private static final String FIELD_SEPARATOR = ":";
+
+	private final StringBuilder payload;
+	String headerName;
+	String headerValue;
+
+	SSEPacket() {
+		payload = new StringBuilder();
+	}
+
+	boolean append(Buffer buffer) {
+		String response = buffer.toString();
+		boolean willTerminate = response.endsWith(END_OF_PACKET);
+		String[] lines = response.split(LINE_SEPARATOR);
+		for (int i = 0; i < lines.length; i++) {
+			final String line = lines[i];
+			int idx = line.indexOf(FIELD_SEPARATOR);
+			if (idx == -1) {
+				continue; // ignore line
+			}
+			final String type = line.substring(0, idx);
+			final String data = line.substring(idx + 2);
+			if (i == 0 && headerName == null && !"data".equals(type)) {
+				headerName = type;
+				headerValue = data;
+			} else {
+				payload.append(data).append(LINE_SEPARATOR);
+			}
+		}
+		return willTerminate;
+	}
+
+	@Override
+	public String toString() {
+		return payload.toString();
+	}
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestBase.java
@@ -1,0 +1,84 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Router;
+import io.vertx.test.core.VertxTestBase;
+
+import java.util.concurrent.CountDownLatch;
+
+abstract class SSETestBase extends VertxTestBase {
+
+	protected final String TOKEN = "test";
+
+	private final static Integer PORT = 9009;
+
+	protected SSEConnection connection;
+	protected SSEHandler sseHandler;
+
+	private HttpServer server;
+	private HttpClientOptions options;
+
+	@Override
+	public void setUp() throws Exception {
+	  super.setUp();
+    CountDownLatch latch = new CountDownLatch(1);
+		HttpServerOptions options = new HttpServerOptions();
+		options.setPort(PORT);
+		server = vertx.createHttpServer(options);
+		Router router = Router.router(vertx);
+		sseHandler = SSEHandler.create();
+		sseHandler.connectHandler(connection -> {
+			final HttpServerRequest request = connection.request();
+			final String token = request.getParam("token");
+			if (token == null) {
+				connection.reject(401);
+			} else if (!TOKEN.equals(token)) {
+				connection.reject(403);
+			} else {
+				this.connection = connection; // accept
+			}
+		});
+		sseHandler.closeHandler(connection -> {
+			if (this.connection != null) {
+				this.connection = null;
+			}
+		});
+		router.get("/sse").handler(sseHandler);
+		server.requestHandler(router);
+		server.listen(ar -> {
+		  if (ar.failed()) {
+		    fail(ar.cause());
+      }
+		  latch.countDown();
+    });
+		awaitLatch(latch);
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+	  super.tearDown();
+		connection = null;
+		sseHandler = null;
+	}
+
+	EventSource eventSource() {
+		return EventSource.create(vertx, clientOptions());
+	}
+
+	HttpClient client() {
+		return vertx.createHttpClient(clientOptions());
+	}
+
+	private HttpClientOptions clientOptions() {
+		if (options == null) {
+			options = new HttpClientOptions();
+			options.setDefaultPort(PORT);
+		}
+		return options;
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestClose.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestClose.java
@@ -1,0 +1,43 @@
+package io.vertx.ext.web.handler.sse;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SSETestClose extends SSETestBase {
+
+	private void waitSafely() {
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException ie) {}
+	}
+
+	@Test
+	public void closeHandlerOnServer() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+				assertTrue(handler.succeeded());
+				assertNotNull(connection);
+                sseHandler.closeHandler(sse -> {
+                    latch.countDown();
+                });
+                waitSafely();
+				eventSource.close(); /* closed by client */
+			});
+		awaitLatch(latch);
+	}
+
+	@Test
+  public void closeHandlerOnClient() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    final EventSource eventSource = eventSource();
+		eventSource.onClose(handler -> latch.countDown());
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+      assertNotNull(connection);
+      connection.close();
+    });
+		awaitLatch(latch);
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestEstablishConnection.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestEstablishConnection.java
@@ -1,0 +1,51 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.core.VertxException;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SSETestEstablishConnection extends SSETestBase {
+
+	@Test
+	public void noToken() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+		eventSource().connect("/sse", handler -> {
+				assertFalse(handler.succeeded());
+				assertTrue(handler.failed());
+				assertNotNull(handler.cause());
+				assertTrue(handler.cause() instanceof VertxException);
+				final VertxException ve = (VertxException) handler.cause();
+				assertTrue(ve.getMessage().endsWith("401"));
+				latch.countDown();
+		});
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void invalidToken() throws InterruptedException {
+	  CountDownLatch latch = new CountDownLatch(1);
+		eventSource().connect("/sse?token=somethingdefinitelynotvalid", handler -> {
+				assertFalse(handler.succeeded());
+				assertTrue(handler.failed());
+				assertTrue(handler.cause() instanceof VertxException);
+				final VertxException cre = (VertxException) handler.cause();
+				assertTrue(cre.getMessage().endsWith("403"));
+				latch.countDown();
+		});
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void validConnection() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    eventSource().connect("/sse?token=" + TOKEN, handler -> {
+      assertTrue(handler.succeeded());
+      assertFalse(handler.failed());
+      assertNull(handler.cause());
+      latch.countDown();
+		});
+    awaitLatch(latch);
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestReceiveData.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestReceiveData.java
@@ -1,0 +1,141 @@
+package io.vertx.ext.web.handler.sse;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.CountDownLatch;
+
+public class SSETestReceiveData extends SSETestBase {
+
+	@Test
+	public void testSimpleDataHandler() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+		final String message = "Happiness is a warm puppy";
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+				assertTrue(handler.succeeded());
+				assertFalse(handler.failed());
+				assertNull(handler.cause());
+				assertNotNull(connection);
+			eventSource.onMessage(msg -> {
+        assertEquals(message + "\n", msg);
+        latch.countDown();
+			});
+			connection.data(message);
+		});
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void testMultipleDataHandler() throws InterruptedException {
+	  CountDownLatch latch = new CountDownLatch(1);
+		final List<String> quotes = createData();
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+      assertTrue(handler.succeeded());
+      assertFalse(handler.failed());
+      assertNull(handler.cause());
+      assertNotNull(connection);
+			eventSource.onMessage(msg -> {
+				final StringJoiner joiner = new StringJoiner("\n");
+				quotes.forEach(joiner::add);
+        assertEquals(joiner.toString() + "\n", msg);
+        latch.countDown();
+      });
+      connection.data(quotes);
+    });
+    awaitLatch(latch);
+	}
+
+	@Test
+	public void testConsecutiveDataHandler() throws InterruptedException {
+	  CountDownLatch latch = new CountDownLatch(1);
+		final List<String> quotes = createData();
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+      assertTrue(handler.succeeded());
+      assertFalse(handler.failed());
+      assertNull(handler.cause());
+      assertNotNull(connection);
+			final List<String> received = new ArrayList<>();
+			eventSource.onMessage(msg -> {
+				received.add(msg.substring(0, msg.length() - 1)); /* remove trailing linefeed */
+				if (received.size() == quotes.size()) {
+				  for (int i = 0; i < received.size(); i++) {
+            assertEquals("Received quotes don't match", quotes.get(i), received.get(i));
+          }
+          latch.countDown();
+				}
+			});
+			quotes.forEach(connection::data);
+		});
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void testEventHandler() throws InterruptedException {
+	  CountDownLatch latch = new CountDownLatch(1);
+		final String eventName = "quotes";
+		final List<String> quotes = createData();
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+			assertTrue(handler.succeeded());
+			assertFalse(handler.failed());
+			assertNull(handler.cause());
+			assertNotNull(connection);
+			eventSource.onEvent("wrong", msg -> {
+				throw new RuntimeException("this handler should not be called, at all !");
+			});
+			eventSource.onEvent(eventName, msg -> {
+				final StringJoiner joiner = new StringJoiner("\n");
+				quotes.forEach(joiner::add);
+				assertEquals(joiner.toString() + "\n", msg);
+				latch.countDown();
+			});
+			connection.event(eventName, quotes);
+		});
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void testId() throws InterruptedException {
+	  CountDownLatch latch = new CountDownLatch(1);
+		final String id = "SomeIdentifier";
+		final List<String> quotes = createData();
+		final EventSource eventSource = eventSource();
+		eventSource.connect("/sse?token=" + TOKEN, handler -> {
+      assertTrue(handler.succeeded());
+      assertFalse(handler.failed());
+      assertNull(handler.cause());
+      assertNotNull(connection);
+			eventSource.onMessage(msg -> {
+				final StringJoiner joiner = new StringJoiner("\n");
+				quotes.forEach(joiner::add);
+        assertEquals(joiner.toString() + "\n", msg);
+        assertEquals(id, eventSource.lastId());
+				eventSource.close();
+				eventSource.connect("/sse?token=" + TOKEN, eventSource.lastId(), secondHandler -> {
+          assertTrue(handler.succeeded());
+          assertFalse(handler.failed());
+          assertNull(handler.cause());
+          assertNotNull(connection);
+          assertEquals(id, connection.lastId());
+          latch.countDown();
+				});
+			});
+			connection.id(id, quotes);
+		});
+		awaitLatch(latch);
+	}
+
+	private List<String> createData() {
+		final List<String> data = new ArrayList<>(3);
+		data.add("Happiness is a warm puppy");
+		data.add("Bleh!");
+		data.add("That's the secret of life... replace one worry with another");
+		return data;
+	}
+
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestRequestResponseHeaders.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sse/SSETestRequestResponseHeaders.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.web.handler.sse;
+
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SSETestRequestResponseHeaders extends SSETestBase {
+
+	@Test
+	public void noHeaderTextEventStreamHttpRequest() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    client().get("/sse", ar -> {
+      assertTrue(ar.succeeded());
+      HttpClientResponse response = ar.result();
+      assertEquals(406, response.statusCode());
+      latch.countDown();
+		}).putHeader("Accept", "foo").end();
+		awaitLatch(latch);
+	}
+
+	@Test
+	public void noHeaderHttpRequest() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    client().getNow("/sse", ar -> {
+      assertTrue(ar.succeeded());
+      HttpClientResponse response = ar.result();
+			assertSSEHeaders(response);
+			latch.countDown();
+		});
+    awaitLatch(latch);
+	}
+
+	@Test
+	public void correctResponseHeaders() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+		client().get("/sse", ar -> {
+      assertTrue(ar.succeeded());
+      HttpClientResponse response = ar.result();
+			assertSSEHeaders(response);
+			latch.countDown();
+		}).putHeader("Accept", "text/event-stream").end();
+		awaitLatch(latch);
+	}
+
+	private void assertSSEHeaders(HttpClientResponse response) {
+    assertEquals("text/event-stream", response.getHeader(HttpHeaders.CONTENT_TYPE));
+    assertEquals("no-cache", response.getHeader(HttpHeaders.CACHE_CONTROL));
+    assertEquals("keep-alive", response.getHeader(HttpHeaders.CONNECTION));
+	}
+}


### PR DESCRIPTION
From: https://github.com/aesteve/vertx-sse
Original discussion: https://github.com/reactiverse/reactiverse/issues/5
Status: Still WIP. Misses documentation + implementation must be discussed further on.

Motivation:

Provide a way to deal with Server-Sent-Events with Vert.x
[SSE](https://www.w3.org/TR/2009/WD-eventsource-20090421/) allows unidirectional communication between server and client in a pure HTTP way.

Status:

I migrated most of the code from [my 3rd party](https://github.com/aesteve/vertx-sse) implementation to make it officially supported by the Vert.x stack, as discussed in [this reactiverse issue](https://github.com/reactiverse/reactiverse/issues/5).

At this point, I'd like to receive feedback on:
* where to add documentation, and how to write it properly
* is the implementation correct, does it align with Vert.x 4 upcoming standards (Future/Promise, etc.)
* is the implementation codegen-compatible
* are you OK with names, variables, coding standards

Thank you.

