### PR TITLE
Implement unwrap on all known engines

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/FreeMarkerTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/FreeMarkerTemplateEngine.java
@@ -22,6 +22,7 @@ import io.vertx.ext.web.templ.freemarker.impl.FreeMarkerTemplateEngineImpl;
 
 /**
  * A template engine that uses the FreeMarker library.
+ * The {@link #unwrap()} shall return an object of class {@link freemarker.template.Configuration}
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/impl/FreeMarkerTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/impl/FreeMarkerTemplateEngineImpl.java
@@ -49,6 +49,11 @@ public class FreeMarkerTemplateEngineImpl extends CachingTemplateEngine<Template
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) config;
+  }
+
+  @Override
   public void render(Map<String, Object> context, String templateFile, Handler<AsyncResult<Buffer>> handler) {
     try {
       String src = adjustLocation(templateFile);

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/HandlebarsTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/HandlebarsTemplateEngine.java
@@ -26,6 +26,7 @@ import io.vertx.ext.web.templ.handlebars.impl.HandlebarsTemplateEngineImpl;
 
 /**
  * A template engine that uses the Handlebars library.
+ * The {@link #unwrap()} shall return an object of class {@link Handlebars}
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -56,27 +57,34 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
   }
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Get a reference to the internal Handlebars object so it
    * can be configured.
    *
    * @return a reference to the internal Handlebars instance.
    */
   @GenIgnore
+  @Deprecated
   Handlebars getHandlebars();
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Return the array of configured handlebars context value resolvers.
+   *
    * @return array of configured resolvers
    */
+  @Deprecated
   @GenIgnore
   ValueResolver[] getResolvers();
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Set the array of handlebars context value resolvers.
    *
    * @param resolvers the value resolvers to be used
    * @return a reference to the internal Handlebars instance.
    */
+  @Deprecated
   @GenIgnore
   HandlebarsTemplateEngine setResolvers(ValueResolver... resolvers);
 }

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
@@ -87,6 +87,11 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) handlebars;
+  }
+
+  @Override
   public Handlebars getHandlebars() {
     return handlebars;
   }

--- a/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/HTTLTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/HTTLTemplateEngine.java
@@ -23,6 +23,7 @@ import io.vertx.ext.web.templ.httl.impl.HTTLTemplateEngineImpl;
 
 /**
  * A template engine that uses the HTTL library.
+ * The {@link #unwrap()} shall return an object of class {@link httl.Engine}
  *
  * @author <a href="mailto:victorqrsilva@gmail.com">Victor Quezado</a>
  */

--- a/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/impl/HTTLTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/impl/HTTLTemplateEngineImpl.java
@@ -44,6 +44,11 @@ public class HTTLTemplateEngineImpl extends CachingTemplateEngine<Template> impl
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) engine;
+  }
+
+  @Override
   public void render(Map<String, Object> context, String templateFile, Handler<AsyncResult<Buffer>> handler) {
     try {
       String src = adjustLocation(templateFile);

--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/jade/JadeTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/jade/JadeTemplateEngine.java
@@ -25,6 +25,7 @@ import io.vertx.ext.web.templ.jade.impl.JadeTemplateEngineImpl;
 
 /**
  * A template engine that uses Jade.
+ * The {@link #unwrap()} shall return an object of class {@link JadeConfiguration}
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -55,11 +56,13 @@ public interface JadeTemplateEngine extends TemplateEngine {
   }
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Get a reference to the internal JadeConfiguration object so it
    * can be configured.
    *
    * @return a reference to the internal JadeConfiguration instance.
    */
   @GenIgnore
+  @Deprecated
   JadeConfiguration getJadeConfiguration();
 }

--- a/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/jade/impl/JadeTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jade/src/main/java/io/vertx/ext/web/templ/jade/impl/JadeTemplateEngineImpl.java
@@ -49,6 +49,11 @@ public class JadeTemplateEngineImpl extends CachingTemplateEngine<JadeTemplate> 
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) config;
+  }
+
+  @Override
   public void render(Map<String, Object> context, String templateFile, Handler<AsyncResult<Buffer>> handler) {
     try {
       String src = adjustLocation(templateFile);

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
@@ -25,6 +25,7 @@ import io.vertx.ext.web.templ.pebble.impl.PebbleTemplateEngineImpl;
 
 /**
  * A template engine that uses the Pebble library.
+ * The {@link #unwrap()} shall return an object of class {@link PebbleEngine}
  *
  * @author Dan Kristensen
  */
@@ -60,7 +61,7 @@ public interface PebbleTemplateEngine extends TemplateEngine {
    *
    * @return the engine
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static PebbleTemplateEngine create(Vertx vertx, PebbleEngine engine) {
     return create(vertx, DEFAULT_TEMPLATE_EXTENSION, engine);
   }
@@ -71,7 +72,7 @@ public interface PebbleTemplateEngine extends TemplateEngine {
    *
    * @return the engine
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static PebbleTemplateEngine create(Vertx vertx, String extension, PebbleEngine engine) {
     return new PebbleTemplateEngineImpl(vertx, extension, engine);
   }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
@@ -54,6 +54,11 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) pebbleEngine;
+  }
+
+  @Override
   public void render(Map<String, Object> context, String templateFile, Handler<AsyncResult<Buffer>> handler) {
     try {
       String src = adjustLocation(templateFile);

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/ThymeleafTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/ThymeleafTemplateEngine.java
@@ -26,6 +26,7 @@ import org.thymeleaf.templatemode.TemplateMode;
 
 /**
  * A template engine that uses the Thymeleaf library.
+ * The {@link #unwrap()} shall return an object of class {@link org.thymeleaf.TemplateEngine}
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -43,20 +44,24 @@ public interface ThymeleafTemplateEngine extends TemplateEngine {
   }
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Set the mode for the engine
    *
    * @param mode the mode
    * @return a reference to this for fluency
    */
   @Fluent
+  @Deprecated
   ThymeleafTemplateEngine setMode(TemplateMode mode);
 
   /**
+   * @deprecated see {@link #unwrap()}
    * Get a reference to the internal Thymeleaf TemplateEngine object so it
    * can be configured.
    *
    * @return a reference to the internal Thymeleaf TemplateEngine instance.
    */
   @GenIgnore
+  @Deprecated
   org.thymeleaf.TemplateEngine getThymeleafTemplateEngine();
 }

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
@@ -69,6 +69,11 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
   }
 
   @Override
+  public <T> T unwrap() {
+    return (T) templateEngine;
+  }
+
+  @Override
   public ThymeleafTemplateEngine setMode(TemplateMode mode) {
     templateResolver.setTemplateMode(mode);
     return this;

--- a/vertx-web-common/src/main/java/io/vertx/ext/web/common/template/TemplateEngine.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/common/template/TemplateEngine.java
@@ -88,4 +88,15 @@ public interface TemplateEngine {
     render(context, templateFileName, promise);
     return promise.future();
   }
+
+  /**
+   * Returns the underlying engine, so further configurations or customizations may be applied.
+   * @param <T> the engine object type.
+   * @return the engine instance.
+   * @throws ClassCastException when the expected type does not match the internal type.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> T unwrap() throws ClassCastException {
+    return null;
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #1725 

Implement `unwrap` on all engines that have runtime config, defaults to `null` on compile time engines.