### PR TITLE
backport of #1541 - Add a Lazy Session option for the SessionHandler

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -300,6 +300,14 @@ public interface RoutingContext {
   @Nullable Session session();
 
   /**
+   * Whether the {@link RoutingContext#session()} has been already called or not. This is usually used by the
+   * {@link io.vertx.ext.web.handler.SessionHandler}.
+   *
+   * @return true if the session has been accessed.
+   */
+  boolean isSessionAccessed();
+
+  /**
    * Get the authenticated user (if any). This will usually be injected by an auth handler if authentication if successful.
    * @return  the user, or null if the current user is not authenticated.
    */

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -81,6 +81,11 @@ public interface SessionHandler extends Handler<RoutingContext> {
 	 */
 	int DEFAULT_SESSIONID_MIN_LENGTH = 16;
 
+  /**
+   * Default of whether the session should be created lazily.
+   */
+	boolean DEFAULT_LAZY_SESSION = false;
+
 	/**
 	 * Create a session handler
 	 *
@@ -90,7 +95,7 @@ public interface SessionHandler extends Handler<RoutingContext> {
 	static SessionHandler create(SessionStore sessionStore) {
 		return new SessionHandlerImpl(DEFAULT_SESSION_COOKIE_NAME, DEFAULT_SESSION_COOKIE_PATH, DEFAULT_SESSION_TIMEOUT,
 				DEFAULT_NAG_HTTPS, DEFAULT_COOKIE_SECURE_FLAG, DEFAULT_COOKIE_HTTP_ONLY_FLAG,
-				DEFAULT_SESSIONID_MIN_LENGTH, sessionStore);
+				DEFAULT_SESSIONID_MIN_LENGTH, DEFAULT_LAZY_SESSION, sessionStore);
 	}
 
 	/**
@@ -168,6 +173,15 @@ public interface SessionHandler extends Handler<RoutingContext> {
    * @return a reference to this, so the API can be used fluently
    */
 	SessionHandler setCookieSameSite(CookieSameSite policy);
+
+  /**
+   * Use a lazy session creation mechanism. The session will only be created when accessed from the context. Thus the
+   * session cookie is set only if the session was accessed.
+   *
+   * @param lazySession true to have a lazy session creation.
+   * @return a reference to this, so the API can be used fluently
+   */
+	SessionHandler setLazySession(boolean lazySession);
 
   /**
    * Set an auth provider that will allow retrieving the User object from the session to the current routing context.

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -215,6 +215,11 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
+  public boolean isSessionAccessed() {
+    return decoratedContext.isSessionAccessed();
+  }
+
+  @Override
   public ParsedHeaderValues parsedHeaders() {
     return decoratedContext.parsedHeaders();
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -62,6 +62,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private Set<FileUpload> fileUploads;
   private Session session;
   private User user;
+  private boolean isSessionAccessed = false;
 
   public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes) {
     super(mountPoint, request, routes);
@@ -311,7 +312,13 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   @Override
   public Session session() {
+    this.isSessionAccessed = true;
     return session;
+  }
+
+  @Override
+  public boolean isSessionAccessed(){
+    return isSessionAccessed;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -141,6 +141,11 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
+  public boolean isSessionAccessed() {
+    return inner.isSessionAccessed();
+  }
+
+  @Override
   public void setUser(User user) {
     inner.setUser(user);
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
@@ -184,4 +184,14 @@ public class RoutingContextImplTest extends WebTestBase {
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
   }
 
+  @Test
+  public void testSessionAccessed() throws Exception {
+    router.route().handler(event -> {
+      assertFalse(event.isSessionAccessed());
+      event.session();
+      assertTrue(event.isSessionAccessed());
+      event.response().end();
+    });
+    testRequest(HttpMethod.GET, "/", null, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
+  }
 }


### PR DESCRIPTION
Backport of #1541.

The goal of this commit is to have a mean to stop vert.x SessionHandler to always create a session Cookie.
In some cases, application built with Vert.x doesn't know in advance if they will use the session, and if not, may not want to be treated like a stateful application by network components (ie Load Balancers).
This commit follows the discussion accessible here : https://groups.google.com/d/msg/vertx/hoQEgU2d_FY/uUu2jdd7AQAJ

This commit adds a new SessionHandler option : lazySession. With this option set, the session is still (re)created in the SessionHandler.handle(...) but not always stored in the sessionStore.
The RoutingContext is now responsible to track whether the session has been accessed. In that case the new accessedSession() method must return true.
Thanks to this new RoutingContext.accessedSession() method, the SessionHandler is able to know whether the session has been accessed and to decide whether it has to store it.

Signed-off-by: Nils Renaud <renaud.nils@gmail.com>

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
