### PR TITLE
Enforce the limit on the context

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -827,6 +827,10 @@ events are not delivered until the body handler is ready to process them.
 {@link examples.WebExamples#example27_1}
 ----
 
+NOTE: Uploads can be a source of DDoS attacks, in order to reduce the attack surface, it is recommended to
+set sensible limits on {@link io.vertx.ext.web.handler.BodyHandler#setBodyLimit} (e.g.: 10mb for general uploads or
+100kb for JSON).
+
 === Getting the request body
 
 If you know the request body is JSON, then you can use {@link io.vertx.ext.web.RoutingContext#getBodyAsJson},

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -256,12 +256,52 @@ public interface RoutingContext {
   @Nullable String getBodyAsString(String encoding);
 
   /**
+   * Gets the current body buffer as a {@link JsonObject}. If a positive limit is provided the parsing will only happen
+   * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
+   *
+   * When the application is only handling uploads in JSON format, it is recommended to set a limit on
+   * {@link io.vertx.ext.web.handler.BodyHandler#setBodyLimit(long)} as this will avoid the upload to be parsed and
+   * loaded into the application memory.
+   *
+   * @param maxAllowedLength if the current buffer length is greater than the limit an {@link IllegalStateException} is
+   *                         thrown. This can be used to avoid DDoS attacks on very long JSON payloads that could take
+   *                         over the CPU while attempting to parse the data.
+   *
    * @return Get the entire HTTP request body as a {@link JsonObject}. The context must have first been routed to a
    * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
-  @Nullable JsonObject getBodyAsJson();
+  @Nullable JsonObject getBodyAsJson(int maxAllowedLength);
+
+  /**
+   * Gets the current body buffer as a {@link JsonArray}. If a positive limit is provided the parsing will only happen
+   * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
+   *
+   * When the application is only handling uploads in JSON format, it is recommended to set a limit on
+   * {@link io.vertx.ext.web.handler.BodyHandler#setBodyLimit(long)} as this will avoid the upload to be parsed and
+   * loaded into the application memory.
+   *
+   * @param maxAllowedLength if the current buffer length is greater than the limit an {@link IllegalStateException} is
+   *                         thrown. This can be used to avoid DDoS attacks on very long JSON payloads that could take
+   *                         over the CPU while attempting to parse the data.
+   *
+   * @return Get the entire HTTP request body as a {@link JsonArray}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  @Nullable JsonArray getBodyAsJsonArray(int maxAllowedLength);
+
+  /**
+   * @return Get the entire HTTP request body as a {@link JsonObject}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  default @Nullable JsonObject getBodyAsJson() {
+    return getBodyAsJson(-1);
+  }
 
   /**
    * @return Get the entire HTTP request body as a {@link JsonArray}. The context must have first been routed to a
@@ -269,7 +309,9 @@ public interface RoutingContext {
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
-  @Nullable JsonArray getBodyAsJsonArray();
+  default @Nullable JsonArray getBodyAsJsonArray() {
+    return getBodyAsJsonArray(-1);
+  }
 
   /**
    * @return Get the entire HTTP request body as a {@link Buffer}. The context must have first been routed to a

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -141,13 +141,13 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
-  public JsonObject getBodyAsJson() {
-    return decoratedContext.getBodyAsJson();
+  public JsonObject getBodyAsJson(int maxAllowedLength) {
+    return decoratedContext.getBodyAsJson(maxAllowedLength);
   }
 
   @Override
-  public JsonArray getBodyAsJsonArray() {
-    return decoratedContext.getBodyAsJsonArray();
+  public JsonArray getBodyAsJsonArray(int maxAllowedLength) {
+    return decoratedContext.getBodyAsJsonArray(maxAllowedLength);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -260,6 +260,12 @@ public class RoutingContextImpl extends RoutingContextImplBase {
         }
       }
       return body.toString();
+    } else {
+      if (!seenHandler(BODY_HANDLER)) {
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("BodyHandler in not enabled on this route: RoutingContext.getBodyAsString(...) in always be NULL");
+        }
+      }
     }
     return null;
   }
@@ -270,17 +276,35 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   }
 
   @Override
-  public JsonObject getBodyAsJson() {
+  public JsonObject getBodyAsJson(int maxAllowedLength) {
     if (body != null) {
+      if (maxAllowedLength >= 0 && body.length() > maxAllowedLength) {
+        throw new IllegalStateException("RoutingContext body size exceeds the allowed limit");
+      }
       return BodyCodecImpl.JSON_OBJECT_DECODER.apply(body);
+    } else {
+      if (!seenHandler(BODY_HANDLER)) {
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("BodyHandler in not enabled on this route: RoutingContext.getBodyAsJson() in always be NULL");
+        }
+      }
     }
     return null;
   }
 
   @Override
-  public JsonArray getBodyAsJsonArray() {
+  public JsonArray getBodyAsJsonArray(int maxAllowedLength) {
     if (body != null) {
+      if (maxAllowedLength >= 0 && body.length() > maxAllowedLength) {
+        throw new IllegalStateException("RoutingContext body size exceeds the allowed limit");
+      }
       return BodyCodecImpl.JSON_ARRAY_DECODER.apply(body);
+    } else {
+      if (!seenHandler(BODY_HANDLER)) {
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("BodyHandler in not enabled on this route: RoutingContext.getBodyAsJsonArray(...) in always be NULL");
+        }
+      }
     }
     return null;
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public abstract class RoutingContextImplBase implements RoutingContextInternal {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RoutingContextImplBase.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(RoutingContext.class);
 
   private final Set<RouteImpl> routes;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -252,13 +252,13 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public JsonObject getBodyAsJson() {
-    return inner.getBodyAsJson();
+  public JsonObject getBodyAsJson(int maxAllowedLength) {
+    return inner.getBodyAsJson(maxAllowedLength);
   }
 
   @Override
-  public JsonArray getBodyAsJsonArray() {
-    return inner.getBodyAsJsonArray();
+  public JsonArray getBodyAsJsonArray(int maxAllowedLength) {
+    return inner.getBodyAsJsonArray(maxAllowedLength);
   }
 
   @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
@@ -791,4 +791,93 @@ public class BodyHandlerTest extends WebTestBase {
       req.write(buffer);
     }, 400, "Bad Request", null);
   }
+
+  @Test
+  public void testJsonLimit() throws Exception {
+    router.clear();
+    router.route().handler(BodyHandler.create());
+    Buffer buffer = Buffer.buffer("000000000000000000000000000000000000000000000000");
+    router.route().handler(rc -> {
+      try {
+        rc.getBodyAsJson(10);
+        // should not reach here!
+        rc.fail(500);
+      } catch (IllegalStateException e) {
+        rc.fail(413);
+      }
+    });
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.setChunked(true);
+      req.putHeader("content-type", "application/json");
+      req.write(buffer);
+    }, 413, "Request Entity Too Large", null);
+  }
+
+  @Test
+  public void testJsonLimitOK() throws Exception {
+    router.clear();
+    router.route().handler(BodyHandler.create());
+    Buffer buffer = Buffer.buffer("{\"k\":1111}");
+    router.route().handler(rc -> {
+      try {
+        rc.getBodyAsJson(10);
+        rc.end();
+      } catch (IllegalStateException e) {
+        // should not reach here!
+        rc.fail(500);
+      }
+    });
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.setChunked(true);
+      req.putHeader("content-type", "application/json");
+      req.write(buffer);
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testFileUploadUTF8() throws Exception {
+    String name = "somename";
+    String fileName = "somefile.dat";
+    String contentType = "application/octet-stream";
+    Buffer fileData = TestUtils.randomBuffer(50);
+    router.route().handler(rc -> {
+      Set<FileUpload> fileUploads = rc.fileUploads();
+      assertNotNull(fileUploads);
+      assertEquals(1, fileUploads.size());
+      FileUpload upload = fileUploads.iterator().next();
+      assertEquals(name, upload.name());
+      // tests https://tools.ietf.org/html/rfc5987
+      assertEquals("\u00A3 and \u20AC " + fileName, upload.fileName());
+      assertEquals(contentType, upload.contentType());
+      assertEquals("binary", upload.contentTransferEncoding());
+      assertEquals(fileData.length(), upload.size());
+      String uploadedFileName = upload.uploadedFileName();
+      assertTrue(uploadedFileName.startsWith(BodyHandler.DEFAULT_UPLOADS_DIRECTORY + File.separator));
+      Buffer uploaded = vertx.fileSystem().readFileBlocking(uploadedFileName);
+      assertEquals(fileData, uploaded);
+      // the data is upload as HTML form, so the body should be empty
+      Buffer rawBody = rc.getBody();
+      assertNull(rawBody);
+      rc.response().end();
+    });
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+      Buffer buffer = Buffer.buffer();
+      String header =
+        "--" + boundary + "\r\n" +
+          "Content-Disposition: form-data; name=\"" + name + "\"; filename*=\"UTF-8''%c2%a3%20and%20%e2%82%ac%20" + fileName + "\"\r\n" +
+          "Content-Type: " + contentType + "\r\n" +
+          "Content-Transfer-Encoding: binary\r\n" +
+          "\r\n";
+      buffer.appendString(header);
+      buffer.appendBuffer(fileData);
+      String footer = "\r\n--" + boundary + "--\r\n";
+      buffer.appendString(footer);
+      req.headers().set("content-length", String.valueOf(buffer.length()));
+      req.headers().set("content-type", "multipart/form-data; boundary=" + boundary);
+      req.setChunked(true);
+      req.write(buffer);
+    }, 200, "OK", null);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes #1691 
Closes #1693

This PR builds on the discussions on the issue. This approach is safer than the previous one as it protect against wrong mime types too.

Documentation has been added warning against the danger of unbounded parsing and where to enforce the limit.