### PR TITLE
bug fix: add RouteingContext as `context`

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -70,7 +70,7 @@ public class TemplateHandlerImpl implements TemplateHandler {
     }
     // render using the engine
 	JsonObject obj = new JsonObject(context.data());
-	obj.put("context", context) // follow the docs: can access RoutingContext as `context`
+	obj.put("context", context); // follow the docs: can access RoutingContext as `context`
     engine.render(obj, templateDirectory + file, res -> {
       if (res.succeeded()) {
         context.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType).end(res.result());

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -69,7 +69,9 @@ public class TemplateHandlerImpl implements TemplateHandler {
       }
     }
     // render using the engine
-    engine.render(new JsonObject(context.data()), templateDirectory + file, res -> {
+	JsonObject obj = new JsonObject(context.data());
+	obj.put("context", context) // follow the docs: can access RoutingContext as `context`
+    engine.render(obj, templateDirectory + file, res -> {
       if (res.succeeded()) {
         context.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType).end(res.result());
       } else {


### PR DESCRIPTION
Signed-off-by: iseki <admin@iseki.space>
Bug fix?
follow the docs: we can access RoutingContext in template by context. But actually we can't.

Thank you

