### PR TITLE
Locale provider for graphql execution

### DIFF
--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
@@ -26,6 +26,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.impl.ApolloWSHandlerImpl;
 import org.dataloader.DataLoaderRegistry;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 /**
@@ -103,4 +104,16 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   ApolloWSHandler dataLoaderRegistry(Function<ApolloWSMessage, DataLoaderRegistry> factory);
+
+  /**
+   * Customize the locale passed to graphql execution engine
+   * The provided {@code factory} method will be invoked for each incoming GraphQL request.
+   *
+   * If a {@code factory} is not provided the first language found in Accept-Language header will be used
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  ApolloWSHandler locale(Function<ApolloWSMessage, Locale> factory);
 }

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/GraphQLHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/GraphQLHandler.java
@@ -25,6 +25,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.impl.GraphQLHandlerImpl;
 import org.dataloader.DataLoaderRegistry;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 /**
@@ -75,4 +76,16 @@ public interface GraphQLHandler extends Handler<RoutingContext> {
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   GraphQLHandler dataLoaderRegistry(Function<RoutingContext, DataLoaderRegistry> factory);
+
+  /**
+   * Customize the locale passed to graphql execution engine
+   * The provided {@code factory} method will be invoked for each incoming GraphQL request.
+   *
+   * If a {@code factory} is not provided the first language found in Accept-Language header will be used
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  GraphQLHandler locale(Function<RoutingContext, Locale> factory);
 }

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLRequest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLRequest.java
@@ -50,6 +50,7 @@ public class GraphQLRequest {
   private boolean variablesAsParam;
   private String contentType = JSON;
   private Buffer requestBody;
+  private String locale;
 
   GraphQLRequest setMethod(HttpMethod method) {
     this.method = method;
@@ -109,6 +110,11 @@ public class GraphQLRequest {
     return this;
   }
 
+  GraphQLRequest setLocale(String locale) {
+    this.locale = locale;
+    return this;
+  }
+
   void send(HttpClient client, Handler<AsyncResult<JsonObject>> handler) throws Exception {
     send(client, 200, handler);
   }
@@ -117,6 +123,8 @@ public class GraphQLRequest {
     Promise<JsonObject> promise = Promise.promise();
     promise.future().setHandler(handler);
     HttpClientRequest request = client.request(method, 8080, "localhost", getUri());
+    if (locale != null)
+      request.putHeader("Accept-Language", locale);
     request.setHandler(ar -> {
       if (ar.succeeded()) {
         HttpClientResponse response = ar.result();

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
@@ -1,0 +1,73 @@
+package io.vertx.ext.web.handler.graphql;
+
+import org.junit.Test;
+
+import static io.vertx.core.http.HttpMethod.GET;
+
+public class LocaleTest extends GraphQLTestBase {
+  private static final String LOCALE = "el-CY";
+
+  @Test
+  public void testLocale() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setLocale(LOCALE)
+      .setGraphQLQuery("query { locale }");
+    request.send(client, onSuccess(body -> {
+      if (body.getJsonObject("data").getString("locale").equals(LOCALE)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testWrongLocale() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setLocale("")
+      .setGraphQLQuery("query { locale }");
+    request.send(client, onSuccess(body -> {
+      if (body.getJsonObject("data").getString("locale") != null) {
+        fail(body.toString());
+      } else {
+        testComplete();
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testMultipleLocale() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setLocale(LOCALE + ",en-GB")
+      .setGraphQLQuery("query { locale }");
+    request.send(client, onSuccess(body -> {
+      if (body.getJsonObject("data").getString("locale").equals(LOCALE)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testMultipleWrongLocales() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setLocale(",,,," + LOCALE)
+      .setGraphQLQuery("query { locale }");
+    request.send(client, onSuccess(body -> {
+      if (body.getJsonObject("data").getString("locale").equals(LOCALE)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+}

--- a/vertx-web-graphql/src/test/resources/locale.graphqls
+++ b/vertx-web-graphql/src/test/resources/locale.graphqls
@@ -1,0 +1,3 @@
+extend type Query {
+  locale: String
+}


### PR DESCRIPTION
Fixes #1529

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

1.I am not sure if it would be better to use io.vertx.ext.web.LanguageHeader inside factory instead of Locale.
2.I could not create test for the websocket implementation since i could not find a way to pass headers (Accept-Language) to httpClient.webSocket
