### PR TITLE
Detect race on close of sockjs tests

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
@@ -62,7 +62,7 @@ public interface PebbleTemplateEngine extends TemplateEngine {
    */
   @GenIgnore
   static PebbleTemplateEngine create(Vertx vertx, PebbleEngine engine) {
-    return new PebbleTemplateEngineImpl(vertx, DEFAULT_TEMPLATE_EXTENSION, engine);
+    return create(vertx, DEFAULT_TEMPLATE_EXTENSION, engine);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -395,12 +395,16 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
     }
   }
 
-  synchronized void handleException(Throwable t) {
-    if (exceptionHandler != null) {
+  void handleException(Throwable t) {
+    Handler<Throwable> eh;
+    synchronized (this) {
+      eh = exceptionHandler;
+    }
+    if (eh != null) {
       if (context == Vertx.currentContext()) {
-        exceptionHandler.handle(t);
+        eh.handle(t);
       } else {
-        context.runOnContext(v -> exceptionHandler.handle(t));
+        context.runOnContext(v -> eh.handle(t));
       }
     } else {
       log.error("Unhandled exception", t);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -404,7 +404,7 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
       if (context == Vertx.currentContext()) {
         eh.handle(t);
       } else {
-        context.runOnContext(v -> eh.handle(t));
+        context.runOnContext(v -> handleException(t));
       }
     } else {
       log.error("Unhandled exception", t);

--- a/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/WebTestBase.java
@@ -73,10 +73,12 @@ public class WebTestBase extends VertxTestBase {
   @Override
   public void tearDown() throws Exception {
     if (client != null) {
-      try {
-        client.close();
-      } catch (IllegalStateException e) {
-      }
+      CountDownLatch latch = new CountDownLatch(1);
+      client.close((asyncResult) -> {
+        assertTrue(asyncResult.succeeded());
+        latch.countDown();
+      });
+      awaitLatch(latch);
     }
     if (server != null) {
       CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
Motivation:

Trying to fix #1720

sockjs handler tests fail intermitently with a ISE. The ISE seems to be thrown when a connection is terminated, avoiding full synchronization on the exception handler + ensure that the test cleanly closes clients and then server, seems to not trigger the issue on a 10000 loop iteration of the test.

Before a fail would happen before the 2000th iteration would happen.