### PR TITLE
Generic  API for web-client #1723

### DIFF
--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -25,6 +25,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-auth-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- Testing -->
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -245,7 +245,7 @@ public interface HttpRequest<T> {
   @Deprecated
   default HttpRequest<T> bearerTokenAuthentication(String bearerToken){
       JsonObject principal = new JsonObject()
-              .put("bearerToken", bearerToken);
+              .put("access_token", bearerToken);
       User user = User.create(principal);
       return authentication(AuthenticationType.BEARER, user);
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -203,12 +203,14 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
         break;
 
       case BEARER:
-        String bearerToken = principal.getString("bearerToken");
+        String bearerToken = principal.getString("access_token");
         putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + bearerToken);
         break;
 
       case DIGEST:
         //TODO implement
+      default:
+        throw new UnsupportedOperationException("not implemented/unsupported");
     }
 
     return this;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -25,11 +25,16 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.ext.web.common.AuthenticationType;
+import static io.vertx.ext.web.common.AuthenticationType.BASIC;
+import static io.vertx.ext.web.common.AuthenticationType.BEARER;
+import static io.vertx.ext.web.common.AuthenticationType.DIGEST;
 import io.vertx.ext.web.multipart.MultipartForm;
 
 import java.util.ArrayList;
@@ -184,20 +189,29 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   @Override
-  public HttpRequest<T> basicAuthentication(String id, String password) {
-    return this.basicAuthentication(Buffer.buffer(id), Buffer.buffer(password));
-  }
+  public HttpRequest<T> authentication(AuthenticationType type, User user, JsonObject options) {
+    JsonObject principal = user.principal();
 
-  @Override
-  public HttpRequest<T> basicAuthentication(Buffer id, Buffer password) {
-    Buffer buff = Buffer.buffer().appendBuffer(id).appendString(":").appendBuffer(password);
-    String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
-    return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
-  }
+    switch(type){
+      case BASIC:
+        String username = principal.getString("username");
+        String password = principal.getString("password");
 
-  @Override
-  public HttpRequest<T> bearerTokenAuthentication(String bearerToken) {
-    return putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + bearerToken);
+        Buffer buff = Buffer.buffer().appendString(username).appendString(":").appendString(password);
+        String credentials =  new String(Base64.getEncoder().encode(buff.getBytes()));
+        putHeader(HttpHeaders.AUTHORIZATION.toString(), "Basic " + credentials);
+        break;
+
+      case BEARER:
+        String bearerToken = principal.getString("bearerToken");
+        putHeader(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + bearerToken);
+        break;
+
+      case DIGEST:
+        //TODO implement
+    }
+
+    return this;
   }
 
   @Override

--- a/vertx-web-common/src/main/asciidoc/enums.adoc
+++ b/vertx-web-common/src/main/asciidoc/enums.adoc
@@ -1,0 +1,20 @@
+= Enums
+
+[[AuthenticationType]]
+== AuthenticationType
+
+++++
+
+ https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[BEARER]]`BEARER`|-
+|[[BASIC]]`BASIC`|-
+|[[DIGEST]]`DIGEST`|-
+|===
+

--- a/vertx-web-common/src/main/java/io/vertx/ext/web/common/AuthenticationType.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/common/AuthenticationType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.common;
+
+/**
+ *
+ *
+ * https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+ *
+ * @author <a href="mailto:hectorvent@gmail.com">Hector Ventura</a>
+ */
+public enum AuthenticationType {
+
+    BEARER,
+
+    BASIC,
+
+    DIGEST
+
+}

--- a/vertx-web-common/src/main/java/io/vertx/ext/web/common/AuthenticationType.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/common/AuthenticationType.java
@@ -15,13 +15,15 @@
  */
 package io.vertx.ext.web.common;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
- *
  *
  * https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
  *
  * @author <a href="mailto:hectorvent@gmail.com">Hector Ventura</a>
  */
+@VertxGen
 public enum AuthenticationType {
 
     BEARER,


### PR DESCRIPTION
Signed-off-by: Hector Ventura <hectorvent@gmail.com>

**Motivation:**
Consume API based on other authentication types different than BASIC/BEARER. So now change to a generic API to implement new authentication types as DIGEST, that it will be the next PR.