### PR TITLE
Fixes #1411

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -271,6 +271,8 @@ numeric character or underscore.
 In the above example, if a POST request is made to path: `/catalogue/products/tools/drill123/` then the route will match
 and `productType` will receive the value `tools` and `productID` will receive the value `drill123`.
 
+Note: You can also capture `*` as path param `*`.
+
 == Routing with regular expressions
 
 Regular expressions can also be used to match URI paths in routes.

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -886,6 +886,9 @@ final class RouteState {
         if (m.groupCount() > 0) {
           if (!exactPath) {
             context.matchRest = m.start("rest");
+            // always replace
+            context.pathParams()
+              .put("*", path.substring(context.matchRest));
           }
 
           if (!isEmpty(groups)) {
@@ -1025,7 +1028,13 @@ final class RouteState {
           }
         }
       }
-      return requestPath.startsWith(thePath);
+      if (requestPath.startsWith(thePath)) {
+        // handle the "rest" as path param *
+        ctx.pathParams()
+          .put("*", requestPath.substring(thePath.length()));
+        return true;
+      }
+      return false;
     }
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2790,4 +2790,21 @@ public class RouterTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/somepath/path1", 500, "Internal Server Error");
 
   }
+
+  @Test
+  public void testRouteRestParam() throws Exception {
+    router
+      .route("/p*")
+      .handler(rc -> {
+        if (rc.pathParam("*") != null) {
+          rc.response().setStatusMessage(rc.pathParam("*")).end();
+        } else {
+          rc.fail(500);
+        }
+      });
+
+    testRequest(HttpMethod.GET, "/p", 200, "");
+    testRequest(HttpMethod.GET, "/pa", 200, "a");
+    testRequest(HttpMethod.GET, "/q", 404, "Not Found");
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Expose the `*` as a path parameter too.
