### PR TITLE
Invalid use of project.version for vertx-json-schema

### DIFF
--- a/vertx-web-openapi/pom.xml
+++ b/vertx-web-openapi/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-json-schema</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/vertx-web-validation/pom.xml
+++ b/vertx-web-validation/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-json-schema</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- Testing dependencies -->


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
