### PR TITLE
Noop Body Processor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ jobs:
     - stage: test
       name: "OpenJDK 8"
       jdk: openjdk8
-      script: mvn -q clean verify -B
+      script: mvn clean verify -B
     - if: type != pull_request
       name: "OpenJDK 11"
       jdk: openjdk11
-      script: mvn -q clean verify -B
+      script: mvn clean verify -B
     - name: "Apollo Link tests"
       jdk: openjdk8
       before_script:

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/NoopBodyProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/NoopBodyProcessorGenerator.java
@@ -1,0 +1,35 @@
+package io.vertx.ext.web.openapi.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.pointer.JsonPointer;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.validation.RequestParameter;
+import io.vertx.ext.web.validation.impl.body.BodyProcessor;
+
+public class NoopBodyProcessorGenerator implements BodyProcessorGenerator {
+
+  public final static NoopBodyProcessorGenerator INSTANCE = new NoopBodyProcessorGenerator();
+
+  @Override
+  public boolean canGenerate(String mediaTypeName, JsonObject mediaTypeObject) {
+    return true;
+  }
+
+  @Override
+  public BodyProcessor generate(String mediaTypeName, JsonObject mediaTypeObject, JsonPointer mediaTypePointer,
+                                GeneratorContext context) {
+    // Noop body processor
+    return new BodyProcessor() {
+      @Override
+      public boolean canProcess(String contentType) {
+        return true;
+      }
+
+      @Override
+      public Future<RequestParameter> process(RoutingContext requestContext) {
+        return Future.succeededFuture(RequestParameter.create(requestContext.getBody()));
+      }
+    };
+  }
+}

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3ValidationHandlerGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3ValidationHandlerGenerator.java
@@ -90,7 +90,8 @@ public class OpenAPI3ValidationHandlerGenerator {
       JsonPointer mediaTypePointer = operation.getPointer().copy().append("requestBody").append("content").append(mediaType.getKey());
       BodyProcessor generated = bodyProcessorGenerators.stream()
         .filter(g -> g.canGenerate(mediaType.getKey(), mediaTypeModel))
-        .findFirst().orElseThrow(() -> RouterFactoryException.createBodyNotSupported(mediaTypePointer))
+        .findFirst()
+        .orElse(NoopBodyProcessorGenerator.INSTANCE)
         .generate(mediaType.getKey(), mediaTypeModel, mediaTypePointer, context);
       bodyProcessors.add(generated);
     }

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterFactoryIntegrationTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterFactoryIntegrationTest.java
@@ -2,20 +2,24 @@ package io.vertx.ext.web.openapi;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.QueryStringEncoder;
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.AuthenticationHandler;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.StaticHandler;
-import io.vertx.ext.web.handler.impl.AuthenticationHandlerImpl;
 import io.vertx.ext.web.multipart.MultipartForm;
-import io.vertx.ext.web.validation.*;
+import io.vertx.ext.web.validation.BodyProcessorException;
+import io.vertx.ext.web.validation.ParameterProcessorException;
+import io.vertx.ext.web.validation.RequestParameter;
+import io.vertx.ext.web.validation.RequestParameters;
 import io.vertx.ext.web.validation.impl.ParameterLocation;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
@@ -32,11 +36,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.vertx.ext.web.validation.testutils.ValidationTestUtils.*;
-import static io.vertx.ext.web.validation.testutils.ValidationTestUtils.badParameterResponse;
 import static io.vertx.ext.web.validation.testutils.TestRequest.*;
+import static io.vertx.ext.web.validation.testutils.ValidationTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * This tests are about RouterFactory behaviours
@@ -1214,6 +1216,32 @@ public class RouterFactoryIntegrationTest extends BaseRouterFactoryTest {
         .expect(statusCode(400))
         .expect(badParameterResponse(ParameterProcessorException.ParameterProcessorErrorType.PARSING_ERROR, "color", ParameterLocation.QUERY))
         .send(testContext, checkpoint);
+    });
+  }
+
+  /**
+   * Test: binary_test
+   */
+  @Test
+  public void testOctetStreamBody(Vertx vertx, VertxTestContext testContext) {
+    Buffer body = Buffer.buffer("Hello World!");
+    loadFactoryAndStartServer(vertx, VALIDATION_SPEC, testContext, routerFactory -> {
+      routerFactory
+        .operation("binary_test")
+        .handler(routingContext -> {
+          RequestParameters params = routingContext.get("parsedParameters");
+          routingContext.response()
+            .setStatusCode(200)
+            .setStatusMessage("OK")
+            .putHeader("content-type", "application/octet-stream")
+            .end(params.body().getBuffer());
+        });
+    }).onComplete(h -> {
+      testRequest(client, HttpMethod.POST, "/binaryTest")
+        .expect(statusCode(200))
+        .expect(bodyResponse(body, "application/octet-stream"))
+        .with(requestHeader("content-type", "application/octet-stream"))
+        .sendBuffer(body, testContext);
     });
   }
 

--- a/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
+++ b/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
@@ -456,6 +456,20 @@ paths:
           description: Wrong validation
         default:
           description: Default response
+  /binaryTest:
+    post:
+      operationId: binary_test
+      requestBody:
+        description: The binary body
+        required: true
+        content:
+          "application/octet-stream":
+            schema:
+              type: string
+              format: binary
+      responses:
+        200:
+          description: Ok
 components:
   schemas:
     Pet:

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/RequestParameter.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/RequestParameter.java
@@ -3,6 +3,7 @@ package io.vertx.ext.web.validation;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.validation.impl.RequestParameterImpl;
@@ -16,65 +17,47 @@ import io.vertx.ext.web.validation.impl.RequestParameterImpl;
 public interface RequestParameter {
 
   /**
-   * Returns null if value is not a {@link String}, otherwise it returns value
-   *
-   * @return
+   * @return null if value is not a {@link String}, otherwise it returns value
    */
   @Nullable String getString();
 
   /**
-   * Returns true if value of this instance is a {@link String} instance
-   *
-   * @return
+   * @return true if value of this instance is a {@link String} instance
    */
   boolean isString();
 
   /**
-   * Returns null if value is not a {@link Number}, otherwise it returns value as {@link Integer}
-   *
-   * @return
+   * @return null if value is not a {@link Number}, otherwise it returns value as {@link Integer}
    */
   @Nullable Integer getInteger();
 
   /**
-   * Returns null if value is not a {@link Number}, otherwise it returns value as {@link Long}
-   *
-   * @return
+   * @return null if value is not a {@link Number}, otherwise it returns value as {@link Long}
    */
   @Nullable Long getLong();
 
   /**
-   * Returns null if value is not a {@link Number}, otherwise it returns value as {@link Float}
-   *
-   * @return
+   * @return null if value is not a {@link Number}, otherwise it returns value as {@link Float}
    */
   @Nullable Float getFloat();
 
   /**
-   * Returns null if value is not a {@link Number}, otherwise it returns value as {@link Double}
-   *
-   * @return
+   * @return null if value is not a {@link Number}, otherwise it returns value as {@link Double}
    */
   @Nullable Double getDouble();
 
   /**
-   * Returns true if value of this instance is a {@link Number} instance
-   *
-   * @return
+   * @return true if value of this instance is a {@link Number} instance
    */
   boolean isNumber();
 
   /**
-   * Returns null if value is not a {@link Boolean}, otherwise it returns value
-   *
-   * @return
+   * @return null if value is not a {@link Boolean}, otherwise it returns value
    */
   @Nullable Boolean getBoolean();
 
   /**
-   * Returns true if value of this instance is a {@link Boolean} instance
-   *
-   * @return
+   * @return true if value of this instance is a {@link Boolean} instance
    */
   boolean isBoolean();
 
@@ -86,54 +69,44 @@ public interface RequestParameter {
   @Nullable JsonObject getJsonObject();
 
   /**
-   * Returns true if value of this instance is a {@link JsonObject} instance
-   *
-   * @return
+   * @return true if value of this instance is a {@link JsonObject} instance
    */
   boolean isJsonObject();
 
   /**
-   * Returns null if value is not a {@link JsonArray}, otherwise it returns value
-   *
-   * @return
+   * @return null if value is not a {@link JsonArray}, otherwise it returns value
    */
   @Nullable JsonArray getJsonArray();
 
   /**
-   * Returns true if value of this instance is a {@link JsonArray} instance
-   *
-   * @return
+   * @return true if value of this instance is a {@link JsonArray} instance
    */
   boolean isJsonArray();
 
   /**
-   * Returns true if value is null
-   *
-   * @return
+   * @return null if value is not a {@link Buffer}, otherwise it returns value
+   */
+  @Nullable Buffer getBuffer();
+
+  /**
+   * @return true if value of this instance is a {@link Buffer} instance
+   */
+  boolean isBuffer();
+
+  /**
+   * @return true if value is null
    */
   boolean isNull();
 
   /**
-   * A parameter is empty if it's an empty string, an empty json object/array or if it's null
-   *
-   * @return
+   * @return True if it's an empty string, an empty json object/array, an empty buffer or it's null
    */
   boolean isEmpty();
 
   /**
-   * Converts deeply this instance into a Json representation
-   *
-   * @return
+   * @return the internal value. The internal value is always a valid Vert.x JSON type
    */
-  @CacheReturn Object toJson();
-
-  /**
-   * Merge this request parameter with another one. Note: the parameter passed by argument has the priority
-   *
-   * @param otherParameter
-   * @return
-   */
-  RequestParameter merge(RequestParameter otherParameter);
+  @CacheReturn Object get();
 
   static RequestParameter create(Object value) {
     return new RequestParameterImpl(value);

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParameterImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParameterImpl.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.web.validation.impl;
 
 import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.validation.RequestParameter;
@@ -16,17 +17,6 @@ public class RequestParameterImpl implements RequestParameter {
 
   public RequestParameterImpl(Object value) {
     this.value = value;
-  }
-
-  @Override
-  public RequestParameter merge(RequestParameter m) {
-    RequestParameterImpl mergingObj = (RequestParameterImpl) m;
-    if (this.isJsonArray() && mergingObj.isJsonArray()) {
-      mergingObj.value = mergingObj.getJsonArray().addAll(this.getJsonArray());
-    } else if (this.isJsonObject() && mergingObj.isJsonObject()) {
-      mergingObj.value = mergingObj.getJsonObject().mergeIn(this.getJsonObject());
-    }
-    return mergingObj;
   }
 
   public RequestParameterImpl() {
@@ -99,6 +89,16 @@ public class RequestParameterImpl implements RequestParameter {
   }
 
   @Override
+  public @Nullable Buffer getBuffer() {
+    return isBuffer() ? (Buffer) value : null;
+  }
+
+  @Override
+  public boolean isBuffer() {
+    return !isNull() && value instanceof Buffer;
+  }
+
+  @Override
   public boolean isNull() {
     return value == null;
   }
@@ -108,11 +108,12 @@ public class RequestParameterImpl implements RequestParameter {
     return isNull() ||
       (isString() && getString().isEmpty()) ||
       (isJsonObject() && getJsonObject().isEmpty()) ||
-      (isJsonArray() && getJsonArray().isEmpty());
+      (isJsonArray() && getJsonArray().isEmpty()) ||
+      (isBuffer() && getBuffer().length() == 0);
   }
 
   @Override
-  public Object toJson() {
+  public Object get() {
     return value;
   }
 

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParametersImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParametersImpl.java
@@ -138,7 +138,7 @@ public class RequestParametersImpl implements RequestParameters {
     root.put("header", mapToJsonObject(headerParameters));
     root.put("cookie", mapToJsonObject(cookieParameters));
     if (body != null)
-      root.put("body", body.toJson());
+      root.put("body", body.get());
     return root;
   }
 
@@ -148,7 +148,7 @@ public class RequestParametersImpl implements RequestParameters {
       .stream()
       .collect(Collector.of(
         JsonObject::new,
-        (j, e) -> j.put(e.getKey(), e.getValue().toJson()),
+        (j, e) -> j.put(e.getKey(), e.getValue().get()),
         JsonObject::mergeIn
       ));
   }

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/RequestParametersTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/RequestParametersTest.java
@@ -13,13 +13,13 @@ public class RequestParametersTest {
   @Test
   public void testRequestParameterToJsonNumber() {
     RequestParameter param = new RequestParameterImpl(1);
-    assertEquals(1, param.toJson());
+    assertEquals(1, param.get());
   }
 
   @Test
   public void testRequestParameterToJsonString() {
     RequestParameter param = new RequestParameterImpl("string");
-    assertEquals("string", param.toJson());
+    assertEquals("string", param.get());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #1643

Now for content types where validation is not supported, the router factory will generate a noop processor that just encapsulates the body inside `RequestParameter` as `Buffer`