### PR TITLE
Uses latest Ubuntu distribution in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ env:
 jobs:
   include:
     - stage: test
-      name: "OpenJDK 8"
-      jdk: openjdk8
-      script: mvn clean verify -B
-    - if: type != pull_request
       name: "OpenJDK 11"
       jdk: openjdk11
       script: mvn clean verify -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch: amd64
+os: linux
+dist: focal
+
 language: java
 services:
   - docker


### PR DESCRIPTION
This updates travis to build and test with the latest Ubuntu distribution (focal)

Motivation:

In Zipkin our integration tests of vertx-web only fail when we we upgrade our OS.

This upgrades the OS here to see if it also fails or if something specific to us..

See https://github.com/openzipkin/brave/issues/1270
