### PR TITLE
OpenAPI path matching must be in correct order

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
@@ -307,6 +307,7 @@ public class OpenAPI3RouterBuilderImpl implements RouterBuilder {
         .solve() // If this optional is empty, this route doesn't need regex
         .map(solvedRegex -> router.routeWithRegex(operation.getHttpMethod(), solvedRegex.toString()))
         .orElseGet(() -> router.route(operation.getHttpMethod(), operation.getOpenAPIPath()))
+        .order(pathResolver.parameters.size())
         .setName(options.getRouteNamingStrategy().apply(operation));
 
       String exposeConfigurationKey = this.getOptions().getOperationModelKey();

--- a/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
+++ b/vertx-web-openapi/src/test/resources/specs/validation_test.yaml
@@ -79,6 +79,94 @@ paths:
       responses:
         default:
           description: ok
+  /pets/{storeId}/{petId}:
+    get:
+      summary: Info for a specific pet in specific store
+      operationId: showPetByIdInStoreById
+      tags:
+        - pets
+      parameters:
+        - name: storeId
+          in: path
+          required: true
+          description: The id of the petstore
+          schema:
+            type: integer
+            format: int32
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/storex/{petId}:
+    get:
+      summary: Info for a specific pet in Storex petstore
+      operationId: showPetByIdInStorex
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{storeId}/dogs:
+    get:
+      summary: Info for dogs in specific store
+      operationId: showDogsInStoreById
+      tags:
+        - pets
+      parameters:
+        - name: storeId
+          in: path
+          required: true
+          description: The id of the petstore
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /pets/{petId}:
     get:
       summary: Info for a specific pet
@@ -106,6 +194,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /pets/mine:
+    get:
+      summary: Info for a specific pet
+      operationId: showMyPets
+      tags:
+        - pets
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
   /queryTests/arrayTests/formExploded:
     get:
       operationId: arrayTestFormExploded


### PR DESCRIPTION
**Issue**: https://github.com/vert-x3/vertx-web/issues/1751

**Description**: Open API paths/routes cannot be mounted/defined to router in order in which they are defined in OpenAPI specfile. They must be ordered from the most specific ones to the least specific (with the most path parameters). 

**Solution**: Because by definition, two paths are equivalent `/path/{param1}` `/path/{param2}` order can be determined based on number of path's parameters.
So, when `io.vertx.ext.web.Router` is created, `order` of its `route`s is defined based on number of path parameters they have.

For example:
`/pets/{param1}` -> `route.order(1)`
`/pets/{param1}/{param2}` -> `route.order(2)`
`/pets/mine` -> `route.order(0)`

