### PR TITLE
Fix #1730: properly extract the rest param as the desired segment

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -55,6 +55,19 @@ public class Utils extends io.vertx.core.impl.Utils {
   }
 
   public static String pathOffset(String path, RoutingContext context) {
+    final String rest = context.pathParam("*");
+    if (rest != null) {
+      // normalize
+      if (rest.length() > 0) {
+        if (rest.charAt(0) == '/') {
+          return rest;
+        } else {
+          return "/" + rest;
+        }
+      } else {
+        return "/";
+      }
+    }
     int prefixLen = 0;
     String mountPoint = context.mountPoint();
     if (mountPoint != null) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
@@ -88,6 +88,25 @@ public class TemplateTest extends WebTestBase {
   }
 
   @Test
+  public void testTemplateEngineWithPathVariables() throws Exception {
+    TemplateEngine engine = new TestEngine(false);
+    router.route().handler(context -> {
+      context.put("foo", "badger");
+      context.put("bar", "fox");
+      context.next();
+    });
+    router.route("/:project/*").handler(TemplateHandler.create(engine, "somedir", "text/html"));
+    String expected =
+      "<html>\n" +
+        "<body>\n" +
+        "<h1>Test template</h1>\n" +
+        "foo is badger bar is fox<br>\n" +
+        "</body>\n" +
+        "</html>";
+    testRequest(HttpMethod.GET, "/1/test-template.html", 200, "OK", expected);
+  }
+
+  @Test
   public void testRenderDirectly() throws Exception {
     TemplateEngine engine = new TestEngine(false);
     router.route().handler(context -> {
@@ -158,6 +177,5 @@ public class TemplateTest extends WebTestBase {
         handler.handle(Future.succeededFuture(Buffer.buffer(rendered)));
       }
     }
-
   }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Extract the rest param to build the file name, not the route path.
