### PR TITLE
Fixes #1742: Copy HTTP response for no body error converters

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/predicate/PredicateInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/predicate/PredicateInterceptor.java
@@ -44,7 +44,7 @@ public class PredicateInterceptor implements Handler<HttpContext<?>> {
         for (ResponsePredicate expectation : expectations) {
           ResponsePredicateResultImpl predicateResult;
           try {
-            predicateResult = (ResponsePredicateResultImpl) expectation.apply(responseCopy(resp, httpContext,null));
+            predicateResult = (ResponsePredicateResultImpl) expectation.apply(responseCopy(resp, httpContext, null));
           } catch (Exception e) {
             httpContext.fail(e);
             return;
@@ -52,6 +52,7 @@ public class PredicateInterceptor implements Handler<HttpContext<?>> {
           if (!predicateResult.succeeded()) {
             ErrorConverter errorConverter = expectation.errorConverter();
             if (!errorConverter.requiresBody()) {
+              predicateResult.setHttpResponse(responseCopy(resp, httpContext, null));
               failOnPredicate(httpContext, errorConverter, predicateResult);
             } else {
               resp.bodyHandler(buffer -> {


### PR DESCRIPTION
Signed-off-by: pn-santos <pedro.santos@yoti.com>

**Motivation:**

See #1742 for details.

**Implementation Notes:**

I also added a test (mostly a replica of an existing one with some minor changes) that reproduces the issue (and passes with the fix).
