### PR TITLE
Lazly allocate the ParsedHeaders structure

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -900,13 +900,15 @@ final class RouteState {
         }
       }
     }
-    List<MIMEHeader> acceptableTypes = context.parsedHeaders().accept();
-    if (!isEmpty(produces) && !acceptableTypes.isEmpty()) {
-      MIMEHeader selectedAccept = context.parsedHeaders().findBestUserAcceptedIn(acceptableTypes, produces);
-      if (selectedAccept != null) {
-        context.setAcceptableContentType(selectedAccept.rawValue());
-      } else {
-        return 406;
+    if (!isEmpty(produces)) {
+      List<MIMEHeader> acceptableTypes = context.parsedHeaders().accept();
+      if(!acceptableTypes.isEmpty()) {
+        MIMEHeader selectedAccept = context.parsedHeaders().findBestUserAcceptedIn(acceptableTypes, produces);
+        if (selectedAccept != null) {
+          context.setAcceptableContentType(selectedAccept.rawValue());
+        } else {
+          return 406;
+        }
       }
     }
     if (!virtualHostMatches(context.request.host())) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -72,7 +72,6 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     super(mountPoint, request, routes);
     this.router = router;
 
-    fillParsedHeaders(request);
     if (request.path().length() == 0) {
       // HTTP paths must start with a '/'
       fail(400);
@@ -352,6 +351,9 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   @Override
   public ParsableHeaderValuesContainer parsedHeaders() {
+    if (parsedHeaders == null) {
+      fillParsedHeaders(request);
+    }
     return parsedHeaders;
   }
 
@@ -428,6 +430,9 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   @SuppressWarnings({"rawtypes", "unchecked" })
   @Override
   public List<Locale> acceptableLocales() {
+    if (parsedHeaders == null) {
+      fillParsedHeaders(request);
+    }
     return (List)parsedHeaders.acceptLanguage();
   }
 


### PR DESCRIPTION
This gives a significant performance boost
in situations where it is not needed

Motivation:

Quarkus does not really use the consumes/produces features of the Router, and this object is very expensive to create. A simple plaintext pipelining based benchmark (similar to the techempower one) I saw performance increase from 1.2m req/sec to 1.7m. 

I have submitted this for the 3.9 branch, let me know if you want a new PR for master.