### PR TITLE
fix #1716

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -460,9 +460,6 @@ public class HttpContext<T> {
           fail(e);
           return;
         }
-        for (String headerName : this.request.headers().names()) {
-          requestOptions.putHeader(headerName, this.request.headers().get(headerName));
-        }
         multipartForm.headers().forEach(header -> {
           requestOptions.putHeader(header.getKey(), header.getValue());
         });

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -471,6 +471,9 @@ public class HttpContext<T> {
         continuation = ar -> {
           if (ar.succeeded()) {
             HttpClientRequest req = ar.result();
+            if (!req.headers().contains(HttpHeaders.CONTENT_LENGTH)) {
+              req.setChunked(true);
+            }
             if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
               req.setChunked(true);
             }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
@@ -59,8 +59,8 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     }
 
     Iterable<Cookie> cookies = webclient.cookieStore().get(request.ssl, domain, request.uri);
-    for (Cookie c : cookies) {
-      request.headers().add("cookie", ClientCookieEncoder.STRICT.encode(c));
+    if (cookies.iterator().hasNext()) {
+      request.headers().add("cookie", ClientCookieEncoder.STRICT.encode(cookies));
     }
   }
 
@@ -119,8 +119,8 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     WebClientSessionAware webclient = (WebClientSessionAware) originalRequest.client;
     String path = parsePath(redirectRequest.getURI());
     Iterable<Cookie> cookies = webclient.cookieStore().get(originalRequest.ssl, domain, path);
-    for (Cookie c : cookies) {
-      redirectRequest.putHeader("cookie", ClientCookieEncoder.STRICT.encode(c));
+    if (cookies.iterator().hasNext()) {
+      redirectRequest.putHeader("cookie", ClientCookieEncoder.STRICT.encode(cookies));
     }
   }
 


### PR DESCRIPTION
@pmlopes @vietj 

Hi.

I try to fix #1716，Please check my pull request.

```
if (request.headers != null) {
      MultiMap headers = requestOptions.getHeaders();
      if (headers == null) {
        headers = MultiMap.caseInsensitiveMultiMap();
        requestOptions.setHeaders(headers);
      }
      headers.addAll(request.headers);
    }
```

```
        for (String headerName : this.request.headers().names()) {
          requestOptions.putHeader(headerName, this.request.headers().get(headerName));
        }
```

The two code logic is duplicated, and it causes the cookie to be lost.
