### PR TITLE
Don't get the host header if no host pattern defined

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -911,8 +911,10 @@ final class RouteState {
         }
       }
     }
-    if (!virtualHostMatches(context.request.host())) {
-      return 404;
+    if(virtualHostPattern != null) {
+      if (!virtualHostMatches(context.request.host())) {
+        return 404;
+      }
     }
     return 0;
   }


### PR DESCRIPTION
Just a minor optimisation, if there is no host pattern to match
don't load the host header from the header map.

Motivation:

Even if no host pattern is defined the router will always call load the host header from the map. This avoids this if the host pattern is not defined.

