### PR TITLE
Fix RequestOptions processing in WebClientBase

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -18,10 +18,12 @@ package io.vertx.ext.web.client.impl;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -196,8 +198,9 @@ public class WebClientBase implements WebClientInternal {
 
   @Override
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, RequestOptions requestOptions) {
-    return new HttpRequestImpl<>(this, method, serverAddress, requestOptions.isSsl(), requestOptions.getPort(),
+      HttpRequestImpl<Buffer> request = new HttpRequestImpl<>(this, method, serverAddress, requestOptions.isSsl(), requestOptions.getPort(),
       requestOptions.getHost(), requestOptions.getURI(), BodyCodecImpl.BUFFER, options);
+      return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
   }
 
   public HttpRequest<Buffer> request(HttpMethod method, String host, String requestURI) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -27,6 +27,7 @@ import io.vertx.ext.web.multipart.MultipartForm;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.tls.Cert;
+
 import org.junit.Test;
 
 import java.io.File;
@@ -48,6 +49,8 @@ import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -1479,6 +1482,21 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> req = webClient.request(HttpMethod.GET, addr, 8080, "another-host", "/test");
     req.send(onSuccess(resp -> testComplete()));
     await();
+  }
+
+  @Test
+  public void testRequest() throws Exception {
+    String headerKey = "header1", headerValue = "value1";
+    RequestOptions options = new RequestOptions().addHeader(headerKey, headerValue);
+
+    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, options);
+    assertThat(request.headers().get(headerKey), equalTo(headerValue));
+
+    request = webClient.request(HttpMethod.GET, SocketAddress.inetSocketAddress(8080, "localhost"), options);
+    assertThat(request.headers().get(headerKey), equalTo(headerValue));
+
+    request = webClient.request(HttpMethod.GET, new RequestOptions());
+    assertThat(request.headers().get(headerKey), nullValue());
   }
 
   @Test


### PR DESCRIPTION
Before this patch WebClientBase was ignoring headers which were passed inside of RequestOptions.
