### PR TITLE
Fixed wrong usage of vertx junit5 apis

### DIFF
--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/BaseRouterFactoryTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/BaseRouterFactoryTest.java
@@ -13,7 +13,6 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.ext.web.handler.ErrorHandler;
 import io.vertx.ext.web.validation.testutils.ValidationTestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -44,7 +43,7 @@ public abstract class BaseRouterFactoryTest {
   @AfterEach
   public void tearDown(VertxTestContext testContext) {
     if (client != null) client.close();
-    if (server != null) server.close(testContext.completing());
+    if (server != null) server.close(testContext.succeedingThenComplete());
     else testContext.completeNow();
   }
 

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/BaseValidationHandlerTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/BaseValidationHandlerTest.java
@@ -12,6 +12,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.validation.testutils.ValidationTestUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,9 +37,14 @@ public abstract class BaseValidationHandlerTest {
     server = vertx
       .createHttpServer()
       .requestHandler(router)
-      .listen(9000, testContext.succeeding(h -> {
-        testContext.completeNow();
-      }));
+      .listen(9000, testContext.succeedingThenComplete());
+  }
+
+  @AfterEach
+  public void tearDown(VertxTestContext testContext) {
+    if (client != null) client.close();
+    if (server != null) server.close(testContext.succeedingThenComplete());
+    else testContext.completeNow();
   }
 
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

After the server is closed, the testContext must be completed