### PR TITLE
Issues/1758

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -2444,7 +2444,7 @@ standard same-origin policy.
 
 [source,$lang]
 ----
-{@link examples.WebExamples#example82}
+{@link examples.WebExamples#example84}
 ----
 
 

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -2416,7 +2416,7 @@ fetch('/process', {
 })
 ----
 
-== HSTSHandler
+== HSTS Handler
 
 HTTP Strict Transport Security (HSTS) is a web security policy mechanism that helps to protect websites against
 man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking. It allows web servers to declare that
@@ -2430,6 +2430,23 @@ This handler will configure the correct header for your application in a single 
 ----
 {@link examples.WebExamples#example80}
 ----
+
+== CSP Handler
+
+Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of
+attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from
+data theft to site defacement to distribution of malware.
+
+CSP is designed to be fully backward compatible. Browsers that don't support it still work with servers that
+implement it, and vice-versa: browsers that don't support CSP simply ignore it, functioning as usual, defaulting to
+the standard same-origin policy for web content. If the site doesn't offer the CSP header, browsers likewise use the
+standard same-origin policy.
+
+[source,$lang]
+----
+{@link examples.WebExamples#example82}
+----
+
 
 == OAuth2AuthHandler Handler
 

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -1890,4 +1890,14 @@ public class WebExamples {
             .setChunked(true)
             .write("Write some text..."));
   }
+
+  public void example84(Router router) {
+
+    // all responses will then include the right
+    // Content-Security-Policy header allowing sub-domain
+    // sources to be fetched from the parent "trusted.com" domain
+    router.route().handler(
+      CSPHandler.create()
+        .addDirective("default-src", "*.trusted.com"));
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CSPHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CSPHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.handler;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.CSPHandlerImpl;
+
+/**
+ * Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of
+ * attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from
+ * data theft to site defacement to distribution of malware.
+ *
+ * CSP is designed to be fully backward compatible. Browsers that don't support it still work with servers that
+ * implement it, and vice-versa: browsers that don't support CSP simply ignore it, functioning as usual, defaulting to
+ * the standard same-origin policy for web content. If the site doesn't offer the CSP header, browsers likewise use the
+ * standard same-origin policy.
+ */
+@VertxGen
+public interface CSPHandler extends Handler<RoutingContext> {
+
+  /**
+   * Creates a new instance of the handler.
+   * @return a new CSP handler.
+   */
+  static CSPHandler create() {
+    return new CSPHandlerImpl();
+  }
+
+  /**
+   * Sets a single directive entry to the handler. All previously set or added directives will be replaced.
+   * For more information on directives see: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">Content-Security-Policy</a>.
+   *
+   * @param name the directive name
+   * @param value the directive value.
+   * @return fluent self
+   */
+  @Fluent
+  CSPHandler setDirective(String name, String value);
+
+  /**
+   * Adds a single directive entry to the handler. All previously set or added directives will be preserved.
+   * For more information on directives see: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">Content-Security-Policy</a>.
+   *
+   * @param name the directive name
+   * @param value the directive value.
+   * @return fluent self
+   */
+  @Fluent
+  CSPHandler addDirective(String name, String value);
+
+  /**
+   * To ease deployment, CSP can be deployed in report-only mode. The policy is not enforced, but any violations are
+   * reported to a provided URI. Additionally, a report-only header can be used to test a future revision to a policy
+   * without actually deploying it.
+   *
+   * @param reportOnly enable report only
+   * @return fluent self.
+   */
+  @Fluent
+  CSPHandler setReportOnly(boolean reportOnly);
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/AbstractSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/AbstractSession.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.sstore;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.VertxContextPRNG;
 import io.vertx.ext.web.Session;
+import io.vertx.ext.web.sstore.impl.SessionInternal;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-public abstract class AbstractSession implements Session {
+public abstract class AbstractSession implements Session, SessionInternal {
 
   private static final char[] HEX = "0123456789abcdef".toCharArray();
 
@@ -103,6 +104,17 @@ public abstract class AbstractSession implements Session {
 
   public void setPRNG(VertxContextPRNG prng) {
     this.prng = prng;
+  }
+
+  @Override
+  public void flushed(boolean skipCrc) {
+    renewed = false;
+    if (oldId != null) {
+      if (!skipCrc) {
+        crc = checksum();
+      }
+      oldId = null;
+    }
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/impl/SessionInternal.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.sstore.impl;
+
+/**
+ * Internal interface to allow cleanup of internal state after a session is stored.
+ */
+public interface SessionInternal {
+
+  /**
+   * Mark this session as flushed, this gives the object a change to clear any state management flags.
+   *
+   * @param skipCrc if the intention is NOT to keep using the session after this call,
+   *                a small optimization can be performed (skip updating the internal CRC)
+   *                which is unnecessary.
+   */
+  void flushed(boolean skipCrc);
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CSPHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CSPHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.WebTestBase;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+public class CSPHandlerTest extends WebTestBase {
+
+  @Test
+  public void testCSPDefault() throws Exception {
+    router.route().handler(CSPHandler.create());
+    router.route().handler(context -> context.response().end());
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      assertEquals("default-src 'self'", resp.getHeader("Content-Security-Policy"));
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCSPCustom() throws Exception {
+    router.route().handler(CSPHandler.create().addDirective("default-src", "*.trusted.com"));
+    router.route().handler(context -> context.response().end());
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      assertEquals("default-src 'self' *.trusted.com", resp.getHeader("Content-Security-Policy"));
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCSPMulti() throws Exception {
+    router.route().handler(
+      CSPHandler.create()
+        .addDirective("img-src", "*")
+        .addDirective("media-src", "media1.com media2.com")
+        .addDirective("script-src", "userscripts.example.com"));
+
+
+    router.route().handler(context -> context.response().end());
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      String h = resp.getHeader("Content-Security-Policy");
+      assertEquals("default-src 'self'; img-src *; media-src media1.com media2.com; script-src userscripts.example.com", h);
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCSPReporting() throws Exception {
+    router.route().handler(
+      CSPHandler.create()
+        .setReportOnly(true)
+        .addDirective("report-uri", "http://reportcollector.example.com/collector.cgi"));
+
+
+    router.route().handler(context -> context.response().end());
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      String h = resp.getHeader("Content-Security-Policy-Report-Only");
+      assertEquals("default-src 'self'; report-uri http://reportcollector.example.com/collector.cgi", h);
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCSPReportingWithoutUri() throws Exception {
+    router.route().handler(
+      CSPHandler.create()
+        .setReportOnly(true));
+
+    router.route().handler(context -> context.response().end());
+    testRequest(HttpMethod.GET, "/", 500, "Internal Server Error");
+  }
+}


### PR DESCRIPTION
Motivation:

regenerateId and local store's would cache the full object keeping the flag "renewed" always active. This PR adds an internal method to allow clean up all internal state after a flush, fixing the re-issue of cookies all the time.