### PR TITLE
Updated json-schema-validator

### DIFF
--- a/vertx-web-api-contract/pom.xml
+++ b/vertx-web-api-contract/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser-v3</artifactId>
-      <version>2.0.18</version>
+      <version>2.0.14</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/vertx-web-api-contract/pom.xml
+++ b/vertx-web-api-contract/pom.xml
@@ -30,17 +30,13 @@
     <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.31</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser-v3</artifactId>
-      <version>2.0.14</version>
+      <version>2.0.18</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-yaml</artifactId>
@@ -50,12 +46,6 @@
           <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <!-- Force to 25.1 as that's the stack version -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>25.1-jre</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fixes #1528 & Fixes #1538

Dep tree:

```
[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ vertx-web-api-contract ---
[INFO] io.vertx:vertx-web-api-contract:jar:4.0.0-SNAPSHOT
[INFO] +- io.vertx:vertx-web:jar:4.0.0-SNAPSHOT:compile
[INFO] |  +- io.vertx:vertx-web-common:jar:4.0.0-SNAPSHOT:compile
[INFO] |  +- io.vertx:vertx-auth-common:jar:4.0.0-SNAPSHOT:compile
[INFO] |  \- io.vertx:vertx-bridge-common:jar:4.0.0-SNAPSHOT:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.2:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.10.2:compile
[INFO] +- com.networknt:json-schema-validator:jar:1.0.31:compile
[INFO] |  \- org.apache.commons:commons-lang3:jar:3.5:compile
[INFO] +- io.swagger.parser.v3:swagger-parser-v3:jar:2.0.14:compile
[INFO] |  +- io.swagger.core.v3:swagger-models:jar:2.0.9:compile
[INFO] |  +- io.swagger.core.v3:swagger-core:jar:2.0.9:compile
[INFO] |  |  +- javax.xml.bind:jaxb-api:jar:2.3.0:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.9.9:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-annotations:jar:2.0.9:compile
[INFO] |  |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO] |  +- io.swagger.parser.v3:swagger-parser-core:jar:2.0.14:compile
[INFO] |  \- commons-io:commons-io:jar:2.4:compile
[INFO] +- io.vertx:vertx-auth-jwt:jar:4.0.0-SNAPSHOT:compile
[INFO] |  \- io.vertx:vertx-jwt:jar:4.0.0-SNAPSHOT:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.10.2:compile
[INFO] |  \- org.yaml:snakeyaml:jar:1.24:compile
[INFO] +- io.vertx:vertx-web:test-jar:tests:4.0.0-SNAPSHOT:test
[INFO] +- io.vertx:vertx-web-client:jar:4.0.0-SNAPSHOT:test
[INFO] +- io.vertx:vertx-unit:jar:4.0.0-SNAPSHOT:test
[INFO] +- io.vertx:vertx-auth-properties:jar:4.0.0-SNAPSHOT:test
[INFO] +- io.vertx:vertx-service-proxy:jar:processor:4.0.0-SNAPSHOT:test
[INFO] +- org.slf4j:slf4j-api:jar:1.7.21:test
[INFO] +- io.vertx:vertx-core:jar:4.0.0-SNAPSHOT:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.45.Final:compile
[INFO] |  |  \- io.netty:netty-codec:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.45.Final:compile
[INFO] |  |  \- io.netty:netty-codec-socks:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.45.Final:compile
[INFO] |  +- io.netty:netty-resolver:jar:4.1.45.Final:compile
[INFO] |  \- io.netty:netty-resolver-dns:jar:4.1.45.Final:compile
[INFO] |     \- io.netty:netty-codec-dns:jar:4.1.45.Final:compile
[INFO] +- io.vertx:vertx-codegen:jar:4.0.0-SNAPSHOT:provided
[INFO] +- io.vertx:vertx-docgen:jar:0.9.2:provided
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- io.vertx:vertx-core:test-jar:tests:4.0.0-SNAPSHOT:test
```
