### PR TITLE
Fixed Internal server error on displayExceptionDetails = true and exc…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
@@ -91,12 +91,14 @@ public class ErrorHandlerImpl implements ErrorHandler {
 
     if (displayExceptionDetails) {
       // failure message may be null
-      errorMessage = failure == null ? null : failure.getMessage();
-      if (errorMessage != null) {
+      String exceptionMessage = failure == null ? null : failure.getMessage();
+      if (exceptionMessage != null) {
         // no new lines are allowed in the status message
-        errorMessage = errorMessage.replaceAll("[\\r\\n]", " ");
+        exceptionMessage = exceptionMessage.replaceAll("[\\r\\n]", " ");
         // apply the newly desired message
-        response.setStatusMessage(errorMessage);
+        response.setStatusMessage(exceptionMessage);
+        //Override the default errorMessage
+        errorMessage = exceptionMessage;
       }
     }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ErrorHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ErrorHandlerTest.java
@@ -155,6 +155,30 @@ public class ErrorHandlerTest extends WebTestBase {
     await();
   }
 
+
+  @Test
+  public void testFailOnNoDisplayExceptionDetailsAndNoException() throws Exception {
+    router
+      // clear the previous setup
+      .clear()
+      // new handler should use development mode
+      .route().failureHandler(ErrorHandler.create(vertx, true));
+    // unset the system property
+
+
+    int statusCode = 404;
+    String statusMessage = "Not Found";
+    router.route().handler(rc -> {
+      rc.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/html");
+      rc.fail(statusCode);
+    });
+    testRequest(HttpMethod.GET, "/", null, resp -> resp.bodyHandler(buff -> {
+      checkHtmlResponse(buff, resp, statusCode, statusMessage);
+      testComplete();
+    }), statusCode, statusMessage, null);
+    await();
+  }
+
   @Test
   public void testFailWithExceptionNoExceptionDetails() throws Exception {
     router.clear();


### PR DESCRIPTION
…eption = null

When displayExceptionDetails is true and there is no exception then the errorMessage is set to null
resulting to a NullPointerException which override the error code with 500.

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>