### PR TITLE
Fix NPE when sending JSON data and the user agent header is disabled

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -79,6 +79,8 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     this.options = options;
     if (options.isUserAgentEnabled()) {
       headers = HttpHeaders.set(HttpHeaders.USER_AGENT, options.getUserAgent());
+    } else {
+      headers = HttpHeaders.headers();
     }
   }
 
@@ -92,7 +94,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     this.host = other.host;
     this.timeout = other.timeout;
     this.uri = other.uri;
-    this.headers = other.headers != null ? HttpHeaders.headers().addAll(other.headers) : null;
+    this.headers = other.headers != null ? HttpHeaders.headers().addAll(other.headers) : HttpHeaders.headers();
     this.params = other.params != null ? HttpHeaders.headers().addAll(other.params) : null;
     this.codec = other.codec;
     this.followRedirects = other.followRedirects;


### PR DESCRIPTION
Signed-off-by: Rory Steele <rory@scoutimpact.com>

Motivation:

Fixes #1814

An issue was discovered when using vertx-config to login to Vault using the app role mechanism. The user agent header had been disabled and this led to NullPointerExceptions when performing the request.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
