### PR TITLE
Allow parsing of query parameters with other content encoding than UTF-8

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -29,6 +29,7 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.impl.Utils;
 
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -570,6 +571,19 @@ public interface RoutingContext {
    * @return the multimap of query parameters
    */
   MultiMap queryParams();
+
+  /**
+   * Always decode the current query string with the given {@code encoding}. The decode result is never cached. Callers
+   * to this method are expected to cache the result if needed. Usually users should use {@link #queryParams()}.
+   *
+   * This method is only useful when the requests without content type ({@code GET} requests as an example) expect that
+   * query params are in the ASCII format {@code ISO-5559-1}.
+   *
+   * @param encoding a non null character set.
+   * @return the multimap of query parameters
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  MultiMap queryParams(Charset encoding);
 
   /**
    * Gets the value of a single query parameter. For more info {@link RoutingContext#queryParams()}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -15,6 +15,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -264,6 +265,11 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   @Override
   public MultiMap queryParams() {
     return decoratedContext.queryParams();
+  }
+
+  @Override
+  public MultiMap queryParams(Charset charset) {
+    return decoratedContext.queryParams(charset);
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -31,6 +31,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -317,6 +318,11 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   @Override
   public MultiMap queryParams() {
     return inner.queryParams();
+  }
+
+  @Override
+  public MultiMap queryParams(Charset charset) {
+    return inner.queryParams(charset);
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #1494 

Allow parsing of query params in other character encoding than UTF8. Although UTF8 is the norm, for GET requests there is no way to specify the desired character encoding. On Tomcat for example a custom config is required to allow this.

This PR allows specifying the desired character encoding for the decode of the query string, however it will not be cached like the default one. This is to avoid behavior changes in the application or undesired side effects of calling the method with or without character set.  