### PR TITLE
bug fix: add RouteingContext as `context`

### DIFF
--- a/vertx-web/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-web/src/main/asciidoc/dataobjects.adoc
@@ -1,7 +1,20 @@
 = Cheatsheets
 
-[[BridgeOptions]]
-== BridgeOptions
+[[Http2PushMapping]]
+== Http2PushMapping
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[extensionTarget]]`@extensionTarget`|`String`|-
+|[[filePath]]`@filePath`|`String`|-
+|[[noPush]]`@noPush`|`Boolean`|-
+|===
+
+[[SockJSBridgeOptions]]
+== SockJSBridgeOptions
 
 ++++
  Options for configuring the event bus bridge.
@@ -16,19 +29,6 @@
 |[[maxHandlersPerSocket]]`@maxHandlersPerSocket`|`Number (int)`|-
 |[[pingTimeout]]`@pingTimeout`|`Number (long)`|-
 |[[replyTimeout]]`@replyTimeout`|`Number (long)`|-
-|===
-
-[[Http2PushMapping]]
-== Http2PushMapping
-
-
-[cols=">25%,25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[extensionTarget]]`@extensionTarget`|`String`|-
-|[[filePath]]`@filePath`|`String`|-
-|[[noPush]]`@noPush`|`Boolean`|-
 |===
 
 [[SockJSHandlerOptions]]

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1899,7 +1899,7 @@ A special SockJS socket handler is then installed on the {@link io.vertx.ext.web
 handles the SockJS data and bridges it to and from the server side event bus.
 
 To activate the bridge you simply call
-{@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(io.vertx.ext.web.handler.sockjs.BridgeOptions)} on the
+{@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions)} on the
 SockJS handler.
 
 [source,$lang]
@@ -2022,7 +2022,7 @@ In other words the bridge acts like a kind of firewall which has a default _deny
 Configuring the bridge to tell it what messages it should pass through is easy.
 
 You can specify which _matches_ you want to allow for inbound and outbound traffic using the
-{@link io.vertx.ext.web.handler.sockjs.BridgeOptions} that you pass in when calling bridge.
+{@link io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions} that you pass in when calling bridge.
 
 Each match is a {@link io.vertx.ext.bridge.PermittedOptions} object:
 
@@ -2087,7 +2087,7 @@ To handle the login and actually auth you can configure the normal Vert.x auth h
 === Handling event bus bridge events
 
 If you want to be notified when an event occurs on the bridge you can provide a handler when calling
-{@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(io.vertx.ext.web.handler.sockjs.BridgeOptions, io.vertx.core.Handler)}.
+{@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions, io.vertx.core.Handler)}.
 
 Whenever an event occurs on the bridge it will be passed to the handler. The event is described by an instance of
 {@link io.vertx.ext.web.handler.sockjs.BridgeEvent}.

--- a/vertx-web/src/main/generated/io/vertx/ext/web/handler/sockjs/SockJSBridgeOptionsConverter.java
+++ b/vertx-web/src/main/generated/io/vertx/ext/web/handler/sockjs/SockJSBridgeOptionsConverter.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.web.handler.sockjs;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions} original class using Vert.x codegen.
+ */
+public class SockJSBridgeOptionsConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SockJSBridgeOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "maxAddressLength":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxAddressLength(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxHandlersPerSocket":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxHandlersPerSocket(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "pingTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setPingTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "replyTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setReplyTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(SockJSBridgeOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(SockJSBridgeOptions obj, java.util.Map<String, Object> json) {
+    json.put("maxAddressLength", obj.getMaxAddressLength());
+    json.put("maxHandlersPerSocket", obj.getMaxHandlersPerSocket());
+    json.put("pingTimeout", obj.getPingTimeout());
+    json.put("replyTimeout", obj.getReplyTimeout());
+  }
+}

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -18,7 +18,6 @@ import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.auth.webauthn.*;
 import io.vertx.ext.jwt.JWTOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
-import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.OAuth2FlowType;
 import io.vertx.ext.auth.oauth2.providers.GithubAuth;
 import io.vertx.ext.bridge.BridgeEventType;
@@ -26,7 +25,7 @@ import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.*;
 import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.handler.*;
-import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.sstore.ClusteredSessionStore;
@@ -922,7 +921,7 @@ public class WebExamples {
     Router router = Router.router(vertx);
 
     SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
-    BridgeOptions options = new BridgeOptions();
+    SockJSBridgeOptions options = new SockJSBridgeOptions();
     // mount the bridge on the router
     router.mountSubRouter("/eventbus", sockJSHandler.bridge(options));
   }
@@ -956,7 +955,7 @@ public class WebExamples {
     PermittedOptions outboundPermitted2 = new PermittedOptions().setAddressRegex("news\\..+");
 
     // Let's define what we're going to allow from client -> server
-    BridgeOptions options = new BridgeOptions().
+    SockJSBridgeOptions options = new SockJSBridgeOptions().
       addInboundPermitted(inboundPermitted1).
       addInboundPermitted(inboundPermitted1).
       addInboundPermitted(inboundPermitted3).
@@ -975,7 +974,7 @@ public class WebExamples {
     // But only if the user is logged in and has the authority "place_orders"
     inboundPermitted.setRequiredAuthority("place_orders");
 
-    BridgeOptions options = new BridgeOptions().addInboundPermitted(inboundPermitted);
+    SockJSBridgeOptions options = new SockJSBridgeOptions().addInboundPermitted(inboundPermitted);
   }
 
   public void example48(Vertx vertx, AuthenticationProvider authProvider) {
@@ -1001,7 +1000,7 @@ public class WebExamples {
     // mount the bridge on the router
     router.mountSubRouter(
       "/eventbus",
-      sockJSHandler.bridge(new BridgeOptions().addInboundPermitted(inboundPermitted)));
+      sockJSHandler.bridge(new SockJSBridgeOptions().addInboundPermitted(inboundPermitted)));
   }
 
   public void example48_1(Vertx vertx) {
@@ -1012,7 +1011,7 @@ public class WebExamples {
     PermittedOptions inboundPermitted = new PermittedOptions().setAddress("demo.orderService");
 
     SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
-    BridgeOptions options = new BridgeOptions().addInboundPermitted(inboundPermitted);
+    SockJSBridgeOptions options = new SockJSBridgeOptions().addInboundPermitted(inboundPermitted);
 
     // mount the bridge on the router
     router.mountSubRouter(
@@ -1037,7 +1036,7 @@ public class WebExamples {
     PermittedOptions inboundPermitted = new PermittedOptions().setAddress("demo.someService");
 
     SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
-    BridgeOptions options = new BridgeOptions().addInboundPermitted(inboundPermitted);
+    SockJSBridgeOptions options = new SockJSBridgeOptions().addInboundPermitted(inboundPermitted);
 
     // mount the bridge on the router
     router.mountSubRouter("/eventbus", sockJSHandler.bridge(options, be -> {
@@ -1057,7 +1056,7 @@ public class WebExamples {
 
     // Initialize SockJS handler
     SockJSHandler sockJSHandler = SockJSHandler.create(vertx);
-    BridgeOptions options = new BridgeOptions().addInboundPermitted(inboundPermitted).setPingTimeout(5000);
+    SockJSBridgeOptions options = new SockJSBridgeOptions().addInboundPermitted(inboundPermitted).setPingTimeout(5000);
 
     // mount the bridge on the router
     router.mountSubRouter("/eventbus", sockJSHandler.bridge(options, be -> {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -69,7 +69,9 @@ public class TemplateHandlerImpl implements TemplateHandler {
       }
     }
     // render using the engine
-    engine.render(new JsonObject(context.data()), templateDirectory + file, res -> {
+	JsonObject obj = new JsonObject(context.data());
+	obj.put("context", context) // follow the docs: can access RoutingContext as `context`
+    engine.render(obj, templateDirectory + file, res -> {
       if (res.succeeded()) {
         context.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType).end(res.result());
       } else {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSBridgeOptions.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSBridgeOptions.java
@@ -16,12 +16,11 @@
 package io.vertx.ext.web.handler.sockjs;
 
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import io.vertx.ext.bridge.BridgeOptions;
 import io.vertx.ext.bridge.PermittedOptions;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -29,8 +28,8 @@ import java.util.List;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-@DataObject
-public class BridgeOptions {
+@DataObject(generateConverter = true)
+public class SockJSBridgeOptions extends BridgeOptions {
 
   /**
    * Default value for max address length = 200
@@ -57,27 +56,24 @@ public class BridgeOptions {
   private long pingTimeout;
   private long replyTimeout;
 
-  private List<PermittedOptions> inboundPermitted = new ArrayList<>();
-  private List<PermittedOptions> outboundPermitted = new ArrayList<>();
-
   /**
    * Copy constructor
    *
    * @param other  the options to copy
    */
-  public BridgeOptions(BridgeOptions other) {
+  public SockJSBridgeOptions(SockJSBridgeOptions other) {
+    super(other);
     this.maxAddressLength = other.maxAddressLength;
     this.maxHandlersPerSocket = other.maxHandlersPerSocket;
     this.pingTimeout = other.pingTimeout;
     this.replyTimeout = other.replyTimeout;
-    this.inboundPermitted = new ArrayList<>(other.inboundPermitted);
-    this.outboundPermitted = new ArrayList<>(other.outboundPermitted);
   }
 
   /**
    * Default constructor
    */
-  public BridgeOptions() {
+  public SockJSBridgeOptions() {
+    super();
     this.maxAddressLength = DEFAULT_MAX_ADDRESS_LENGTH;
     this.maxHandlersPerSocket = DEFAULT_MAX_HANDLERS_PER_SOCKET;
     this.pingTimeout = DEFAULT_PING_TIMEOUT;
@@ -89,41 +85,17 @@ public class BridgeOptions {
    *
    * @param json  the JSON
    */
-  public BridgeOptions(JsonObject json) {
-    this.maxAddressLength = json.getInteger("maxAddressLength", DEFAULT_MAX_ADDRESS_LENGTH);
-    this.maxHandlersPerSocket = json.getInteger("maxHandlersPerSocket", DEFAULT_MAX_HANDLERS_PER_SOCKET);
-    this.pingTimeout = json.getLong("pingTimeout", DEFAULT_PING_TIMEOUT);
-    this.replyTimeout = json.getLong("replyTimeout", DEFAULT_REPLY_TIMEOUT);
-    //TODO simplify common code
-    JsonArray arr = json.getJsonArray("inboundPermitteds");
-    if (arr != null) {
-      for (Object obj: arr) {
-        if (obj instanceof JsonObject) {
-          JsonObject jobj = (JsonObject)obj;
-          inboundPermitted.add(new PermittedOptions(jobj));
-        } else {
-          throw new IllegalArgumentException("Invalid type " + obj.getClass() + " in inboundPermitteds array");
-        }
-      }
-    }
-    arr = json.getJsonArray("outboundPermitteds");
-    if (arr != null) {
-      for (Object obj: arr) {
-        if (obj instanceof JsonObject) {
-          JsonObject jobj = (JsonObject)obj;
-          outboundPermitted.add(new PermittedOptions(jobj));
-        } else {
-          throw new IllegalArgumentException("Invalid type " + obj.getClass() + " in outboundPermitteds array");
-        }
-      }
-    }
+  public SockJSBridgeOptions(JsonObject json) {
+    // init defaults
+    this();
+    SockJSBridgeOptionsConverter.fromJson(json, this);
   }
 
   public int getMaxAddressLength() {
     return maxAddressLength;
   }
 
-  public BridgeOptions setMaxAddressLength(int maxAddressLength) {
+  public SockJSBridgeOptions setMaxAddressLength(int maxAddressLength) {
     if (maxAddressLength < 1) {
       throw new IllegalArgumentException("maxAddressLength must be > 0");
     }
@@ -135,7 +107,7 @@ public class BridgeOptions {
     return maxHandlersPerSocket;
   }
 
-  public BridgeOptions setMaxHandlersPerSocket(int maxHandlersPerSocket) {
+  public SockJSBridgeOptions setMaxHandlersPerSocket(int maxHandlersPerSocket) {
     if (maxHandlersPerSocket < 1) {
       throw new IllegalArgumentException("maxHandlersPerSocket must be > 0");
     }
@@ -147,7 +119,7 @@ public class BridgeOptions {
     return pingTimeout;
   }
 
-  public BridgeOptions setPingTimeout(long pingTimeout) {
+  public SockJSBridgeOptions setPingTimeout(long pingTimeout) {
     if (pingTimeout < 1) {
       throw new IllegalArgumentException("pingTimeout must be > 0");
     }
@@ -159,7 +131,7 @@ public class BridgeOptions {
     return replyTimeout;
   }
 
-  public BridgeOptions setReplyTimeout(long replyTimeout) {
+  public SockJSBridgeOptions setReplyTimeout(long replyTimeout) {
     if (replyTimeout < 1) {
       throw new IllegalArgumentException("replyTimeout must be > 0");
     }
@@ -167,29 +139,34 @@ public class BridgeOptions {
     return this;
   }
 
-  public BridgeOptions addInboundPermitted(PermittedOptions permitted) {
-    inboundPermitted.add(permitted);
+  @Override
+  public SockJSBridgeOptions addInboundPermitted(PermittedOptions permitted) {
+    super.addInboundPermitted(permitted);
     return this;
   }
 
-  public List<PermittedOptions> getInboundPermitteds() {
-    return inboundPermitted;
-  }
-
-  public void setInboundPermitted(List<PermittedOptions> inboundPermitted) {
-    this.inboundPermitted = inboundPermitted;
-  }
-
-  public BridgeOptions addOutboundPermitted(PermittedOptions permitted) {
-    outboundPermitted.add(permitted);
+  @Override
+  public SockJSBridgeOptions setInboundPermitteds(List<PermittedOptions> inboundPermitted) {
+    super.setInboundPermitteds(inboundPermitted);
     return this;
   }
 
-  public List<PermittedOptions> getOutboundPermitteds() {
-    return outboundPermitted;
+  @Override
+  public SockJSBridgeOptions addOutboundPermitted(PermittedOptions permitted) {
+    super.addOutboundPermitted(permitted);
+    return this;
   }
 
-  public void setOutboundPermitted(List<PermittedOptions> outboundPermitted) {
-    this.outboundPermitted = outboundPermitted;
+  @Override
+  public SockJSBridgeOptions setOutboundPermitteds(List<PermittedOptions> outboundPermitted) {
+    super.setOutboundPermitteds(outboundPermitted);
+    return this;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    SockJSBridgeOptionsConverter.toJson(this, json);
+    return json;
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandler.java
@@ -75,29 +75,29 @@ public interface SockJSHandler extends Handler<RoutingContext> {
    * @param bridgeOptions  options to configure the bridge with
    * @return a router to be mounted on an existing router
    */
-  default Router bridge(BridgeOptions bridgeOptions) {
+  default Router bridge(SockJSBridgeOptions bridgeOptions) {
     return bridge(null, bridgeOptions, null);
 
   }
 
   /**
-   * Like {@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(BridgeOptions)} but specifying a handler
+   * Like {@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(SockJSBridgeOptions)} but specifying a handler
    * that will receive bridge events.
    * @param authorizationProvider authorization provider to be used on the bridge
    * @param bridgeOptions  options to configure the bridge with
    * @param bridgeEventHandler  handler to receive bridge events
    * @return a router to be mounted on an existing router
    */
-  Router bridge(AuthorizationProvider authorizationProvider, BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler);
+  Router bridge(AuthorizationProvider authorizationProvider, SockJSBridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler);
 
   /**
-   * Like {@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(BridgeOptions)} but specifying a handler
+   * Like {@link io.vertx.ext.web.handler.sockjs.SockJSHandler#bridge(SockJSBridgeOptions)} but specifying a handler
    * that will receive bridge events.
    * @param bridgeOptions  options to configure the bridge with
    * @param bridgeEventHandler  handler to receive bridge events
    * @return a router to be mounted on an existing router
    */
-  default Router bridge(BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
+  default Router bridge(SockJSBridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
     return bridge(null, bridgeOptions, bridgeEventHandler);
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -80,7 +80,7 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
   private final Handler<BridgeEvent> bridgeEventHandler;
   private final AuthorizationProvider authzProvider;
 
-  public EventBusBridgeImpl(Vertx vertx, AuthorizationProvider authzProvider, BridgeOptions options, Handler<BridgeEvent> bridgeEventHandler) {
+  public EventBusBridgeImpl(Vertx vertx, AuthorizationProvider authzProvider, SockJSBridgeOptions options, Handler<BridgeEvent> bridgeEventHandler) {
     this.vertx = vertx;
     this.eb = vertx.eventBus();
     this.authzProvider = authzProvider;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -43,12 +43,8 @@ import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.auth.authorization.AuthorizationProvider;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.sockjs.BridgeEvent;
-import io.vertx.ext.web.handler.sockjs.BridgeOptions;
-import io.vertx.ext.web.handler.sockjs.SockJSHandler;
-import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
-import io.vertx.ext.web.handler.sockjs.SockJSSocket;
-import io.vertx.ext.web.handler.sockjs.Transport;
+import io.vertx.ext.web.handler.sockjs.*;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -94,7 +90,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
   }
 
   @Override
-  public Router bridge(AuthorizationProvider authorizationProvider, BridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
+  public Router bridge(AuthorizationProvider authorizationProvider, SockJSBridgeOptions bridgeOptions, Handler<BridgeEvent> bridgeEventHandler) {
     return socketHandler(new EventBusBridgeImpl(vertx, authorizationProvider, bridgeOptions, bridgeEventHandler));
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -44,9 +44,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class EventbusBridgeTest extends WebTestBase {
 
   protected SockJSHandler sockJSHandler;
-  protected BridgeOptions defaultOptions = new BridgeOptions();
-  protected BridgeOptions allAccessOptions =
-    new BridgeOptions().addInboundPermitted(new PermittedOptions()).addOutboundPermitted(new PermittedOptions());
+  protected SockJSBridgeOptions defaultOptions = new SockJSBridgeOptions();
+  protected SockJSBridgeOptions allAccessOptions =
+    new SockJSBridgeOptions().addInboundPermitted(new PermittedOptions()).addOutboundPermitted(new PermittedOptions());
 
   protected String websocketURI = "/eventbus/websocket";
   protected String addr = "someaddress";
@@ -994,7 +994,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     CountDownLatch latch = new CountDownLatch(1);
 
-    sockJSHandler.bridge(new BridgeOptions(allAccessOptions).setMaxHandlersPerSocket(maxHandlers));
+    sockJSHandler.bridge(new SockJSBridgeOptions(allAccessOptions).setMaxHandlersPerSocket(maxHandlers));
 
     client.webSocket(websocketURI, onSuccess(ws -> {
 
@@ -1038,7 +1038,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     CountDownLatch latch = new CountDownLatch(1);
 
-    sockJSHandler.bridge(new BridgeOptions(allAccessOptions).setMaxAddressLength(10));
+    sockJSHandler.bridge(new SockJSBridgeOptions(allAccessOptions).setMaxAddressLength(10));
 
     client.webSocket(websocketURI, onSuccess(ws -> {
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -387,7 +387,7 @@ public class SockJSHandlerTest extends WebTestBase {
   public void testTimeoutCloseCode() {
     router.mountSubRouter("/ws-timeout", SockJSHandler
       .create(vertx)
-      .bridge(new BridgeOptions().setPingTimeout(1))
+      .bridge(new SockJSBridgeOptions().setPingTimeout(1))
     );
 
     client.webSocket("/ws-timeout/websocket", onSuccess(ws -> ws.frameHandler(frame -> {
@@ -404,7 +404,7 @@ public class SockJSHandlerTest extends WebTestBase {
   public void testInvalidMessageCode() {
     router.mountSubRouter("/ws-timeout", SockJSHandler
       .create(vertx)
-      .bridge(new BridgeOptions().addInboundPermitted(new PermittedOptions().setAddress("SockJSHandlerTest.testInvalidMessageCode")))
+      .bridge(new SockJSBridgeOptions().addInboundPermitted(new PermittedOptions().setAddress("SockJSHandlerTest.testInvalidMessageCode")))
     );
 
     vertx.eventBus().consumer("SockJSHandlerTest.testInvalidMessageCode", msg -> msg.reply(new JsonObject()));


### PR DESCRIPTION
Bug fix?
follow the docs: we can access RoutingContext in template by `context`. But actually we can't.

Thank you