### PR TITLE
Fixes #1514

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -338,8 +338,7 @@ public interface Router extends Handler<HttpServerRequest> {
    * @param subRouter  the router to mount as a sub router
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  Router mountSubRouter(String mountPoint, Router subRouter);
+  Route mountSubRouter(String mountPoint, Router subRouter);
 
   /**
    * Specify a handler for any unhandled exceptions on this router. The handler will be called for exceptions thrown

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -276,15 +276,13 @@ public class RouterImpl implements Router {
   }
 
   @Override
-  public Router mountSubRouter(String mountPoint, Router subRouter) {
+  public Route mountSubRouter(String mountPoint, Router subRouter) {
     if (mountPoint.endsWith("*")) {
       throw new IllegalArgumentException("Don't include * when mounting a sub router");
     }
 
-    route(mountPoint + "*")
+    return route(mountPoint + "*")
       .subRouter(subRouter);
-
-    return this;
   }
 
   @Deprecated


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

The return of the mount should be a `Route` this way we can still perform the default route management tasks like `remove` of the router like we do for any other kind of route.