### PR TITLE
Schema#getDefaultValue() throws NoSyncValidationException if it is a RefSchema

### DIFF
--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ParameterProcessorImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/parameter/ParameterProcessorImpl.java
@@ -40,12 +40,8 @@ public class ParameterProcessorImpl implements ParameterProcessor, Comparable<Pa
     else if (!isOptional)
       throw createMissingParameterWhenRequired(parameterName, location);
     else {
-      if (validator.getDefault() != null)
-        return Future.succeededFuture(RequestParameter.create(validator.getDefault()));
-      else
-        return Future.succeededFuture();
+      return validator.getDefault().map(defaultValue -> null != defaultValue ? RequestParameter.create(defaultValue) : null);
     }
-
   }
 
   @Override

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/SchemaValidator.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/SchemaValidator.java
@@ -20,7 +20,7 @@ public class SchemaValidator implements ValueValidator {
     if (s.isSync()) {
       try {
         s.validateSync(json);
-        ((SchemaImpl)s).doApplyDefaultValues(json);
+        ((SchemaImpl) s).doApplyDefaultValues(json);
         return Future.succeededFuture(RequestParameter.create(json));
       } catch (ValidationException e) {
         return Future.failedFuture(e);
@@ -28,8 +28,8 @@ public class SchemaValidator implements ValueValidator {
     }
     return s.validateAsync(json).map(v -> {
       try {
-        ((SchemaImpl)s).doApplyDefaultValues(json);
-      } catch (NoSyncValidationException e){
+        ((SchemaImpl) s).doApplyDefaultValues(json);
+      } catch (NoSyncValidationException e) {
         // This happens if I try to apply default values to an async ref schema
       }
       return RequestParameter.create(json);
@@ -37,8 +37,12 @@ public class SchemaValidator implements ValueValidator {
   }
 
   @Override
-  public Object getDefault() {
-    return s.getDefaultValue();
+  public Future<Object> getDefault() {
+    if (s.isSync()) {
+      return Future.succeededFuture(s.getDefaultValue());
+    }
+    return s.validateAsync(null) // validate a dummy to trigger syncing
+      .map(s.getDefaultValue())
+      .otherwise(s.getDefaultValue());
   }
-
 }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/SchemaValidator.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/SchemaValidator.java
@@ -20,7 +20,7 @@ public class SchemaValidator implements ValueValidator {
     if (s.isSync()) {
       try {
         s.validateSync(json);
-        ((SchemaImpl) s).doApplyDefaultValues(json);
+        ((SchemaImpl) s).getOrApplyDefaultSync(json);
         return Future.succeededFuture(RequestParameter.create(json));
       } catch (ValidationException e) {
         return Future.failedFuture(e);
@@ -28,7 +28,7 @@ public class SchemaValidator implements ValueValidator {
     }
     return s.validateAsync(json).map(v -> {
       try {
-        ((SchemaImpl) s).doApplyDefaultValues(json);
+        ((SchemaImpl) s).getOrApplyDefaultAsync(json);
       } catch (NoSyncValidationException e) {
         // This happens if I try to apply default values to an async ref schema
       }
@@ -39,10 +39,8 @@ public class SchemaValidator implements ValueValidator {
   @Override
   public Future<Object> getDefault() {
     if (s.isSync()) {
-      return Future.succeededFuture(s.getDefaultValue());
+      return Future.succeededFuture( ((SchemaImpl) s).getOrApplyDefaultSync(null));
     }
-    return s.validateAsync(null) // validate a dummy to trigger syncing
-      .map(s.getDefaultValue())
-      .otherwise(s.getDefaultValue());
+    return ((SchemaImpl) s).getOrApplyDefaultAsync(null);
   }
 }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/ValueValidator.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/validator/ValueValidator.java
@@ -21,6 +21,6 @@ public interface ValueValidator {
    *
    * @return
    */
-  Object getDefault();
+  Future<Object> getDefault();
 
 }

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ParameterProcessorUnitTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/ParameterProcessorUnitTest.java
@@ -77,6 +77,7 @@ public class ParameterProcessorUnitTest {
     );
 
     when(mockedParser.parseParameter(any())).thenReturn(null);
+    when(mockedValidator.getDefault()).thenReturn(Future.succeededFuture());
 
     processor.process(new HashMap<>()).onComplete(testContext.succeeding(value -> {
       testContext.verify(() ->
@@ -98,7 +99,7 @@ public class ParameterProcessorUnitTest {
     );
 
     when(mockedParser.parseParameter(any())).thenReturn(null);
-    when(mockedValidator.getDefault()).thenReturn("bla");
+    when(mockedValidator.getDefault()).thenReturn(Future.succeededFuture("bla"));
 
     processor.process(new HashMap<>()).onComplete(testContext.succeeding(value -> {
       testContext.verify(() ->


### PR DESCRIPTION
given a yaml:

```
paths:
  /tryout:
    get:
      operationId: tryout
      parameters:
        - in: query
          name: namespace
          required: false
          schema:
            $ref: '#/components/schemas/namespace'

components:
  schemas:
    namespace:
      type: string
      minLength: 1
```

using `io.vertx.ext.web.openapi.RouterBuilder` and sending `GET /tryout`  the schemaValidation will blow up with the noted exception because `namespace` is `null` and calling `getDefaultValue()` on the schema before any validation fails because its a `RefSchema` and has not been resolved yet.