### PR TITLE
Expose interfaces for manual sockjs session management.

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1977,7 +1977,11 @@ this will be called every time a SockJS connection is made from a client:
 The object passed into the handler is a {@link io.vertx.ext.web.handler.sockjs.SockJSSocket}. This has a familiar
 socket-like interface which you can read and write to similarly to a {@link io.vertx.core.net.NetSocket} or
 a {@link io.vertx.core.http.WebSocket}. It also implements {@link io.vertx.core.streams.ReadStream} and
-{@link io.vertx.core.streams.WriteStream} so you can pump it to and from other read and write streams.
+{@link io.vertx.core.streams.WriteStream} so you can pump it to and from other read and write streams. The
+{@link io.vertx.ext.web.RoutingContext} is accessible for manual session management while the SockJS connection
+is loaded using {@link io.vertx.ext.web.handler.sockjs.SockJSSocket#routingContext()}. With this you can manage
+the users and sessions accessible through {@link io.vertx.ext.web.handler.sockjs.SockJSSocket#webSession()}
+and {@link io.vertx.ext.web.handler.sockjs.SockJSSocket#webUser()}.
 
 Here's an example of a simple SockJS handler that simply echoes back any back any data that it reads:
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.impl.SessionHandlerImpl;
 import io.vertx.ext.web.sstore.SessionStore;
 
@@ -221,12 +222,33 @@ public interface SessionHandler extends Handler<RoutingContext> {
   SessionHandler flush(RoutingContext ctx, Handler<AsyncResult<Void>> handler);
 
   /**
+   * Flush a context session earlier to the store, this will allow the end user to have full control on the event of
+   * a failure at the store level. Once a session is flushed no automatic save will be performed at end of request.
+   *
+   * @param ctx the current context
+   * @param ignoreStatus flush regardless of response status code
+   * @param handler the event handler to signal a asynchronous response.
+   * @return fluent self
+   */
+  @Fluent
+  SessionHandler flush(RoutingContext ctx, boolean ignoreStatus, Handler<AsyncResult<Void>> handler);
+
+  /**
    * Promisified flush. See {@link #flush(RoutingContext, Handler)}.
    */
 	default Future<Void> flush(RoutingContext ctx) {
 	  Promise<Void> promise = ((VertxInternal)ctx.vertx()).promise();
 	  flush(ctx, promise);
 	  return promise.future();
+  }
+
+  /**
+   * Promisified flush. See {@link #flush(RoutingContext, boolean, Handler)}.
+   */
+  default Future<Void> flush(RoutingContext ctx, boolean ignoreStatus) {
+    Promise<Void> promise = ((VertxInternal)ctx.vertx()).promise();
+    flush(ctx, ignoreStatus, promise);
+    return promise.future();
   }
 
   /**
@@ -239,4 +261,12 @@ public interface SessionHandler extends Handler<RoutingContext> {
    */
   @Fluent
   SessionHandler setCookieless(boolean cookieless);
+
+  /**
+   * Create a new session
+   *
+   * @param context the routing context
+   * @return the session
+   */
+  Session newSession(RoutingContext context);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -36,9 +36,9 @@ import io.vertx.ext.web.sstore.impl.SessionInternal;
  */
 public class SessionHandlerImpl implements SessionHandler {
 
-  private static final String SESSION_USER_HOLDER_KEY = "__vertx.userHolder";
-  private static final String SESSION_FLUSHED_KEY = "__vertx.session-flushed";
-  private static final String SESSION_STOREUSER_KEY = "__vertx.session-storeuser";
+  public static final String SESSION_USER_HOLDER_KEY = "__vertx.userHolder";
+  public static final String SESSION_FLUSHED_KEY = "__vertx.session-flushed";
+  public static final String SESSION_STOREUSER_KEY = "__vertx.session-storeuser";
 
   private static final Logger log = LoggerFactory.getLogger(SessionHandlerImpl.class);
 
@@ -135,7 +135,12 @@ public class SessionHandlerImpl implements SessionHandler {
 
   @Override
   public SessionHandler flush(RoutingContext context, Handler<AsyncResult<Void>> handler) {
-    return flush(context, false, handler);
+    return flush(context, false, false, handler);
+  }
+
+  @Override
+  public SessionHandler flush(RoutingContext context, boolean ignoreStatus, Handler<AsyncResult<Void>> handler) {
+    return flush(context, false, ignoreStatus, handler);
   }
 
   /**
@@ -155,13 +160,13 @@ public class SessionHandlerImpl implements SessionHandler {
     }
   }
 
-  private SessionHandler flush(RoutingContext context, boolean skipCrc, Handler<AsyncResult<Void>> handler) {
+  private SessionHandler flush(RoutingContext context, boolean skipCrc, boolean ignoreStatus, Handler<AsyncResult<Void>> handler) {
     boolean sessionUsed = context.isSessionAccessed();
     Session session = context.session();
     if (!session.isDestroyed()) {
       final int currentStatusCode = context.response().getStatusCode();
       // Store the session (only and only if there was no error)
-      if (currentStatusCode >= 200 && currentStatusCode < 400) {
+      if (ignoreStatus || (currentStatusCode >= 200 && currentStatusCode < 400)) {
         // store the current user into the session
         Boolean storeUser = context.get(SESSION_STOREUSER_KEY);
         if (storeUser != null && storeUser) {
@@ -318,6 +323,22 @@ public class SessionHandlerImpl implements SessionHandler {
     }
   }
 
+  public Session newSession(RoutingContext context) {
+    Session session = sessionStore.createSession(sessionTimeout, minLength);
+    context.setSession(session);
+    if (!cookieless) {
+      context.removeCookie(sessionCookieName, false);
+    }
+    // it's a new session we must store the user too otherwise it won't be linked
+    context.put(SESSION_STOREUSER_KEY, true);
+    flush(context, true, true, flush -> {
+      if (flush.failed()) {
+        log.warn("Failed to flush the session to the underlying store", flush.cause());
+      }
+    });
+    return session;
+  }
+
   private String getSessionId(RoutingContext  context) {
     if (cookieless) {
       // cookieless sessions store the session on the path or the request
@@ -382,7 +403,7 @@ public class SessionHandlerImpl implements SessionHandler {
       // skip flush if we already flushed
       Boolean flushed = context.get(SESSION_FLUSHED_KEY);
       if (flushed == null || !flushed) {
-        flush(context, true, flush -> {
+        flush(context, true, false, flush -> {
           if (flush.failed()) {
             log.warn("Failed to flush the session to the underlying store", flush.cause());
           }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSSocket.java
@@ -40,6 +40,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 
 /**
@@ -156,6 +157,11 @@ public interface SockJSSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    * Return the URI corresponding to the last request for this socket or the websocket handshake
    */
   String uri();
+
+  /**
+   *  @return the Vert.x-Web RoutingContext corresponding to this socket
+   */
+  RoutingContext routingContext();
 
   /**
    * @return the Vert.x-Web session corresponding to this socket

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
@@ -38,9 +38,8 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.Session;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 
@@ -55,8 +54,8 @@ class RawWebSocketTransport {
     MultiMap headers;
     boolean closed;
 
-    RawWSSockJSSocket(Vertx vertx, Session webSession, User webUser, SockJSHandlerOptions options, ServerWebSocket ws) {
-      super(vertx, webSession, webUser, options);
+    RawWSSockJSSocket(Vertx vertx, RoutingContext rc, SockJSHandlerOptions options, ServerWebSocket ws) {
+      super(vertx, rc, options);
       this.ws = ws;
       ws.closeHandler(v -> {
         // Make sure the writeHandler gets unregistered
@@ -207,7 +206,7 @@ class RawWebSocketTransport {
             rc.request().resume();
           }
           // handle the sockjs session as usual
-          SockJSSocket sock = new RawWSSockJSSocket(vertx, rc.session(), rc.user(), options, toWebSocket.result());
+          SockJSSocket sock = new RawWSSockJSSocket(vertx, rc, options, toWebSocket.result());
           sockHandler.handle(sock);
         } else {
           // the upgrade failed

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -97,7 +97,7 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
   }
 
   SockJSSession(Vertx vertx, LocalMap<String, SockJSSession> sessions, RoutingContext rc, String id, SockJSHandlerOptions options, Handler<SockJSSocket> sockHandler) {
-    super(vertx, rc.session(), rc.user(), options);
+    super(vertx, rc, options);
     this.sessions = sessions;
     this.id = id;
     this.timeout = id == null ? -1:options.getSessionTimeout();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
@@ -37,6 +37,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSSocket;
@@ -47,8 +48,7 @@ public abstract class SockJSSocketBase implements SockJSSocket {
 
   private final MessageConsumer<Buffer> registration;
   protected final Vertx vertx;
-  protected Session webSession;
-  protected User webUser;
+  protected RoutingContext routingContext;
 
   /**
    * When a {@code SockJSSocket} is created it automatically registers an event handler with the event bus, the ID of that
@@ -63,10 +63,9 @@ public abstract class SockJSSocketBase implements SockJSSocket {
   @Override
   public abstract SockJSSocket exceptionHandler(Handler<Throwable> handler);
 
-  protected SockJSSocketBase(Vertx vertx, Session webSession, User webUser, SockJSHandlerOptions options) {
+  protected SockJSSocketBase(Vertx vertx, RoutingContext rc, SockJSHandlerOptions options) {
     this.vertx = vertx;
-    this.webSession = webSession;
-    this.webUser = webUser;
+    this.routingContext = rc;
     if (options.isRegisterWriteHandler()) {
       Handler<Message<Buffer>> writeHandler = msg -> write(msg.body());
       writeHandlerID = UUID.randomUUID().toString();
@@ -119,12 +118,17 @@ public abstract class SockJSSocketBase implements SockJSSocket {
   }
 
   @Override
+  public RoutingContext routingContext() {
+    return routingContext;
+  }
+
+  @Override
   public Session webSession() {
-    return webSession;
+    return routingContext.session();
   }
 
   @Override
   public User webUser() {
-    return webUser;
+    return routingContext.user();
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -29,11 +29,13 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.impl.UserHolder;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.vertx.ext.web.handler.impl.SessionHandlerImpl.SESSION_USER_HOLDER_KEY;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -329,6 +331,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   @Override
   public void setSession(Session session) {
     this.session = session;
+    // attempt to load the user from the session if one exists
+    UserHolder holder = session.get(SESSION_USER_HOLDER_KEY);
+    if (holder != null) {
+      holder.refresh(this);
+    }
   }
 
   @Override


### PR DESCRIPTION
Motivation:

Currently it appears to be nearly impossible to manage/bind sockjs sessions using a normal session store. This should allow accessing routing context from within a sockjs connection in addition to manually creating and restoring of sessions and their associated users from within the sockjs connection.