### PR TITLE
Make forward header parsing strict

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/AllowForwardHeaders.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/AllowForwardHeaders.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * What kind of forward header parsing are we allowing.
+ *
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+@VertxGen
+public enum AllowForwardHeaders {
+
+  /**
+   * No parsing shall be performed.
+   */
+  NONE,
+
+  /**
+   * Only process the standard {@code Forward} header as defined by <a href="https://tools.ietf.org/html/rfc7239#section-4>RFC 7239, section 4: Forwarded</a>.
+   *
+   * For more info see: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded">https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded</a>
+   */
+  FORWARD,
+
+  /**
+   * Only process the non standard but widely used {@code X-Forward-*} headers.
+   *
+   * These headers are not official standards but widely used. Users are advised to avoid them for new applications.
+   */
+  X_FORWARD,
+
+  /**
+   * Will process both {@link #FORWARD} and {@link #X_FORWARD}. Be aware that mixing the 2 headers can open
+   * security holes has specially crafted requests that are not validated as proxy level can allow bypassing
+   * the proxy desired forward value.
+   *
+   * For example, a proxy will add the {@code X-Forward-*} headers to a request but not filter out if the original
+   * request includes the {@code Forward} header.
+   */
+  ALL
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -394,9 +394,9 @@ public interface Router extends Handler<HttpServerRequest> {
   /**
    * Set whether the router should parse "forwarded"-type headers
    *
-   * @param allow to enable parsing of "forwarded"-type headers
+   * @param allowForwardHeaders to enable parsing of "forwarded"-type headers
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  Router allowForward(boolean allow);
+  Router allowForward(AllowForwardHeaders allowForwardHeaders);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -25,6 +25,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.ext.web.AllowForwardHeaders;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,7 +47,7 @@ class ForwardedParser {
   private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
 
   private final HttpServerRequest delegate;
-  private final boolean allowForward;
+  private final AllowForwardHeaders allowForward;
 
   private boolean calculated;
   private String host;
@@ -55,7 +56,7 @@ class ForwardedParser {
   private String absoluteURI;
   private SocketAddress remoteAddress;
 
-  ForwardedParser(HttpServerRequest delegate, boolean allowForward) {
+  ForwardedParser(HttpServerRequest delegate, AllowForwardHeaders allowForward) {
     this.delegate = delegate;
     this.allowForward = allowForward;
   }
@@ -93,62 +94,29 @@ class ForwardedParser {
     return remoteAddress;
   }
 
+  /**
+   * Parses the current {@code Forward} header if present.
+   */
   private void calculate() {
     calculated = true;
     remoteAddress = delegate.remoteAddress();
     scheme = delegate.scheme();
     setHostAndPort(delegate.host(), port);
 
-    if (allowForward) {
-      String forwardedSsl = delegate.getHeader(X_FORWARDED_SSL);
-      boolean isForwardedSslOn = forwardedSsl != null && forwardedSsl.equalsIgnoreCase("on");
-
-      String forwarded = delegate.getHeader(FORWARDED);
-      if (forwarded != null) {
-        String forwardedToUse = forwarded.split(",")[0];
-        Matcher matcher = FORWARDED_PROTO_PATTERN.matcher(forwardedToUse);
-        if (matcher.find()) {
-          scheme = (matcher.group(1).trim());
-          port = -1;
-        } else if (isForwardedSslOn) {
-          scheme = HTTPS_SCHEME;
-          port = -1;
-        }
-
-        matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
-        if (matcher.find()) {
-          setHostAndPort(matcher.group(1).trim(), port);
-        }
-
-        matcher = FORWARDED_FOR_PATTERN.matcher(forwardedToUse);
-        if (matcher.find()) {
-          remoteAddress = parseFor(matcher.group(1).trim(), remoteAddress.port());
-        }
-      } else {
-        String protocolHeader = delegate.getHeader(X_FORWARDED_PROTO);
-        if (protocolHeader != null) {
-          scheme = protocolHeader.split(",")[0];
-          port = -1;
-        } else if (isForwardedSslOn) {
-          scheme = HTTPS_SCHEME;
-          port = -1;
-        }
-
-        String hostHeader = delegate.getHeader(X_FORWARDED_HOST);
-        if (hostHeader != null) {
-          setHostAndPort(hostHeader.split(",")[0], port);
-        }
-
-        String portHeader = delegate.getHeader(X_FORWARDED_PORT);
-        if (portHeader != null) {
-          port = parsePort(portHeader.split(",")[0], port);
-        }
-
-        String forHeader = delegate.getHeader(X_FORWARDED_FOR);
-        if (forHeader != null) {
-          remoteAddress = parseFor(forHeader.split(",")[0], remoteAddress.port());
-        }
-      }
+    switch (allowForward) {
+      case X_FORWARD:
+        calculateXForward();
+        break;
+      case FORWARD:
+        calculateForward();
+        break;
+      case ALL:
+        calculateXForward();
+        calculateForward();
+        break;
+      case NONE:
+      default:
+        break;
     }
 
     if (((scheme.equals(HTTP_SCHEME) && port == 80) || (scheme.equals(HTTPS_SCHEME) && port == 443))) {
@@ -157,6 +125,57 @@ class ForwardedParser {
 
     host = host + (port >= 0 ? ":" + port : "");
     absoluteURI = scheme + "://" + host + delegate.uri();
+  }
+
+  private void calculateForward() {
+    String forwarded = delegate.getHeader(FORWARDED);
+    if (forwarded != null) {
+      String forwardedToUse = forwarded.split(",")[0];
+      Matcher matcher = FORWARDED_PROTO_PATTERN.matcher(forwardedToUse);
+      if (matcher.find()) {
+        scheme = (matcher.group(1).trim());
+        port = -1;
+      }
+
+      matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
+      if (matcher.find()) {
+        setHostAndPort(matcher.group(1).trim(), port);
+      }
+
+      matcher = FORWARDED_FOR_PATTERN.matcher(forwardedToUse);
+      if (matcher.find()) {
+        remoteAddress = parseFor(matcher.group(1).trim(), remoteAddress.port());
+      }
+    }
+  }
+
+  private void calculateXForward() {
+    String forwardedSsl = delegate.getHeader(X_FORWARDED_SSL);
+    boolean isForwardedSslOn = forwardedSsl != null && forwardedSsl.equalsIgnoreCase("on");
+
+    String protocolHeader = delegate.getHeader(X_FORWARDED_PROTO);
+    if (protocolHeader != null) {
+      scheme = protocolHeader.split(",")[0];
+      port = -1;
+    } else if (isForwardedSslOn) {
+      scheme = HTTPS_SCHEME;
+      port = -1;
+    }
+
+    String hostHeader = delegate.getHeader(X_FORWARDED_HOST);
+    if (hostHeader != null) {
+      setHostAndPort(hostHeader.split(",")[0], port);
+    }
+
+    String portHeader = delegate.getHeader(X_FORWARDED_PORT);
+    if (portHeader != null) {
+      port = parsePort(portHeader.split(",")[0], port);
+    }
+
+    String forHeader = delegate.getHeader(X_FORWARDED_FOR);
+    if (forHeader != null) {
+      remoteAddress = parseFor(forHeader.split(",")[0], remoteAddress.port());
+    }
   }
 
   private void setHostAndPort(String hostToParse, int defaultPort) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -8,6 +8,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.AllowForwardHeaders;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -27,7 +28,7 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   private String uri;
   private String absoluteURI;
 
-  HttpServerRequestWrapper(HttpServerRequest request, boolean allowForward) {
+  HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward) {
     delegate = request;
     forwardedParser = new ForwardedParser(delegate, allowForward);
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.web.AllowForwardHeaders;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -265,13 +266,13 @@ public class RouterImpl implements Router {
   }
 
   @Override
-  public synchronized Router allowForward(boolean allow) {
-    state = state.setAllowForward(allow);
+  public synchronized Router allowForward(AllowForwardHeaders allowForwardHeaders) {
+    state = state.setAllowForward(allowForwardHeaders);
     return this;
   }
 
-  public boolean isAllowForward() {
-    return state.isAllowForward();
+  public AllowForwardHeaders getAllowForward() {
+    return state.getAllowForward();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterState.java
@@ -16,6 +16,7 @@
 package io.vertx.ext.web.impl;
 
 import io.vertx.core.Handler;
+import io.vertx.ext.web.AllowForwardHeaders;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
@@ -57,9 +58,9 @@ final class RouterState {
   private final int orderSequence;
   private final Map<Integer, Handler<RoutingContext>> errorHandlers;
   private final Handler<Router> modifiedHandler;
-  private final boolean allowForward;
+  private final AllowForwardHeaders allowForward;
 
-  public RouterState(RouterImpl router, Set<RouteImpl> routes, int orderSequence, Map<Integer, Handler<RoutingContext>> errorHandlers, Handler<Router> modifiedHandler, boolean allowForward) {
+  public RouterState(RouterImpl router, Set<RouteImpl> routes, int orderSequence, Map<Integer, Handler<RoutingContext>> errorHandlers, Handler<Router> modifiedHandler, AllowForwardHeaders allowForward) {
     this.router = router;
     this.routes = routes;
     this.orderSequence = orderSequence;
@@ -75,7 +76,7 @@ final class RouterState {
       0,
       null,
       null,
-      false);
+      AllowForwardHeaders.NONE);
   }
 
   public RouterImpl router() {
@@ -216,7 +217,7 @@ final class RouterState {
       this.allowForward);
   }
 
-  public RouterState setAllowForward(boolean allow) {
+  public RouterState setAllowForward(AllowForwardHeaders allow) {
     return new RouterState(
       this.router,
       this.routes,
@@ -226,7 +227,7 @@ final class RouterState {
       allow);
   }
 
-  public boolean isAllowForward() {
+  public AllowForwardHeaders getAllowForward() {
     return allowForward;
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -66,7 +66,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes) {
     super(mountPoint, routes);
     this.router = router;
-    this.request = new HttpServerRequestWrapper(request, router.isAllowForward());
+    this.request = new HttpServerRequestWrapper(request, router.getAllowForward());
 
     fillParsedHeaders(request);
     if (request.path().length() == 0) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -19,11 +19,13 @@ package io.vertx.ext.web;
 import io.vertx.core.http.HttpMethod;
 import org.junit.Test;
 
+import static io.vertx.ext.web.AllowForwardHeaders.*;
+
 public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testXForwardSSL() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
       rc.end();
@@ -33,8 +35,31 @@ public class ForwardedTest extends WebTestBase {
   }
 
   @Test
+  public void testXForwardSSLVariation2() throws Exception {
+    router.allowForward(FORWARD).route("/").handler(rc -> {
+      // in this case the legacy headers are not considered and will not overwrite the value
+      assertFalse(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "http");
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Ssl", "On");
+  }
+
+  @Test
+  public void testXForwardSSLVariation3() throws Exception {
+    router.allowForward(X_FORWARD).route("/").handler(rc -> {
+      // this is variation of the previous test but in this case it should assert true
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-Ssl", "On");
+  }
+  @Test
   public void testForwardedProto() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
       rc.end();
@@ -46,7 +71,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testForwardedHostAlongWithXForwardSSL() throws Exception {
     String host = "vertx.io";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
@@ -58,7 +83,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testMultipleForwarded() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
       rc.end();
@@ -69,7 +94,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testForwardedProtoAlongWIthXForwardSSL() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertFalse(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "http");
       rc.end();
@@ -81,7 +106,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testForwardedHost() throws Exception {
     String host = "vertx.io";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -92,7 +117,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testForwardedHostAndPort() throws Exception {
     String host = "vertx.io:1234";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -103,7 +128,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testForwardedHostAndPortAndProto() throws Exception {
     String host = "vertx.io:1234";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
@@ -115,7 +140,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testXForwardedProto() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "https");
       rc.end();
@@ -126,7 +151,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testXForwardedProtoAlongWIthXForwardSSL() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertFalse(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "http");
       rc.end();
@@ -139,7 +164,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedHost() throws Exception {
     String host = "vertx.io";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -150,7 +175,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedHostAndPort() throws Exception {
     String host = "vertx.io:4321";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -161,7 +186,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedHostRemovesCommonPort() throws Exception {
     String host = "vertx.io";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -172,7 +197,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedHostMultiple() throws Exception {
     String host = "vertx.io";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertEquals(rc.request().host(), host);
       rc.end();
     });
@@ -183,7 +208,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedPort() throws Exception {
     String port = "1234";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().host().endsWith(":" + port));
       rc.end();
     });
@@ -195,7 +220,7 @@ public class ForwardedTest extends WebTestBase {
   public void testXForwardedPortAndHost() throws Exception {
     String host = "vertx.io";
     String port = "1234";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().host().equals(host + ":" + port));
       rc.end();
     });
@@ -207,7 +232,7 @@ public class ForwardedTest extends WebTestBase {
   public void testXForwardedPortAndHostWithPort() throws Exception {
     String host = "vertx.io";
     String port = "1234";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().host().equals(host + ":" + port));
       rc.end();
     });
@@ -217,7 +242,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testIllegalPort() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().host().endsWith(":8080"));
       rc.end();
     });
@@ -228,7 +253,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testXForwardedFor() throws Exception {
     String host = "1.2.3.4";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().remoteAddress().host().equals(host));
       rc.end();
     });
@@ -240,7 +265,7 @@ public class ForwardedTest extends WebTestBase {
   public void testXForwardedForWithPort() throws Exception {
     String host = "1.2.3.4";
     int port = 1111;
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().remoteAddress().host().equals(host));
       assertTrue(rc.request().remoteAddress().port() == port);
       rc.end();
@@ -252,7 +277,7 @@ public class ForwardedTest extends WebTestBase {
   @Test
   public void testForwardedFor() throws Exception {
     String host = "1.2.3.4";
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().remoteAddress().host().equals(host));
       rc.end();
     });
@@ -265,7 +290,7 @@ public class ForwardedTest extends WebTestBase {
     String host = "[2001:db8:cafe::17]";
     int port = 4711;
 
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().remoteAddress().host().equals(host));
       assertTrue(rc.request().remoteAddress().port() == port);
       rc.end();
@@ -276,7 +301,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testNoForwarded() throws Exception {
-    router.allowForward(true).route("/").handler(rc -> {
+    router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().remoteAddress().host().equals("127.0.0.1"));
       assertTrue(rc.request().host().equals("localhost:8080"));
       assertTrue(rc.request().scheme().equals("http"));
@@ -289,7 +314,7 @@ public class ForwardedTest extends WebTestBase {
 
   @Test
   public void testForwardedDisabled() throws Exception {
-    router.allowForward(false).route("/").handler(rc -> {
+    router.allowForward(NONE).route("/").handler(rc -> {
       assertFalse(rc.request().isSSL());
       assertEquals(rc.request().scheme(), "http");
       rc.end();


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Current forward parsing is not strict and may allow users with bad intentions to bypass bad configured proxy servers.

This is a breaking change as it requires the user to specifically state what kind of parsing should be applied.

Fixes #1519 