### PR TITLE
[Issue-1647] Content-Type-based Routing not working properly

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -137,6 +137,9 @@ public abstract class RoutingContextImplBase implements RoutingContext {
           }
           return true;
         } else if (matchResult != 404) {
+          if (this.matchFailure != 404 && this.matchFailure != 405 && matchResult == 405) {
+            continue;
+          }
           this.matchFailure = matchResult;
         }
       } catch (Throwable e) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2691,6 +2691,43 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testRouteMatchingUnsupportedMediaType() throws Exception {
+    router.post("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("post api").end());
+    router.put("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("put api").end());
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/json", 200, "post api");
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/xml", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/json", 200, "put api");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/xml", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.PATCH, "/api", "application/json", 405, "Method Not Allowed");
+  }
+
+  @Test
+  public void testRouteMatchingUnsupportedMediaTypeOrder() throws Exception {
+    router.put("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("put api").end());
+    router.post("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("post api").end());
+    router.get("/api").handler(rc -> rc.response().setStatusMessage("get api").end());
+    router.put("/api").consumes("application/xml").handler(rc -> rc.response().setStatusMessage("put api xml").end());
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/json", 200, "post api");
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/xml", 415, "Unsupported Media Type");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/json", 200, "put api");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/xml", 200, "put api xml");
+    testRequestWithContentType(HttpMethod.PATCH, "/api", "application/json", 405, "Method Not Allowed");
+  }
+
+  @Test
+  public void testRouteMatchingSupportedMediaTypes() throws Exception {
+    router.post("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("post api").end());
+    router.post("/api").consumes("application/xml").handler(rc -> rc.response().setStatusMessage("post api xml").end());
+    router.put("/api").consumes("application/json").handler(rc -> rc.response().setStatusMessage("put api").end());
+    router.put("/api").consumes("application/xml").handler(rc -> rc.response().setStatusMessage("put api xml").end());
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/json", 200, "post api");
+    testRequestWithContentType(HttpMethod.POST, "/api", "application/xml", 200, "post api xml");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/json", 200, "put api");
+    testRequestWithContentType(HttpMethod.PUT, "/api", "application/xml", 200, "put api xml");
+    testRequestWithContentType(HttpMethod.PATCH, "/api", "application/json", 405, "Method Not Allowed");
+  }
+
+  @Test
   public void testRouteCustomVerb() throws Exception {
     router
       .route()


### PR DESCRIPTION
Motivation:

Fixes: #1647 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

HTTP method should be considered as the umbrella for other matching elements after matching the path, like consumes, produces, etc. If it is not a `405` nor `404`, the `matchFailure` should not be updated.
