### PR TITLE
handles invalid cors status with an error handler optionally

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -163,7 +163,7 @@ public class CorsHandlerImpl implements CorsHandler {
   }
 
   private void sendInvalid(HttpServerResponse resp) {
-    resp.setStatusCode(403).setStatusMessage("CORS Rejected - Invalid origin").end();
+    resp.setStatusCode(403).end();
   }
 
   private boolean isValidOrigin(String origin) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -147,7 +147,7 @@ public class CorsHandlerImpl implements CorsHandler {
         context.next();
       }
     } else {
-      sendInvalid(request.response());
+      context.fail(403);
     }
   }
 
@@ -160,10 +160,6 @@ public class CorsHandlerImpl implements CorsHandler {
       // Can be '*' too
       response.putHeader(ACCESS_CONTROL_ALLOW_ORIGIN, getAllowedOrigin(origin));
     }
-  }
-
-  private void sendInvalid(HttpServerResponse resp) {
-    resp.setStatusCode(403).end();
   }
 
   private boolean isValidOrigin(String origin) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -18,6 +18,7 @@ package io.vertx.ext.web.handler;
 
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebTestBase;
 import org.junit.Test;
 
@@ -25,6 +26,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -76,6 +83,17 @@ public class CORSHandlerTest extends WebTestBase {
       // Make sure the '.' doesn't match like a regex
       req.headers().add("origin", "fooxio");
     }, resp -> checkHeaders(resp, null, null, null, null), 403, "Forbidden", null);
+  }
+
+  @Test
+  @SuppressWarnings ("unchecked")
+  public void testAcceptConstantOriginDeniedErrorHandler() throws Exception {
+    Consumer<RoutingContext> handler = mock(Consumer.class);
+
+    router.route().handler(CorsHandler.create("vertx\\.io"));
+    router.route().handler(context -> context.response().end());
+    router.errorHandler(403, handler::accept);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.io"), resp -> verify(handler, never()).accept(any()), 403, "Forbidden", null);
   }
 
   @Test

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -65,7 +65,7 @@ public class CORSHandlerTest extends WebTestBase {
   public void testAcceptConstantOriginDenied1() throws Exception {
     router.route().handler(CorsHandler.create("vertx\\.io"));
     router.route().handler(context -> context.response().end());
-    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.io"), resp -> checkHeaders(resp, null, null, null, null), 403, "CORS Rejected - Invalid origin", null);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.io"), resp -> checkHeaders(resp, null, null, null, null), 403, "Forbidden", null);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class CORSHandlerTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/", req -> {
       // Make sure the '.' doesn't match like a regex
       req.headers().add("origin", "fooxio");
-    }, resp -> checkHeaders(resp, null, null, null, null), 403, "CORS Rejected - Invalid origin", null);
+    }, resp -> checkHeaders(resp, null, null, null, null), 403, "Forbidden", null);
   }
 
   @Test
@@ -107,8 +107,8 @@ public class CORSHandlerTest extends WebTestBase {
     // Any subdomains of vertx.io
     router.route().handler(CorsHandler.create(".*\\.vertx\\.io"));
     router.route().handler(context -> context.response().end());
-    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.vertx.com"), resp -> checkHeaders(resp, null, null, null, null), 403, "CORS Rejected - Invalid origin", null);
-    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "barxvertxxio"), resp -> checkHeaders(resp, null, null, null, null), 403, "CORS Rejected - Invalid origin", null);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.vertx.com"), resp -> checkHeaders(resp, null, null, null, null), 403, "Forbidden", null);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "barxvertxxio"), resp -> checkHeaders(resp, null, null, null, null), 403, "Forbidden", null);
   }
 
   @Test

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -30,7 +30,6 @@ import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -93,7 +92,7 @@ public class CORSHandlerTest extends WebTestBase {
     router.route().handler(CorsHandler.create("vertx\\.io"));
     router.route().handler(context -> context.response().end());
     router.errorHandler(403, handler::accept);
-    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.io"), resp -> verify(handler, never()).accept(any()), 403, "Forbidden", null);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "foo.io"), resp -> verify(handler).accept(any()), 403, "Forbidden", null);
   }
 
   @Test


### PR DESCRIPTION
Uses `context.fail` instead of `setStatusCode` to allow cors issues being handled by an error handler.

The status message has been changed to the default message for the 403 `Forbidden`

resolves https://github.com/vert-x3/vertx-web/issues/1555
