### PR TITLE
Iterate over webclient interceptors instead of chain style

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.client.impl;
 
+import io.vertx.ext.web.client.predicate.PredicateInterceptor;
 import java.net.URI;
 import java.util.List;
 
@@ -15,12 +16,12 @@ import io.vertx.ext.web.client.spi.CookieStore;
 /**
  * A stateless interceptor for session management that operates on the {@code HttpContext}
  */
-public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
+public class SessionAwareInterceptor implements PredicateInterceptor {
 
   private static final String HEADERS_CONTEXT_KEY = "_originalHeaders";
 
   @Override
-  public void handle(HttpContext<?> context) {
+  public boolean handle(HttpContext<?> context) {
     switch(context.phase()) {
     case PREPARE_REQUEST:
       prepareRequest(context);
@@ -35,7 +36,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
       break;
     }
 
-    context.next();
+    return true;
   }
 
   private void prepareRequest(HttpContext<?> context) {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -266,7 +266,7 @@ public class WebClientBase implements WebClientInternal {
   @Override
   public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
     HttpClientImpl client = (HttpClientImpl) this.client;
-    return new HttpContext<T>(client, interceptors, handler);
+    return new HttpContext<>(client, interceptors, handler);
   }
 
   @Override

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.ext.web.client.impl;
 
+import io.vertx.ext.web.client.predicate.PredicateInterceptor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -32,7 +33,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.ext.web.client.impl.predicate.PredicateInterceptor;
+import io.vertx.ext.web.client.impl.predicate.PredicateInterceptorImpl;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
 
 /**
@@ -42,7 +43,7 @@ public class WebClientBase implements WebClientInternal {
 
   final HttpClient client;
   final WebClientOptions options;
-  private final List<Handler<HttpContext<?>>> interceptors;
+  private final List<PredicateInterceptor> interceptors;
 
   public WebClientBase(HttpClient client, WebClientOptions options) {
     this.client = client;
@@ -50,7 +51,7 @@ public class WebClientBase implements WebClientInternal {
     this.interceptors = new CopyOnWriteArrayList<>();
 
     // Add base interceptor
-    addInterceptor(new PredicateInterceptor());
+    addInterceptor(new PredicateInterceptorImpl());
   }
 
   WebClientBase(WebClientBase webClient) {
@@ -257,15 +258,15 @@ public class WebClientBase implements WebClientInternal {
   }
 
   @Override
-  public WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor) {
-    interceptors.add((Handler) interceptor);
+  public WebClientInternal addInterceptor(PredicateInterceptor interceptor) {
+    interceptors.add(interceptor);
     return this;
   }
 
   @Override
   public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
     HttpClientImpl client = (HttpClientImpl) this.client;
-    return new HttpContext<>(client, interceptors, handler);
+    return new HttpContext<T>(client, interceptors, handler);
   }
 
   @Override

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -19,6 +19,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.PredicateInterceptor;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -40,6 +41,6 @@ public interface WebClientInternal extends WebClient {
    * @param interceptor the interceptor to add, must not be null
    * @return a reference to this, so the API can be used fluently
    */
-  WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
+  WebClientInternal addInterceptor(PredicateInterceptor interceptor);
 
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/predicate/PredicateInterceptorImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/predicate/PredicateInterceptorImpl.java
@@ -24,15 +24,16 @@ import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.HttpRequestImpl;
 import io.vertx.ext.web.client.impl.HttpResponseImpl;
 import io.vertx.ext.web.client.predicate.ErrorConverter;
+import io.vertx.ext.web.client.predicate.PredicateInterceptor;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class PredicateInterceptor implements Handler<HttpContext<?>> {
+public class PredicateInterceptorImpl implements PredicateInterceptor {
 
   @Override
-  public void handle(HttpContext<?> httpContext) {
+  public boolean handle(HttpContext<?> httpContext) {
 
     if (httpContext.phase() == ClientPhase.RECEIVE_RESPONSE) {
 
@@ -47,7 +48,7 @@ public class PredicateInterceptor implements Handler<HttpContext<?>> {
             predicateResult = (ResponsePredicateResultImpl) expectation.apply(responseCopy(resp, httpContext,null));
           } catch (Exception e) {
             httpContext.fail(e);
-            return;
+            return false;
           }
           if (!predicateResult.succeeded()) {
             ErrorConverter errorConverter = expectation.errorConverter();
@@ -60,13 +61,13 @@ public class PredicateInterceptor implements Handler<HttpContext<?>> {
               });
               resp.resume();
             }
-            return;
+            return false;
           }
         }
       }
     }
 
-    httpContext.next();
+    return true;
   }
 
   private <B> HttpResponseImpl<B> responseCopy(HttpClientResponse resp, HttpContext<?> httpContext, B value) {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/PredicateInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/PredicateInterceptor.java
@@ -1,0 +1,9 @@
+package io.vertx.ext.web.client.predicate;
+
+import io.vertx.ext.web.client.impl.HttpContext;
+
+public interface PredicateInterceptor {
+
+  boolean handle(HttpContext<?> context);
+
+}


### PR DESCRIPTION
Resolve #1625.

The list of WebClient interceptors is iterated and then the execute method is called. If a interceptor returns false, next interceptors and execute method are not called.

Tests pass ok. No more tests have been added since the behaviour is the same than before.