### PR TITLE
Add a Lazy Session option for the SessionHandler

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -294,6 +294,14 @@ public interface RoutingContext {
   @Nullable Session session();
 
   /**
+   * Whether the {@link RoutingContext#session()} has been already called or not. This is usually used by the
+   * {@link io.vertx.ext.web.handler.SessionHandler}.
+   *
+   * @return true if the session has been accessed.
+   */
+  boolean isSessionAccessed();
+
+  /**
    * Get the authenticated user (if any). This will usually be injected by an auth handler if authentication if successful.
    * @return  the user, or null if the current user is not authenticated.
    */

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -81,6 +81,11 @@ public interface SessionHandler extends Handler<RoutingContext> {
 	 */
 	int DEFAULT_SESSIONID_MIN_LENGTH = 16;
 
+  /**
+   * Default of whether the session should be created lazily.
+   */
+	boolean DEFAULT_LAZY_SESSION = false;
+
 	/**
 	 * Create a session handler
 	 *
@@ -90,7 +95,7 @@ public interface SessionHandler extends Handler<RoutingContext> {
 	static SessionHandler create(SessionStore sessionStore) {
 		return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_COOKIE_PATH, DEFAULT_SESSION_TIMEOUT,
 				DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG,
-				DEFAULT_SESSIONID_MIN_LENGTH, sessionStore);
+				DEFAULT_SESSIONID_MIN_LENGTH, DEFAULT_LAZY_SESSION, sessionStore);
 	}
 
 	/**
@@ -168,6 +173,15 @@ public interface SessionHandler extends Handler<RoutingContext> {
    * @return a reference to this, so the API can be used fluently
    */
 	SessionHandler setCookieSameSite(CookieSameSite policy);
+
+  /**
+   * Use a lazy session creation mechanism. The session will only be created when accessed from the context. Thus the
+   * session cookie is set only if the session was accessed.
+   *
+   * @param lazySession true to have a lazy session creation.
+   * @return a reference to this, so the API can be used fluently
+   */
+	SessionHandler setLazySession(boolean lazySession);
 
   /**
    * Set an auth provider that will allow retrieving the User object from the session to the current routing context.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -48,9 +48,11 @@ public class SessionHandlerImpl implements SessionHandler {
   private boolean sessionCookieHttpOnly;
   private int minLength;
   private CookieSameSite cookieSameSite;
+  private boolean lazySession = false;
 
   public SessionHandlerImpl(String sessionCookieName, String sessionCookiePath, long sessionTimeout, boolean nagHttps,
-                            boolean sessionCookieSecure, boolean sessionCookieHttpOnly, int minLength, SessionStore sessionStore) {
+                            boolean sessionCookieSecure, boolean sessionCookieHttpOnly, int minLength, boolean lazySession,
+                            SessionStore sessionStore) {
     this.sessionCookieName = sessionCookieName;
     this.sessionCookiePath = sessionCookiePath;
     this.sessionTimeout = sessionTimeout;
@@ -59,6 +61,7 @@ public class SessionHandlerImpl implements SessionHandler {
     this.sessionCookieSecure = sessionCookieSecure;
     this.sessionCookieHttpOnly = sessionCookieHttpOnly;
     this.minLength = minLength;
+    this.lazySession = lazySession;
   }
 
   @Override
@@ -106,6 +109,12 @@ public class SessionHandlerImpl implements SessionHandler {
   @Override
   public SessionHandler setCookieSameSite(CookieSameSite policy) {
     this.cookieSameSite = policy;
+    return this;
+  }
+
+  @Override
+  public SessionHandler setLazySession(boolean lazySession) {
+    this.lazySession = lazySession;
     return this;
   }
 
@@ -204,12 +213,12 @@ public class SessionHandlerImpl implements SessionHandler {
 
   private void addStoreSessionHandler(RoutingContext context, boolean storeUser) {
     context.addHeadersEndHandler(v -> {
+      boolean sessionUsed = context.isSessionAccessed();
       Session session = context.session();
       if (!session.isDestroyed()) {
         final int currentStatusCode = context.response().getStatusCode();
         // Store the session (only and only if there was no error)
         if (currentStatusCode >= 200 && currentStatusCode < 400) {
-
           // store the current user into the session
           if (storeUser) {
             // during the request the user might have been removed
@@ -218,7 +227,6 @@ public class SessionHandlerImpl implements SessionHandler {
             }
           }
 
-          session.setAccessed();
           if (session.isRegenerated()) {
             // this means that a session id has been changed, usually it means a session
             // upgrade
@@ -228,8 +236,9 @@ public class SessionHandlerImpl implements SessionHandler {
             // https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Session_ID_Life_Cycle
 
             // the session cookie needs to be updated to the new id
-            final Cookie cookie = context.getCookie(sessionCookieName);
+            final Cookie cookie = sessionCookie(context, session);
             // restore defaults
+            session.setAccessed();
             cookie.setValue(session.value()).setPath("/").setSecure(sessionCookieSecure)
               .setHttpOnly(sessionCookieHttpOnly);
 
@@ -246,17 +255,16 @@ public class SessionHandlerImpl implements SessionHandler {
                 });
               }
             });
-          } else {
+          } else if (! lazySession || sessionUsed) {
+            // if lazy mode activated, no need to store the session nor to create the session cookie if not used.
+            sessionCookie(context, session);
+            session.setAccessed();
             sessionStore.put(session, res -> {
               if (res.failed()) {
                 log.error("Failed to store session", res.cause());
               }
             });
           }
-        } else {
-          // don't send a cookie if status is not 2xx or 3xx
-          // remove it from the set (do not invalidate)
-          context.removeCookie(sessionCookieName, false);
         }
       } else {
         // invalidate the cookie as the session has been destroyed
@@ -284,13 +292,22 @@ public class SessionHandlerImpl implements SessionHandler {
   private void createNewSession(RoutingContext context) {
     Session session = sessionStore.createSession(sessionTimeout, minLength);
     context.setSession(session);
-    Cookie cookie = Cookie.cookie(sessionCookieName, session.value());
+    context.removeCookie(sessionCookieName, false);
+    addStoreSessionHandler(context, true);
+  }
+
+  private Cookie sessionCookie(final RoutingContext context, final Session session){
+    Cookie cookie = context.getCookie(sessionCookieName);
+    if(cookie != null) {
+      return cookie;
+    }
+    cookie = Cookie.cookie(sessionCookieName, session.value());
     cookie.setPath(sessionCookiePath);
     cookie.setSecure(sessionCookieSecure);
     cookie.setHttpOnly(sessionCookieHttpOnly);
     cookie.setSameSite(cookieSameSite);
     // Don't set max age - it's a session cookie
     context.addCookie(cookie);
-    addStoreSessionHandler(context, true);
+    return cookie;
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -206,6 +206,11 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
+  public boolean isSessionAccessed() {
+    return decoratedContext.isSessionAccessed();
+  }
+
+  @Override
   public ParsedHeaderValues parsedHeaders() {
     return decoratedContext.parsedHeaders();
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -61,6 +61,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private Set<FileUpload> fileUploads;
   private Session session;
   private User user;
+  private boolean isSessionAccessed = false;
 
   public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes) {
     super(mountPoint, routes);
@@ -289,7 +290,13 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   @Override
   public Session session() {
+    this.isSessionAccessed = true;
     return session;
+  }
+
+  @Override
+  public boolean isSessionAccessed(){
+    return isSessionAccessed;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -142,6 +142,11 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
+  public boolean isSessionAccessed() {
+    return inner.isSessionAccessed();
+  }
+
+  @Override
   public void setUser(User user) {
     inner.setUser(user);
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
@@ -271,4 +271,15 @@ public class RoutingContextImplTest extends WebTestBase {
       req.write(Buffer.buffer("{ \"foo\": \"bar\" }"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
   }
+  @Test
+  public void testSessionAccessed() throws Exception {
+    router.route().handler(event -> {
+      assertFalse(event.isSessionAccessed());
+      event.session();
+      assertTrue(event.isSessionAccessed());
+      event.response().end();
+    });
+    testRequest(HttpMethod.GET, "/", null, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
+  }
+
 }


### PR DESCRIPTION


This commit adds a new SessionHandler option : lazySession. With this option set, the session is still (re)created in the SessionHandler.handle(...) but not always stored in the sessionStore.
The RoutingContext is now responsible to track whether the session has been accessed. In that case the new accessedSession() method must return true.
Thanks to this new RoutingContext.accessedSession() method, the SessionHandler is able to know whether the session has been accessed and to decide whether it has to store it.

Motivation:

The goal of this PR is to have a mean to stop vert.x SessionHandler to always create a session Cookie.

In some cases, application built with Vert.x doesn't know in advance if they will use the session, and if not, may not want to be treated like a stateful application by network components (ie Load Balancers).

This commit follows the discussion accessible here : https://groups.google.com/d/msg/vertx/hoQEgU2d_FY/uUu2jdd7AQAJ

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
