### PR TITLE
Add a type safe extra parameter for scopes

### DIFF
--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -14,6 +14,7 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.auth.webauthn.*;
 import io.vertx.ext.jwt.JWTOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
@@ -1243,7 +1244,7 @@ public class WebExamples {
   public void example59(Vertx vertx, Router router) {
 
     // create an OAuth2 provider, clientID and clientSecret should be requested to Google
-    OAuth2Auth authProvider = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+    OAuth2Auth authProvider = OAuth2Auth.create(vertx, new OAuth2Options()
       .setClientID("CLIENT_ID")
       .setClientSecret("CLIENT_SECRET")
       .setFlow(OAuth2FlowType.AUTH_CODE)
@@ -1255,7 +1256,7 @@ public class WebExamples {
     OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(vertx, authProvider, "http://localhost:8080");
 
     // these are the scopes
-    oauth2.extraParams(new JsonObject().put("scope", "profile"));
+    oauth2.withScope("profile");
 
     // setup the callback handler for receiving the Google callback
     oauth2.setupCallback(router.get("/callback"));
@@ -1298,7 +1299,7 @@ public class WebExamples {
         .setupCallback(router.route("/callback"))
         // for this resource we require that users have
         // the authority to retrieve the user emails
-        .extraParams(new JsonObject().put("scope", "user:email"))
+        .withScope("user:email")
     );
     // Entry point to the application, this will render
     // a custom template.
@@ -1519,7 +1520,7 @@ public class WebExamples {
     githubOAuth2.setupCallback(router.route());
 
     // create an OAuth2 provider, clientID and clientSecret should be requested to Google
-    OAuth2Auth googleAuthProvider = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+    OAuth2Auth googleAuthProvider = OAuth2Auth.create(vertx, new OAuth2Options()
       .setClientID("CLIENT_ID")
       .setClientSecret("CLIENT_SECRET")
       .setFlow(OAuth2FlowType.AUTH_CODE)

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -76,6 +76,25 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
   OAuth2AuthHandler withScope(String scope);
 
   /**
+   * Indicates the type of user interaction that is required. Not all providers support this or the full list.
+   *
+   * Well known values are:
+   *
+   * <ul>
+   *   <li><b>login</b> will force the user to enter their credentials on that request, negating single-sign on.</li>
+   *   <li><b>none</b> is the opposite - it will ensure that the user isn't presented with any interactive prompt whatsoever. If the request can't be completed silently via single-sign on, the Microsoft identity platform endpoint will return an interaction_required error.</li>
+   *   <li><b>consent</b> will trigger the OAuth consent dialog after the user signs in, asking the user to grant permissions to the app.</li>
+   *   <li><b>select_account</b> will interrupt single sign-on providing account selection experience listing all the accounts either in session or any remembered account or an option to choose to use a different account altogether.</li>
+   *   <li><b></b></li>
+   * </ul>
+   *
+   * @param prompt the prompt choice.
+   * @return self
+   */
+  @Fluent
+  OAuth2AuthHandler prompt(String prompt);
+
+  /**
    * add the callback handler to a given route.
    * @param route a given route e.g.: `/callback`
    * @return self

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -67,6 +67,15 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
   OAuth2AuthHandler extraParams(JsonObject extraParams);
 
   /**
+   * scopes to be requested while requesting a token.
+   *
+   * @param scope scope.
+   * @return self
+   */
+  @Fluent
+  OAuth2AuthHandler withScope(String scope);
+
+  /**
    * add the callback handler to a given route.
    * @param route a given route e.g.: `/callback`
    * @return self

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -51,6 +51,7 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
   private Route callback;
   private JsonObject extraParams;
   private List<String> scopes = new ArrayList<>();
+  private String prompt;
 
   // explicit signal that tokens are handled as bearer only (meaning, no backend server known)
   private boolean bearerOnly = true;
@@ -149,8 +150,9 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
       config.mergeIn(extraParams);
     }
 
-    if (scopes.size() > 0) {
-      config.put("scopes", scopes);
+    config.put("scopes", scopes);
+    if (prompt != null) {
+      config.put("prompt", prompt);
     }
 
     return ((OAuth2Auth) authProvider).authorizeURL(config);
@@ -165,6 +167,12 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
   @Override
   public OAuth2AuthHandler withScope(String scope) {
     this.scopes.add(scope);
+    return this;
+  }
+
+  @Override
+  public OAuth2AuthHandler prompt(String prompt) {
+    this.prompt = prompt;
     return this;
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -34,6 +34,8 @@ import io.vertx.ext.web.handler.OAuth2AuthHandler;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
@@ -48,6 +50,8 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
 
   private Route callback;
   private JsonObject extraParams;
+  private List<String> scopes = new ArrayList<>();
+
   // explicit signal that tokens are handled as bearer only (meaning, no backend server known)
   private boolean bearerOnly = true;
 
@@ -145,12 +149,22 @@ public class OAuth2AuthHandlerImpl extends AuthorizationAuthHandler implements O
       config.mergeIn(extraParams);
     }
 
+    if (scopes.size() > 0) {
+      config.put("scopes", scopes);
+    }
+
     return ((OAuth2Auth) authProvider).authorizeURL(config);
   }
 
   @Override
   public OAuth2AuthHandler extraParams(JsonObject extraParams) {
     this.extraParams = extraParams;
+    return this;
+  }
+
+  @Override
+  public OAuth2AuthHandler withScope(String scope) {
+    this.scopes.add(scope);
     return this;
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -21,7 +21,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
-import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
 import io.vertx.ext.jwt.JWK;
 import io.vertx.ext.jwt.JWT;
@@ -56,7 +56,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
   public void testAuthCodeFlow() throws Exception {
 
     // lets mock a oauth2 server using code auth code flow
-    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
       .setClientID("client-id")
       .setFlow(OAuth2FlowType.AUTH_CODE)
       .setClientSecret("client-secret")
@@ -114,7 +114,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
   public void testAuthCodeFlowBadSetup() throws Exception {
 
     // lets mock a oauth2 server using code auth code flow
-    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
       .setFlow(OAuth2FlowType.AUTH_CODE)
       .setClientID("client-id")
       .setClientSecret("client-secret")
@@ -199,7 +199,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
   public void testPasswordFlow() throws Exception {
 
     // lets mock a oauth2 server using code auth code flow
-    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
       .setClientID("client-id")
       .setClientSecret("client-secret")
       .setSite("http://localhost:10000")
@@ -256,7 +256,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
   public void testBearerOnly() throws Exception {
 
     // lets mock a oauth2 server using code auth code flow
-    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2ClientOptions().setFlow(OAuth2FlowType.AUTH_CODE).setClientID("client-id"));
+    OAuth2Auth oauth2 = OAuth2Auth.create(vertx, new OAuth2Options().setFlow(OAuth2FlowType.AUTH_CODE).setClientID("client-id"));
     OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(vertx, oauth2);
 
     // protect everything under /protected
@@ -279,7 +279,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     OAuth2Auth oauth = OAuth2Auth
       .create(
         vertx,
-        new OAuth2ClientOptions()
+        new OAuth2Options()
           .setClientID("dummy-client")
           .addPubSecKey(new PubSecKeyOptions()
             .setAlgorithm("RS256")


### PR DESCRIPTION
currently adding required oauth2 scopes requires the user to fiddle with untyped json config. This pull request will make the api self documenting and type safe.