### PR TITLE
Set default LinkBuilder

### DIFF
--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
@@ -25,6 +25,8 @@ import io.vertx.ext.web.common.WebEnvironment;
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.IContext;
+import org.thymeleaf.context.IExpressionContext;
+import org.thymeleaf.linkbuilder.StandardLinkBuilder;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.StringTemplateResolver;
 import org.thymeleaf.templateresource.ITemplateResource;
@@ -55,6 +57,15 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
 
     this.templateResolver = templateResolver;
     this.templateEngine.setTemplateResolver(templateResolver);
+    // There's no servlet context in Vert.x, so we override default link builder
+    // See https://github.com/vert-x3/vertx-web/issues/161
+    this.templateEngine.setLinkBuilder(new StandardLinkBuilder() {
+      @Override
+      protected String computeContextPath(
+        final IExpressionContext context, final String base, final Map<String, Object> parameters) {
+        return "/";
+      }
+    });
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/java/io/vertx/ext/web/templ/ThymeleafTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/java/io/vertx/ext/web/templ/ThymeleafTemplateTest.java
@@ -183,6 +183,9 @@ public class ThymeleafTemplateTest {
       .put("context", new JsonObject().put("path", "/test-thymeleaf-template2.html"));
 
     engine.render(context, "somedir/test-thymeleaf-fragmented.html", render -> {
+      if(render.cause()!=null) {
+        throw new RuntimeException(render.cause());
+      }
       should.assertTrue(render.succeeded());
 
       final String expected =
@@ -190,6 +193,7 @@ public class ThymeleafTemplateTest {
           "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
           "<head>\n" +
           "  <meta charset=\"utf-8\">\n" +
+          "  <link rel=\"shortcut icon\" type=\"image/x-icon\" href=\"/resources/images/favicon.png\">\n" +
           "</head>\n" +
           "<body>\n" +
           "<p>badger</p>\n" +

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/resources/somedir/test-thymeleaf-fragmented.html
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/test/resources/somedir/test-thymeleaf-fragmented.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="utf-8">
+  <link rel="shortcut icon" type="image/x-icon" th:href="@{/resources/images/favicon.png}">
 </head>
 <body>
 <th:block th:include="somedir/test-thymeleaf-include.html :: example"></th:block>


### PR DESCRIPTION
Motivation:

Fixes https://github.com/vert-x3/vertx-web/issues/161

See the discussion there. In short, Vert.x doesn't have servlet context that Thymeleaf depends on. Without this change, it throws exceptions when rendering `@{/path}` in template.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
