### PR TITLE
[WIP] Fix vert.x reroute failing when params map cannot be built

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -180,6 +180,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   }
 
   @Override
+  public void clearParams() {
+    delegate.clearParams();
+  }
+
+  @Override
   public String getParam(String s) {
     return delegate.getParam(s);
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -399,7 +399,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     // change the method and path of the request
     ((HttpServerRequestWrapper) request).changeTo(method, path);
     // clear the params
-    request.params().clear();
+    request.clearParams();
     // we need to reset the normalized path
     normalisedPath = null;
     // we also need to reset any previous status

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RerouteTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RerouteTest.java
@@ -139,6 +139,14 @@ public class RerouteTest extends WebTestBase {
   }
 
   @Test
+  public void testRerouteWhenBaseRequestHasBadlyEncodedParams() throws Exception {
+    router.get("/other").handler(ctx -> ctx.response().end("/other"));
+    router.get("/base").handler(ctx -> ctx.reroute("/other"));
+
+    testRequest(HttpMethod.GET, "/base?parameter1=%%value1%%", 200, "OK", "/other");
+  }
+
+  @Test
   public void testRerouteAbsoluteURI() throws Exception {
     router.get("/other").handler(ctx -> {
       assertEquals("http://localhost:8080/other?paramter1=p1&parameter2=p2", ctx.request().absoluteURI());


### PR DESCRIPTION
Motivation:

Attempt to fix issue https://github.com/vert-x3/vertx-web/issues/1687 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
