### PR TITLE
[vertx-web-openapi] Allow users to set body handler as null

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/RouterFactory.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/RouterFactory.java
@@ -73,12 +73,15 @@ public interface RouterFactory {
   List<Operation> operations();
 
   /**
-   * Supply your own BodyHandler if you would like to control body limit, uploads directory and deletion of uploaded files
+   * Supply your own BodyHandler if you would like to control body limit, uploads directory and deletion of uploaded
+   * files.
+   * If you provide a null body handler, you won't be able to validate request bodies
+   *
    * @param bodyHandler
    * @return self
    */
   @Fluent
-  RouterFactory bodyHandler(BodyHandler bodyHandler);
+  RouterFactory bodyHandler(@Nullable BodyHandler bodyHandler);
 
   /**
    * Add global handler to be applied prior to {@link Router} being generated. <br/>

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterFactoryImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterFactoryImpl.java
@@ -170,7 +170,6 @@ public class OpenAPI3RouterFactoryImpl implements RouterFactory {
 
   @Override
   public RouterFactory bodyHandler(BodyHandler bodyHandler) {
-    Objects.requireNonNull(bodyHandler);
     this.bodyHandler = bodyHandler;
     return this;
   }
@@ -231,7 +230,9 @@ public class OpenAPI3RouterFactoryImpl implements RouterFactory {
   public Router createRouter() {
     Router router = Router.router(vertx);
     Route globalRoute = router.route();
-    globalRoute.handler(bodyHandler);
+    if (bodyHandler != null) {
+      globalRoute.handler(bodyHandler);
+    }
     globalHandlers.forEach(globalRoute::handler);
 
     for (OperationImpl operation : operations.values()) {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #1680