### PR TITLE
Decide whether to Chunked after body encoding.

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -506,7 +506,8 @@ public class HttpContext<T> {
         continuation = ar -> {
           if (ar.succeeded()) {
             HttpClientRequest req = ar.result();
-            if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
+            MultiMap headers = req.headers();
+            if (headers == null || !headers.contains(HttpHeaders.CONTENT_LENGTH)) {
               req.setChunked(true);
             }
             pipe.endOnFailure(false);


### PR DESCRIPTION
Motivation:

Decide whether to Chunked after body encoding.  Netty will automatically calculate the Content-length. When the Content-length is greater than `8k`, it will not set the Content-length header value, so we can decide whether to Chunk or not based on it.
If it is up to the developer to set the content-length value, it is likely to cause an error. In addition, when sending the `application/x-www-form-urlencoded` form, it will cause `chunked=true`, which is not necessary, usually the body is very small.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
