### PR TITLE
digest auth: fix auth behind a reverse proxy

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
@@ -153,12 +153,6 @@ public class DigestAuthHandlerImpl extends AuthorizationAuthHandler implements D
           nonces.put(nonce, new Nonce(n.createdAt, nc));
         }
 
-        final String uri = authInfo.getString("uri");
-
-        if (!uri.equalsIgnoreCase(context.request().uri())) {
-          handler.handle(Future.failedFuture(UNAUTHORIZED));
-          return;
-        }
       } catch (RuntimeException e) {
         handler.handle(Future.failedFuture(e));
       }


### PR DESCRIPTION
rfc2617 section 3.2.2

"""
digest-uri
     The URI from Request-URI of the Request-Line; duplicated here
     because proxies are allowed to change the Request-Line in transit.
"""

so don't check digest-uri against request uri

