### PR TITLE
Fix #1782

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/DeepObjectParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/DeepObjectParameterProcessorGenerator.java
@@ -24,10 +24,10 @@ public class DeepObjectParameterProcessorGenerator implements ParameterProcessor
       parsedLocation,
       !parameter.getBoolean("required", false),
       new DeepObjectValueParameterParser(
+        parameter.getString("name"),
         ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
         ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
-        ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema()),
-        parameter.getString("name")
+        ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema())
       ),
       schemas.getValidator()
     );

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/DefaultParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/DefaultParameterProcessorGenerator.java
@@ -51,7 +51,7 @@ public class DefaultParameterProcessorGenerator implements ParameterProcessorGen
         parsedLocation,
         !parameter.getBoolean("required", false),
         new AnyOfOneOfSingleParameterParser(
-          parameter.getString("name"),
+          parsedLocation.lowerCaseIfNeeded(parameter.getString("name")),
           valueParsers
         ),
         schemas.getValidator()
@@ -65,7 +65,7 @@ public class DefaultParameterProcessorGenerator implements ParameterProcessorGen
         parsedLocation,
         !parameter.getBoolean("required", false),
         new SingleValueParameterParser(
-          parameter.getString("name"),
+          parsedLocation.lowerCaseIfNeeded(parameter.getString("name")),
           valueParser
         ),
         schemas.getValidator()

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedArrayParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedArrayParameterProcessorGenerator.java
@@ -33,8 +33,8 @@ public class ExplodedArrayParameterProcessorGenerator implements ParameterProces
       parsedLocation,
       !parameter.getBoolean("required", false),
       new ExplodedArrayValueParameterParser(
-        ValueParserInferenceUtils.infeerItemsParserForArraySchema(schemas.getFakeSchema()),
-        parameter.getString("name")
+        parsedLocation.lowerCaseIfNeeded(parameter.getString("name")),
+        ValueParserInferenceUtils.infeerItemsParserForArraySchema(schemas.getFakeSchema())
       ),
       schemas.getValidator()
     );

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedMatrixArrayParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedMatrixArrayParameterProcessorGenerator.java
@@ -69,7 +69,7 @@ public class ExplodedMatrixArrayParameterProcessorGenerator implements Parameter
       parsedLocation,
       !parameter.getBoolean("required", false),
       new SingleValueParameterParser(
-        parameter.getString("name"),
+        parsedLocation.lowerCaseIfNeeded(parameter.getString("name")),
         new ExplodedMatrixArrayValueParser(ValueParserInferenceUtils.infeerItemsParserForArraySchema(schemas.getFakeSchema()))
       ),
       schemas.getValidator()

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedObjectParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedObjectParameterProcessorGenerator.java
@@ -30,10 +30,10 @@ public class ExplodedObjectParameterProcessorGenerator implements ParameterProce
       parsedLocation,
       !parameter.getBoolean("required", false),
       new ExplodedObjectValueParameterParser(
+        parameter.getString("name"),
         ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
         ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
-        ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema()),
-        parameter.getString("name")
+        ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema())
       ),
       schemas.getValidator()
     );

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedSimpleObjectParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedSimpleObjectParameterProcessorGenerator.java
@@ -75,7 +75,8 @@ public class ExplodedSimpleObjectParameterProcessorGenerator implements Paramete
       new SingleValueParameterParser(
         parameter.getString("name"),
         new ExplodedSimpleObjectValueParser(
-          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
+          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema(),
+            parsedLocation::lowerCaseIfNeeded),
           ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
           ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema())
         )

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedSimpleObjectParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ExplodedSimpleObjectParameterProcessorGenerator.java
@@ -75,8 +75,7 @@ public class ExplodedSimpleObjectParameterProcessorGenerator implements Paramete
       new SingleValueParameterParser(
         parameter.getString("name"),
         new ExplodedSimpleObjectValueParser(
-          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema(),
-            parsedLocation::lowerCaseIfNeeded),
+          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
           ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(schemas.getFakeSchema()),
           ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(schemas.getFakeSchema())
         )

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/JsonParameterProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/JsonParameterProcessorGenerator.java
@@ -29,7 +29,8 @@ public class JsonParameterProcessorGenerator implements ParameterProcessorGenera
       parameter.getString("name"),
       parsedLocation,
       !parameter.getBoolean("required", false),
-      new SingleValueParameterParser(parameter.getString("name"), ValueParser.JSON_PARSER),
+      new SingleValueParameterParser(parsedLocation.lowerCaseIfNeeded(parameter.getString("name")),
+        ValueParser.JSON_PARSER),
       schemas.getValidator()
     );
   }

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterBuilderIntegrationTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterBuilderIntegrationTest.java
@@ -1347,4 +1347,26 @@ public class RouterBuilderIntegrationTest extends BaseRouterBuilderTest {
     });
   }
 
+  @Test
+  public void testHeaderCaseInsensitive(Vertx vertx, VertxTestContext testContext) {
+    loadBuilderAndStartServer(vertx, VALIDATION_SPEC, testContext, routerBuilder -> {
+      routerBuilder.setOptions(HANDLERS_TESTS_OPTIONS);
+      routerBuilder
+        .operation("headerCaseInsensitive")
+        .handler(routingContext -> {
+          RequestParameters params = routingContext.get("parsedParameters");
+          testContext.verify(() -> {
+            assertThat(params.headerParameter("CASEINSENSITIVE").getString())
+              .isEqualTo("hello");
+          });
+          routingContext.response().setStatusCode(200).end();
+        });
+    }).onComplete(h -> {
+      testRequest(client, HttpMethod.GET, "/headerCaseInsensitive")
+        .with(requestHeader("cASEiNSENSITIVE", "hello"))
+        .expect(statusCode(200))
+        .send(testContext);
+    });
+  }
+
 }

--- a/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
+++ b/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
@@ -470,6 +470,18 @@ paths:
       responses:
         200:
           description: Ok
+  /headerCaseInsensitive:
+    get:
+      operationId: headerCaseInsensitive
+      parameters:
+        - name: CaseInsensitive
+          in: header
+          required: false
+          schema:
+            type: string
+      responses:
+        default:
+          description: ok
 components:
   schemas:
     Pet:

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/RequestParameters.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/RequestParameters.java
@@ -53,7 +53,8 @@ public interface RequestParameters {
   List<String> headerParametersNames();
 
   /**
-   * Get header parameter by name
+   * Get header parameter by name.
+   * This getter is case insensitive.
    *
    * @param name Parameter name
    * @return

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/builder/Parameters.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/builder/Parameters.java
@@ -26,7 +26,10 @@ public interface Parameters {
       parameterName,
       location,
       false,
-      new SingleValueParameterParser(parameterName, schemaBuilder.isIntegerSchema() ? ValueParser.LONG_PARSER : ValueParser.DOUBLE_PARSER),
+      new SingleValueParameterParser(
+        location.lowerCaseIfNeeded(parameterName),
+        schemaBuilder.isIntegerSchema() ? ValueParser.LONG_PARSER : ValueParser.DOUBLE_PARSER
+      ),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -43,7 +46,10 @@ public interface Parameters {
       parameterName,
       location,
       true,
-      new SingleValueParameterParser(parameterName, schemaBuilder.isIntegerSchema() ? ValueParser.LONG_PARSER : ValueParser.DOUBLE_PARSER),
+      new SingleValueParameterParser(
+        location.lowerCaseIfNeeded(parameterName),
+        schemaBuilder.isIntegerSchema() ? ValueParser.LONG_PARSER : ValueParser.DOUBLE_PARSER
+      ),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -60,7 +66,7 @@ public interface Parameters {
       parameterName,
       location,
       false,
-      new SingleValueParameterParser(parameterName, ValueParser.NOOP_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.NOOP_PARSER),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -77,7 +83,7 @@ public interface Parameters {
       parameterName,
       location,
       true,
-      new SingleValueParameterParser(parameterName, ValueParser.NOOP_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.NOOP_PARSER),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -94,7 +100,7 @@ public interface Parameters {
       parameterName,
       location,
       false,
-      new SingleValueParameterParser(parameterName, ValueParser.BOOLEAN_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.BOOLEAN_PARSER),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -111,7 +117,7 @@ public interface Parameters {
       parameterName,
       location,
       true,
-      new SingleValueParameterParser(parameterName, ValueParser.BOOLEAN_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.BOOLEAN_PARSER),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -225,7 +231,7 @@ public interface Parameters {
       parameterName,
       location,
       false,
-      new SingleValueParameterParser(parameterName, valueParser),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), valueParser),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -243,7 +249,7 @@ public interface Parameters {
       parameterName,
       location,
       true,
-      new SingleValueParameterParser(parameterName, valueParser),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), valueParser),
       new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
     );
   }
@@ -260,7 +266,7 @@ public interface Parameters {
       parameterName,
       location,
       false,
-      new SingleValueParameterParser(parameterName, ValueParser.JSON_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.JSON_PARSER),
       new SchemaValidator(builder.build(parser))
     );
   }
@@ -277,7 +283,7 @@ public interface Parameters {
       parameterName,
       location,
       true,
-      new SingleValueParameterParser(parameterName, ValueParser.JSON_PARSER),
+      new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), ValueParser.JSON_PARSER),
       new SchemaValidator(builder.build(parser))
     );
   }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/builder/impl/ValidationDSLUtils.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/builder/impl/ValidationDSLUtils.java
@@ -22,14 +22,14 @@ public class ValidationDSLUtils {
   public static BiFunction<ParameterLocation, SchemaParser, ParameterProcessor> createArrayParamFactory(String parameterName, ArrayParserFactory arrayParserFactory, ArraySchemaBuilder schemaBuilder, boolean isOptional) {
     return (location, jsonSchemaParser) -> {
       Schema s = schemaBuilder.build(jsonSchemaParser);
-      ValueParser parser = arrayParserFactory.newArrayParser(
+      ValueParser<String> parser = arrayParserFactory.newArrayParser(
         ValueParserInferenceUtils.infeerItemsParserForArraySchema(s.getJson())
       );
       return new ParameterProcessorImpl(
         parameterName,
         location,
         isOptional,
-        new SingleValueParameterParser(parameterName, parser),
+        new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), parser),
         new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
       );
     };
@@ -38,15 +38,15 @@ public class ValidationDSLUtils {
   public static BiFunction<ParameterLocation, SchemaParser, ParameterProcessor> createTupleParamFactory(String parameterName, TupleParserFactory tupleParserFactory, TupleSchemaBuilder schemaBuilder, boolean isOptional) {
     return (location, jsonSchemaParser) -> {
       Schema s = schemaBuilder.build(jsonSchemaParser);
-      ValueParser parser = tupleParserFactory.newTupleParser(
-          ValueParserInferenceUtils.infeerTupleParsersForArraySchema(s.getJson()),
-          ValueParserInferenceUtils.infeerAdditionalItemsParserForArraySchema(s.getJson())
+      ValueParser<String> parser = tupleParserFactory.newTupleParser(
+        ValueParserInferenceUtils.infeerTupleParsersForArraySchema(s.getJson()),
+        ValueParserInferenceUtils.infeerAdditionalItemsParserForArraySchema(s.getJson())
       );
       return new ParameterProcessorImpl(
         parameterName,
         location,
         isOptional,
-        new SingleValueParameterParser(parameterName, parser),
+        new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), parser),
         new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
       );
     };
@@ -55,7 +55,7 @@ public class ValidationDSLUtils {
   public static BiFunction<ParameterLocation, SchemaParser, ParameterProcessor> createObjectParamFactory(String parameterName, ObjectParserFactory objectParserFactory, ObjectSchemaBuilder schemaBuilder, boolean isOptional) {
     return (location, jsonSchemaParser) -> {
       Schema s = schemaBuilder.build(jsonSchemaParser);
-      ValueParser parser =
+      ValueParser<String> parser =
         objectParserFactory.newObjectParser(
           ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(s.getJson()),
           ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(s.getJson()),
@@ -65,7 +65,7 @@ public class ValidationDSLUtils {
         parameterName,
         location,
         isOptional,
-        new SingleValueParameterParser(parameterName, parser),
+        new SingleValueParameterParser(location.lowerCaseIfNeeded(parameterName), parser),
         new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
       );
     };
@@ -75,9 +75,9 @@ public class ValidationDSLUtils {
     return (location, jsonSchemaParser) -> {
       Schema s = schemaBuilder.build(jsonSchemaParser);
       ParameterParser parser = new ExplodedArrayValueParameterParser(
-          ValueParserInferenceUtils.infeerItemsParserForArraySchema(s.getJson()),
-          parameterName
-        );
+        location.lowerCaseIfNeeded(parameterName),
+        ValueParserInferenceUtils.infeerItemsParserForArraySchema(s.getJson())
+      );
       return new ParameterProcessorImpl(
         parameterName,
         location,
@@ -92,9 +92,9 @@ public class ValidationDSLUtils {
     return (location, jsonSchemaParser) -> {
       Schema s = schemaBuilder.build(jsonSchemaParser);
       ParameterParser parser = new ExplodedTupleValueParameterParser(
-          ValueParserInferenceUtils.infeerTupleParsersForArraySchema(s.getJson()),
-          ValueParserInferenceUtils.infeerAdditionalItemsParserForArraySchema(s.getJson()),
-          parameterName
+        location.lowerCaseIfNeeded(parameterName),
+        ValueParserInferenceUtils.infeerTupleParsersForArraySchema(s.getJson()),
+        ValueParserInferenceUtils.infeerAdditionalItemsParserForArraySchema(s.getJson())
       );
       return new ParameterProcessorImpl(
         parameterName,
@@ -114,10 +114,10 @@ public class ValidationDSLUtils {
         location,
         isOptional,
         new ExplodedObjectValueParameterParser(
-          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(s.getJson()),
+          parameterName,
+          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(s.getJson(), location::lowerCaseIfNeeded),
           ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(s.getJson()),
-          ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(s.getJson()),
-          parameterName
+          ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(s.getJson())
         ),
         new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
       );
@@ -132,10 +132,9 @@ public class ValidationDSLUtils {
         location,
         isOptional,
         new DeepObjectValueParameterParser(
-          ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(s.getJson()),
+          parameterName, ValueParserInferenceUtils.infeerPropertiesParsersForObjectSchema(s.getJson()),
           ValueParserInferenceUtils.infeerPatternPropertiesParsersForObjectSchema(s.getJson()),
-          ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(s.getJson()),
-          parameterName
+          ValueParserInferenceUtils.infeerAdditionalPropertiesParserForObjectSchema(s.getJson())
         ),
         new SchemaValidator(schemaBuilder.build(jsonSchemaParser))
       );

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/ParameterLocation.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/ParameterLocation.java
@@ -12,5 +12,10 @@ public enum ParameterLocation {
   HEADER,
   QUERY,
   PATH,
-  COOKIE
+  COOKIE;
+
+  public String lowerCaseIfNeeded(String parameterName) {
+    return this == HEADER ? parameterName.toLowerCase() : parameterName;
+  }
+
 }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParametersImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/RequestParametersImpl.java
@@ -95,7 +95,7 @@ public class RequestParametersImpl implements RequestParameters {
 
   @Override
   public RequestParameter headerParameter(String name) {
-    return headerParameters.get(name);
+    return headerParameters.get(name.toLowerCase());
   }
 
   @Override

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/ValueParserInferenceUtils.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/ValueParserInferenceUtils.java
@@ -42,6 +42,16 @@ public class ValueParserInferenceUtils {
     );
   }
 
+  public static Map<String, ValueParser<String>> infeerPropertiesParsersForObjectSchema(Object s, Function<String,
+    String> keyMapper) {
+    return jsonObjectSchemaToMapOfValueParser(
+      s,
+      "properties",
+      keyMapper,
+      ValueParserInferenceUtils::infeerPrimitiveParser
+    );
+  }
+
   public static Map<Pattern, ValueParser<String>> infeerPatternPropertiesParsersForObjectSchema(Object s) {
     return jsonObjectSchemaToMapOfValueParser(
       s,

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/DeepObjectValueParameterParser.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/DeepObjectValueParameterParser.java
@@ -17,7 +17,9 @@ public class DeepObjectValueParameterParser extends ObjectParser<String> impleme
 
   String parameterName;
 
-  public DeepObjectValueParameterParser(Map<String, ValueParser<String>> propertiesParsers, Map<Pattern, ValueParser<String>> patternPropertiesParsers, ValueParser<String> additionalPropertiesParsers, String parameterName) {
+  public DeepObjectValueParameterParser(String parameterName, Map<String, ValueParser<String>> propertiesParsers,
+                                        Map<Pattern, ValueParser<String>> patternPropertiesParsers,
+                                        ValueParser<String> additionalPropertiesParsers) {
     super(propertiesParsers, patternPropertiesParsers, additionalPropertiesParsers);
     this.parameterName = parameterName;
   }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedArrayValueParameterParser.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedArrayValueParameterParser.java
@@ -16,7 +16,7 @@ public class ExplodedArrayValueParameterParser extends ArrayParser implements Pa
 
   String parameterName;
 
-  public ExplodedArrayValueParameterParser(ValueParser<String> itemsParser, String parameterName) {
+  public ExplodedArrayValueParameterParser(String parameterName, ValueParser<String> itemsParser) {
     super(itemsParser);
     this.parameterName = parameterName;
   }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedObjectValueParameterParser.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedObjectValueParameterParser.java
@@ -15,7 +15,9 @@ public class ExplodedObjectValueParameterParser extends ObjectParser<String> imp
 
   String parameterName;
 
-  public ExplodedObjectValueParameterParser(Map<String, ValueParser<String>> propertiesParsers, Map<Pattern, ValueParser<String>> patternPropertiesParsers, ValueParser<String> additionalPropertiesParsers, String parameterName) {
+  public ExplodedObjectValueParameterParser(String parameterName, Map<String, ValueParser<String>> propertiesParsers,
+                                            Map<Pattern, ValueParser<String>> patternPropertiesParsers,
+                                            ValueParser<String> additionalPropertiesParsers) {
     super(propertiesParsers, patternPropertiesParsers, additionalPropertiesParsers);
     this.parameterName = parameterName;
   }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedTupleValueParameterParser.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ExplodedTupleValueParameterParser.java
@@ -18,7 +18,8 @@ public class ExplodedTupleValueParameterParser extends TupleParser implements Pa
 
   String parameterName;
 
-  public ExplodedTupleValueParameterParser(List<ValueParser<String>> itemsParser, ValueParser<String> additionalItemsParser, String parameterName) {
+  public ExplodedTupleValueParameterParser(String parameterName, List<ValueParser<String>> itemsParser,
+                                           ValueParser<String> additionalItemsParser) {
     super(itemsParser, additionalItemsParser);
     this.parameterName = parameterName;
   }

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/ValidationHandlerProcessorsIntegrationTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/ValidationHandlerProcessorsIntegrationTest.java
@@ -951,4 +951,27 @@ public class ValidationHandlerProcessorsIntegrationTest extends BaseValidationHa
       .send(testContext, checkpoint);
   }
 
+  @Test
+  public void testSimpleHeaderCaseInsensitivity(VertxTestContext testContext) {
+    ValidationHandler validationHandler = ValidationHandler
+      .builder(parser)
+      .headerParameter(param("AnHeader", intSchema()))
+      .build();
+
+    router.get("/test")
+      .handler(validationHandler)
+      .handler(routingContext -> {
+        RequestParameters params = routingContext.get("parsedParameters");
+        routingContext
+          .response()
+          .putHeader("content-type", "application/json")
+          .end(params.headerParameter("anHeader").getInteger().toString());
+      });
+
+    testRequest(client, HttpMethod.GET, "/test")
+      .with(requestHeader("anheader", "10"))
+      .expect(statusCode(200), jsonBodyResponse(10))
+      .send(testContext);
+  }
+
 }

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/DeepObjectValueParameterParserTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/DeepObjectValueParameterParserTest.java
@@ -38,10 +38,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testValid() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -68,10 +67,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testNoAdditionalProperties() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      null,
-      "bla"
+      null
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -98,10 +96,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testNull() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -126,10 +123,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testEmptyString() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -154,10 +150,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testMissingProp() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -183,10 +178,9 @@ public class DeepObjectValueParameterParserTest {
   @Test
   public void testInvalid() {
     DeepObjectValueParameterParser parser = new DeepObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedArrayValueParameterParserTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedArrayValueParameterParserTest.java
@@ -34,7 +34,7 @@ public class ExplodedArrayValueParameterParserTest {
   @Test
   public void testValid() {
     ExplodedArrayValueParameterParser parser = new ExplodedArrayValueParameterParser(
-      ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -57,7 +57,7 @@ public class ExplodedArrayValueParameterParserTest {
   @Test
   public void testNull() {
     ExplodedArrayValueParameterParser parser = new ExplodedArrayValueParameterParser(
-      ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -80,7 +80,7 @@ public class ExplodedArrayValueParameterParserTest {
   @Test
   public void testInvalid() {
     ExplodedArrayValueParameterParser parser = new ExplodedArrayValueParameterParser(
-      ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedObjectValueParameterParserTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedObjectValueParameterParserTest.java
@@ -38,10 +38,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testValid() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -66,10 +65,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testNoAdditionalProperties() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      null,
-      "bla"
+      null
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -94,10 +92,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testNull() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -121,10 +118,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testEmptyString() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -149,10 +145,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testMissingProp() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -180,10 +175,9 @@ public class ExplodedObjectValueParameterParserTest {
   @Test
   public void testInvalid() {
     ExplodedObjectValueParameterParser parser = new ExplodedObjectValueParameterParser(
-      TestParsers.SAMPLE_PROPERTIES_PARSERS,
+      "bla", TestParsers.SAMPLE_PROPERTIES_PARSERS,
       TestParsers.SAMPLE_PATTERN_PROPERTIES_PARSERS,
-      ValueParser.NOOP_PARSER,
-      "bla"
+      ValueParser.NOOP_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedTupleValueParameterParserTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ExplodedTupleValueParameterParserTest.java
@@ -40,7 +40,7 @@ public class ExplodedTupleValueParameterParserTest {
   @Test
   public void testValid() {
     ExplodedTupleValueParameterParser parser = new ExplodedTupleValueParameterParser(
-      TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -63,7 +63,7 @@ public class ExplodedTupleValueParameterParserTest {
   @Test
   public void testNoAdditionalItems() {
     ExplodedTupleValueParameterParser parser = new ExplodedTupleValueParameterParser(
-      TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, null, "bla"
+      "bla", TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, null
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -86,7 +86,7 @@ public class ExplodedTupleValueParameterParserTest {
   @Test
   public void testNullAndEmptyString() {
     ExplodedTupleValueParameterParser parser = new ExplodedTupleValueParameterParser(
-      TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", TestParsers.SAMPLE_TUPLE_ITEMS_PARSERS, ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();
@@ -109,7 +109,7 @@ public class ExplodedTupleValueParameterParserTest {
   @Test
   public void testInvalid() {
     ExplodedArrayValueParameterParser parser = new ExplodedArrayValueParameterParser(
-      ValueParser.BOOLEAN_PARSER, "bla"
+      "bla", ValueParser.BOOLEAN_PARSER
     );
 
     Map<String, List<String>> map = new HashMap<>();


### PR DESCRIPTION
Fix #1782

This fix doesn't change the logic of `ParameterParser`, which are by design location unaware, hence case-sensitivity unaware. To trick the parsers, I just pass the headers always lowercase (and i carefully build the parsers to get the parameters using their lowercase form).

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>