### PR TITLE
Provide a safe end handler for use to cleanup at request termination

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -390,6 +390,64 @@ public interface RoutingContext {
   boolean removeBodyEndHandler(int handlerID);
 
   /**
+   * Adds an exception handler that will be called if an exception occurs. The handler is called asynchronously of
+   * when the response has been received by the client.
+   *
+   * @param handler  the handler
+   * @return  the id of the handler. This can be used if you later want to remove the handler.
+   */
+  int addExceptionHandler(Handler<Void> handler);
+
+  /**
+   * Remove an exception handler
+   *
+   * @param handlerID  the id as returned from {@link io.vertx.ext.web.RoutingContext#addExceptionHandler(Handler)}.
+   * @return true if the handler existed and was removed, false otherwise
+   */
+  boolean removeExceptionHandler(int handlerID);
+
+  /**
+   * Adds a handler that will be called when the underlying connection is closed and the response
+   * was still using the connection. The handler is called asynchronously of when the response has been received by
+   * the client.
+   * <p>
+   * For HTTP/1.x it is called when the connection is closed before {@code end()} is called, therefore it is not
+   * guaranteed to be called.
+   * <p>
+   * For HTTP/2 it is called when the related stream is closed, and therefore it will be always be called.
+   *
+   * @param handler  the handler
+   * @return  the id of the handler. This can be used if you later want to remove the handler.
+   */
+  int addCloseHandler(Handler<Void> handler);
+
+  /**
+   * Remove a close handler
+   *
+   * @param handlerID  the id as returned from {@link io.vertx.ext.web.RoutingContext#addCloseHandler(Handler)}.
+   * @return true if the handler existed and was removed, false otherwise
+   */
+  boolean removeCloseHandler(int handlerID);
+
+  /**
+   * Add an end handler for the response. This will be called when the response is disposed or an exception has been
+   * encountered to allow consistent cleanup. The handler is called asynchronously of when the response has been received
+   * by the client.
+   *
+   * @param handler  the handler
+   * @return  the id of the handler. This can be used if you later want to remove the handler.
+   */
+  int addEndHandler(Handler<Void> handler);
+
+  /**
+   * Remove an end handler
+   *
+   * @param handlerID  the id as returned from {@link io.vertx.ext.web.RoutingContext#addEndHandler(Handler)}.
+   * @return true if the handler existed and was removed, false otherwise
+   */
+  boolean removeEndHandler(int handlerID);
+
+  /**
    * @return true if the context is being routed to failure handlers.
    */
   boolean failed();

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -43,8 +43,23 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
+  public int addCloseHandler(Handler<Void> handler) {
+    return decoratedContext.addCloseHandler(handler);
+  }
+
+  @Override
   public RoutingContext addCookie(io.vertx.core.http.Cookie cookie) {
     return decoratedContext.addCookie(cookie);
+  }
+
+  @Override
+  public int addEndHandler(Handler<Void> handler) {
+    return decoratedContext.addEndHandler(handler);
+  }
+
+  @Override
+  public int addExceptionHandler(Handler<Void> handler) {
+    return decoratedContext.addExceptionHandler(handler);
   }
 
   @Override
@@ -176,8 +191,23 @@ public class RoutingContextDecorator implements RoutingContext {
   }
 
   @Override
+  public boolean removeCloseHandler(int handlerID) {
+    return decoratedContext.removeCloseHandler(handlerID);
+  }
+
+  @Override
   public Cookie removeCookie(String name, boolean invalidate) {
     return decoratedContext.removeCookie(name, invalidate);
+  }
+
+  @Override
+  public boolean removeEndHandler(int handlerID) {
+    return decoratedContext.removeEndHandler(handlerID);
+  }
+
+  @Override
+  public boolean removeExceptionHandler(int handlerID) {
+    return decoratedContext.removeExceptionHandler(handlerID);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -132,6 +132,36 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
+  public int addExceptionHandler(Handler<Void> handler) {
+    return inner.addExceptionHandler(handler);
+  }
+
+  @Override
+  public boolean removeExceptionHandler(int handlerID) {
+    return inner.removeExceptionHandler(handlerID);
+  }
+
+  @Override
+  public int addCloseHandler(Handler<Void> handler) {
+    return inner.addCloseHandler(handler);
+  }
+
+  @Override
+  public boolean removeCloseHandler(int handlerID) {
+    return inner.removeCloseHandler(handlerID);
+  }
+
+  @Override
+  public int addEndHandler(Handler<Void> handler) {
+    return inner.addEndHandler(handler);
+  }
+
+  @Override
+  public boolean removeEndHandler(int handlerID) {
+    return inner.removeEndHandler(handlerID);
+  }
+
+  @Override
   public void setSession(Session session) {
     inner.setSession(session);
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -1434,6 +1434,102 @@ public class RouterTest extends WebTestBase {
     assertWaitUntil(() -> cnt.get() == 1);
   }
 
+  // Test that adding an endHandler doesn't overwrite other ones
+  @Test
+  public void testEndHandler() throws Exception {
+    AtomicInteger cnt = new AtomicInteger();
+    router.route().handler(rc -> {
+      rc.addEndHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addEndHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addEndHandler(v -> cnt.incrementAndGet());
+      rc.response().end();
+    });
+    testRequest(HttpMethod.GET, "/", 200, "OK");
+    assertWaitUntil(() -> cnt.get() == 3);
+  }
+
+  // Test that adding an exceptionHandler doesn't overwrite other ones
+  @Test
+  public void testExceptionHandler() throws Exception {
+    HttpClientRequest req = client.request(HttpMethod.GET, server.actualPort(), "localhost", "/path");
+    AtomicInteger cnt = new AtomicInteger();
+    router.route().handler(rc -> {
+      rc.addExceptionHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addExceptionHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addExceptionHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      req.connection().close();
+    });
+    req.end();
+    assertWaitUntil(() -> cnt.get() == 3);
+  }
+
+  // Test that adding a closeHandler doesn't overwrite other ones
+  @Test
+  public void testCloseHandler() throws Exception {
+    HttpClientRequest req = client.request(HttpMethod.GET, server.actualPort(), "localhost", "/path");
+    AtomicInteger cnt = new AtomicInteger();
+    router.route().handler(rc -> {
+      rc.addCloseHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addCloseHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addCloseHandler(v -> cnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      req.connection().close();
+    });
+    req.end();
+    assertWaitUntil(() -> cnt.get() == 3);
+  }
+
+  // Test that the endHandler is called once for an exception
+  @Test
+  public void testEndHandlerCalledOnce() throws Exception {
+    HttpClientRequest req = client.request(HttpMethod.GET, server.actualPort(), "localhost", "/path");
+    AtomicInteger endCnt = new AtomicInteger();
+    AtomicInteger excCnt = new AtomicInteger();
+    AtomicInteger closeCnt = new AtomicInteger();
+    router.route().handler(rc -> {
+      rc.addExceptionHandler(v -> excCnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addEndHandler(v -> endCnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      rc.addCloseHandler(v -> closeCnt.incrementAndGet());
+      rc.next();
+    });
+    router.route().handler(rc -> {
+      req.connection().close();
+    });
+    req.end();
+    assertWaitUntil(() -> endCnt.get() == 1);
+    assertWaitUntil(() -> excCnt.get() == 1);
+    assertWaitUntil(() -> closeCnt.get() == 1);
+  }
+
   @Test
   public void testNoRoutes() throws Exception {
     testRequest(HttpMethod.GET, "/whatever", 404, "Not Found");


### PR DESCRIPTION
Motivation:

Adds `addEndHandler`, `addExceptionHandler` and `addCloseHandler`
methods to the `RoutingContext` to allow you to create multiple
handlers for the `endHandler`, `exceptionHandler` and
`closeHandler` properties of the `HttpServerResponse`. Handlers
added using the `addEndHandler` will always be called whether
the request fails with an exception or completes normally. It
can therefore be used to perform cleanup on the request.

Signed-off-by: Graeme McRobert <mcrobert@uk.ibm.com>

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
