### PR TITLE
Added handling of connection params in GraphQL subscription

### DIFF
--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSConnectionInitEvent.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSConnectionInitEvent.java
@@ -1,0 +1,16 @@
+package io.vertx.ext.web.handler.graphql;
+
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Promise;
+
+@VertxGen
+public interface ApolloWSConnectionInitEvent extends Promise<Object> {
+  /**
+   * Provides {@link ApolloWSMessageType#CONNECTION_INIT} message content.
+   *
+   * @return message
+   */
+  @CacheReturn
+  ApolloWSMessage message();
+}

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
@@ -69,6 +69,15 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
   ApolloWSHandler connectionHandler(Handler<ServerWebSocket> connectionHandler);
 
   /**
+   * Customize the connection init {@link Handler}.
+   * This handler will be called when the {@link ApolloWSMessageType#CONNECTION_INIT} message is received.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ApolloWSHandler connectionInitHandler(Handler<ApolloWSConnectionInitEvent> connectionInitHandler);
+
+  /**
    * Customize the message {@link Handler}.
    * This handler will be called for each {@link ApolloWSMessage} received.
    *

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSMessage.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSMessage.java
@@ -17,11 +17,12 @@
 package io.vertx.ext.web.handler.graphql;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 
 /**
- * A message recevied over Apollo's {@code subscriptions-transport-ws} transport.
+ * A message received over Apollo's {@code subscriptions-transport-ws} transport.
  *
  * @author Rogelio Orts
  */
@@ -42,5 +43,10 @@ public interface ApolloWSMessage {
    * @return the message content
    */
   JsonObject content();
+
+  /**
+   * @return the connection params
+   */
+  Object connectionParams();
 
 }

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSMessageType.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSMessageType.java
@@ -34,7 +34,7 @@ public enum ApolloWSMessageType {
   START("start"),
   STOP("stop"),
   CONNECTION_ACK("connection_ack"),
-  CONNECTION_ERROR("error"),
+  CONNECTION_ERROR("connection_error"),
   CONNECTION_KEEP_ALIVE("ka"),
   DATA("data"),
   ERROR("error"),

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.graphql.ApolloWSConnectionInitEvent;
 import io.vertx.ext.web.handler.graphql.ApolloWSHandler;
 import io.vertx.ext.web.handler.graphql.ApolloWSMessage;
 import io.vertx.ext.web.handler.graphql.ApolloWSOptions;
@@ -49,6 +50,7 @@ public class ApolloWSHandlerImpl implements ApolloWSHandler {
   private Function<ApolloWSMessage, DataLoaderRegistry> dataLoaderRegistryFactory = DEFAULT_DATA_LOADER_REGISTRY_FACTORY;
   private Function<ApolloWSMessage, Locale> localeFactory = DEFAULT_LOCALE_FACTORY;
   private Handler<ServerWebSocket> connectionHandler;
+  private Handler<ApolloWSConnectionInitEvent> connectionInitHandler;
   private Handler<ServerWebSocket> endHandler;
   private Handler<ApolloWSMessage> messageHandler;
 
@@ -75,6 +77,16 @@ public class ApolloWSHandlerImpl implements ApolloWSHandler {
 
   synchronized Handler<ServerWebSocket> getConnectionHandler() {
     return connectionHandler;
+  }
+
+  @Override
+  public ApolloWSHandler connectionInitHandler(Handler<ApolloWSConnectionInitEvent> connectionInitHandler) {
+    this.connectionInitHandler = connectionInitHandler;
+    return this;
+  }
+
+  synchronized Handler<ApolloWSConnectionInitEvent> getConnectionInitHandler() {
+    return connectionInitHandler;
   }
 
   @Override

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSMessageImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSMessageImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.handler.graphql.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.graphql.ApolloWSMessage;
@@ -29,11 +30,20 @@ public class ApolloWSMessageImpl implements ApolloWSMessage {
   private final ServerWebSocket serverWebSocket;
   private final ApolloWSMessageType type;
   private final JsonObject content;
+  private final Object connectionParams;
 
   public ApolloWSMessageImpl(ServerWebSocket serverWebSocket, ApolloWSMessageType type, JsonObject content) {
     this.serverWebSocket = serverWebSocket;
     this.type = type;
     this.content = content;
+    this.connectionParams = null;
+  }
+
+  public ApolloWSMessageImpl(ServerWebSocket serverWebSocket, ApolloWSMessageType type, JsonObject content, Object connectionParams) {
+    this.serverWebSocket = serverWebSocket;
+    this.type = type;
+    this.content = content;
+    this.connectionParams = connectionParams;
   }
 
   @Override
@@ -49,5 +59,10 @@ public class ApolloWSMessageImpl implements ApolloWSMessage {
   @Override
   public JsonObject content() {
     return content;
+  }
+
+  @Override
+  public Object connectionParams() {
+    return connectionParams;
   }
 }

--- a/vertx-web-graphql/tests/apollo/apollo.test.js
+++ b/vertx-web-graphql/tests/apollo/apollo.test.js
@@ -108,6 +108,41 @@ test('ws link subscription', () => {
   });
 });
 
+test('ws link subscription with connection params', () => {
+  const client = new SubscriptionClient(wsUri, {
+    connectionParams: {
+      count: 2
+    }
+  });
+  const link = new WebSocketLink(client);
+
+  return new Promise((resolve, reject) => {
+    execute(link, {query: counterSubscription})
+      .subscribe(result => {
+        expect(result).toHaveProperty('data.counter');
+        expect(result.data.counter).toBeInstanceOf(Object);
+
+        expect(result.data.counter.count).toEqual(2);
+
+        resolve();
+      });
+  });
+});
+
+test('ws link subscription with failed promise', () => {
+  return new Promise((resolve, reject) => {
+    new SubscriptionClient(wsUri, {
+      connectionParams: {
+        rejectMessage: "test"
+      },
+      connectionCallback: error => {
+        expect(error).toEqual("test");
+        resolve()
+      }
+    });
+  });
+});
+
 test('upload file mutation', async () => {
   const file = new Blob(['Foo.'], { type: 'text/plain' })
 


### PR DESCRIPTION
Motivation:

This pull request is enabling handling of connection params with GraphQL subscription, fix #1579

@tsegismont thanks for the review in #1721 , I closed that PR in favor of this one since implementation has substantially changed.
