### PR TITLE
Ignore charset / boundary on contentType predicates

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicate.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicate.java
@@ -413,8 +413,14 @@ public interface ResponsePredicate extends Function<HttpResponse<Void>, Response
       if (contentType == null) {
         return ResponsePredicateResult.failure("Missing response content type");
       }
+      String mediaType = contentType;
+      int idx = mediaType.indexOf(';');
+      if (idx != -1) {
+        mediaType = mediaType.substring(0, idx);
+      }
+
       for (String mimeType : mimeTypes) {
-        if (contentType.equalsIgnoreCase(mimeType)) {
+        if (mediaType.equalsIgnoreCase(mimeType)) {
           return ResponsePredicateResult.success();
         }
       }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -1737,6 +1737,13 @@ public class WebClientTest extends WebClientTestBase {
   }
 
   @Test
+  public void testExpectContentTypeWithEncodingPass() throws Exception {
+    testExpectation(false,
+      req -> req.expect(ResponsePredicate.JSON),
+      resp -> resp.putHeader("content-type", "application/JSON;charset=UTF-8").end());
+  }
+
+  @Test
   public void testExpectOneOfContentTypesPass() throws Exception {
     testExpectation(false,
       req -> req.expect(ResponsePredicate.contentType(Arrays.asList("text/plain", "text/HTML"))),


### PR DESCRIPTION
Fixes #1583

Ignore charset / boundary on contentType predicates.