### PR TITLE
OAuth2 redirect is handled at IdP, so it should only be available for…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -104,6 +104,13 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
           }
           handler.handle(Future.failedFuture(new HttpStatusException(500, "Infinite redirect loop [oauth2 callback]")));
         } else {
+          if (context.request().method() != HttpMethod.GET) {
+            // we can only redirect GET requests
+            LOG.error("OAuth2 redirect attempt to non GET resource");
+            context.fail(400);
+            return;
+          }
+
           // the redirect is processed as a failure to abort the chain
           String redirectUri = context.request().uri();
           String state = null;


### PR DESCRIPTION
… GET requests

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

The OAuth2 redirect happens at the IdP side, so we can only perform the redirect later if the original request is an GET operation.