### PR TITLE
Vert.x Web Proxy Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <module>vertx-web-api-service</module>
     <module>vertx-web-validation</module>
     <module>vertx-web-openapi</module>
+    <module>vertx-web-proxy</module>
   </modules>
 
   <profiles>

--- a/vertx-web-proxy/pom.xml
+++ b/vertx-web-proxy/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>vertx-web-parent</artifactId>
+    <groupId>io.vertx</groupId>
+    <version>4.0.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>vertx-web-proxy</artifactId>
+
+  <properties>
+    <doc.skip>false</doc.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-http-proxy</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/vertx-web-proxy/src/main/asciidoc/index.adoc
+++ b/vertx-web-proxy/src/main/asciidoc/index.adoc
@@ -1,0 +1,87 @@
+= Vert.x Web Proxy
+:toc: left
+
+Vert.x Web Proxy provides a handler that handles the reverse proxy logic using
+https://github.com/eclipse-vertx/vertx-http-proxy[Vert.x Http Proxy].
+
+WARNING: This module has _Tech Preview_ status, this means the API can change between versions.
+
+== Using Vert.x Web Proxy
+To use Vert.x Web Proxy, add the following dependency to the _dependencies_ section of your build descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-web-proxy</artifactId>
+  <version>${maven.version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  compile 'io.vertx:vertx-web-proxy:${maven.version}'
+}
+----
+
+== Basic Web Proxy
+
+In order to accomplish local reverse proxy with Vert.x Web Proxy you need the following:
+
+1. *Proxy Server* that handles front requests and forward them to the *origin server* using `ProxyHandler`.
+2. *Origin Server* that handles requests from the *proxy server* and handles responses accordingly.
+
+Now, you have the overall concept so let's dive in implementation and begin with *origin server* then
+the *proxy server* using `ProxyHandler`:
+
+== Origin Server (Backend)
+
+You simply create the *origin server* and handle requests with Vert.x Web `Router`, the *origin server*
+listens to port `7070`
+
+[source,java]
+----
+{@link examples.WebProxyExamples#origin}
+----
+
+== Proxy Server
+
+Create the *proxy server* that listens to port `8080`
+
+[source,java]
+----
+{@link examples.WebProxyExamples#proxy}
+----
+== Using `ProxyHandler`
+
+The last interesting part is to route *proxy server* requests to the *origin server*, so you need to create `HttpProxy`
+with specified target and `ProxyHandler`.
+
+[source,java]
+----
+{@link examples.WebProxyExamples#route}
+----
+
+Or you can specify the target in `ProxyHandler` instead.
+
+[source,java]
+----
+{@link examples.WebProxyExamples#routeShort}
+----
+
+Finally, the *proxy server* requests will be routed as a reverse proxy to the *origin server* conveniently.
+
+== Using `ProxyHandler` for multiple targets
+
+In order to route *proxy server* requests to multiple *origin servers* you simply create `HttpProxy` for
+each one and specify the target independently.
+
+[source,java]
+----
+{@link examples.WebProxyExamples#multi}
+----

--- a/vertx-web-proxy/src/main/java/examples/WebProxyExamples.java
+++ b/vertx-web-proxy/src/main/java/examples/WebProxyExamples.java
@@ -1,0 +1,79 @@
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.proxy.handler.ProxyHandler;
+import io.vertx.httpproxy.HttpProxy;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class WebProxyExamples {
+
+  public void origin(Vertx vertx) {
+    HttpServer backendServer = vertx.createHttpServer();
+
+    Router backendRouter = Router.router(vertx);
+
+    backendRouter.route(HttpMethod.GET, "/foo").handler(rc -> {
+      rc.response()
+        .putHeader("content-type", "text/html")
+        .end("<html><body><h1>I'm the target resource!</h1></body></html>");
+    });
+
+    backendServer.requestHandler(backendRouter).listen(7070);
+  }
+
+  public void proxy(Vertx vertx) {
+    HttpServer proxyServer = vertx.createHttpServer();
+
+    Router proxyRouter = Router.router(vertx);
+
+    proxyServer.requestHandler(proxyRouter);
+
+    proxyServer.listen(8080);
+  }
+
+  public void route(Vertx vertx, Router proxyRouter) {
+    HttpClient proxyClient = vertx.createHttpClient();
+
+    HttpProxy httpProxy = HttpProxy.reverseProxy2(proxyClient);
+    httpProxy.target(7070, "localhost");
+
+    proxyRouter
+      .route(HttpMethod.GET, "/foo").handler(ProxyHandler.create(httpProxy));
+  }
+
+  public void routeShort(Vertx vertx, Router proxyRouter) {
+    HttpClient proxyClient = vertx.createHttpClient();
+
+    HttpProxy httpProxy = HttpProxy.reverseProxy2(proxyClient);
+
+    proxyRouter
+      .route(HttpMethod.GET, "/foo")
+      .handler(ProxyHandler.create(httpProxy, 7070, "localhost"));
+  }
+
+  public void multi(Vertx vertx, Router proxyRouter) {
+    HttpClient proxyClient = vertx.createHttpClient();
+
+    HttpProxy httpProxy1 = HttpProxy.reverseProxy2(proxyClient);
+    httpProxy1.target(7070, "localhost");
+
+    HttpProxy httpProxy2 = HttpProxy.reverseProxy2(proxyClient);
+    httpProxy2.target(6060, "localhost");
+
+    proxyRouter
+      .route(HttpMethod.GET, "/foo").handler(ProxyHandler.create(httpProxy1));
+
+    proxyRouter
+      .route(HttpMethod.GET, "/bar").handler(ProxyHandler.create(httpProxy2));
+  }
+
+}
+
+

--- a/vertx-web-proxy/src/main/java/examples/package-info.java
+++ b/vertx-web-proxy/src/main/java/examples/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@Source
+package examples;
+import io.vertx.docgen.Source;

--- a/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/handler/ProxyHandler.java
+++ b/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/handler/ProxyHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.ext.web.proxy.handler;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.proxy.handler.impl.ProxyHandlerImpl;
+import io.vertx.httpproxy.HttpProxy;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+@VertxGen
+public interface ProxyHandler extends Handler<RoutingContext> {
+
+  static ProxyHandler create(HttpProxy httpProxy) {
+    return new ProxyHandlerImpl(httpProxy);
+  }
+
+  static ProxyHandler create(HttpProxy httpProxy, int port, String host) {
+    return new ProxyHandlerImpl(httpProxy, port, host);
+  }
+}

--- a/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/handler/impl/ProxyHandlerImpl.java
+++ b/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/handler/impl/ProxyHandlerImpl.java
@@ -1,0 +1,27 @@
+package io.vertx.ext.web.proxy.handler.impl;
+
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.proxy.handler.ProxyHandler;
+import io.vertx.httpproxy.HttpProxy;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class ProxyHandlerImpl implements ProxyHandler {
+
+  private final HttpProxy httpProxy;
+
+  public ProxyHandlerImpl(HttpProxy httpProxy) {
+    this.httpProxy = httpProxy;
+  }
+
+  public ProxyHandlerImpl(HttpProxy httpProxy, int port, String host) {
+    this.httpProxy = httpProxy.target(port, host);
+  }
+
+  @Override
+  public void handle(RoutingContext ctx) {
+    httpProxy.handle(ctx.request());
+  }
+}

--- a/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/package-info.java
+++ b/vertx-web-proxy/src/main/java/io/vertx/ext/web/proxy/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "vertx-web-proxy", groupPackage = "io.vertx")
+package io.vertx.ext.web.proxy;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-web-proxy/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-web-proxy/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Automatic-Module-Name: io.vertx.web.proxy

--- a/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/WebProxyTestBase.java
+++ b/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/WebProxyTestBase.java
@@ -1,0 +1,79 @@
+package io.vertx.ext.web.proxy;
+
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.WebTestBase;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class WebProxyTestBase extends WebTestBase {
+
+  protected HttpServer backendServer;
+  protected HttpClient proxyClient;
+  protected Router backendRouter;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    backendRouter = Router.router(vertx);
+    backendServer = vertx.createHttpServer(getBackendServerOptions());
+    proxyClient = vertx.createHttpClient(getProxyClientOptions());
+    CountDownLatch latch = new CountDownLatch(1);
+    backendServer.requestHandler(backendRouter).listen(onSuccess(res -> latch.countDown()));
+    awaitLatch(latch);
+  }
+
+  protected HttpServerOptions getBackendServerOptions() {
+    return new HttpServerOptions().setPort(1234).setHost("localhost");
+  }
+
+  protected HttpClientOptions getProxyClientOptions() {
+    return new HttpClientOptions();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    if (proxyClient != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      proxyClient.close((asyncResult) -> {
+        assertTrue(asyncResult.succeeded());
+        latch.countDown();
+      });
+      awaitLatch(latch);
+    }
+    if (client != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      client.close((asyncResult) -> {
+        assertTrue(asyncResult.succeeded());
+        latch.countDown();
+      });
+      awaitLatch(latch);
+    }
+    if (server != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      server.close((asyncResult) -> {
+        assertTrue(asyncResult.succeeded());
+        latch.countDown();
+      });
+      awaitLatch(latch);
+    }
+    if (backendServer != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      backendServer.close((asyncResult) -> {
+        assertTrue(asyncResult.succeeded());
+        latch.countDown();
+      });
+      awaitLatch(latch);
+    }
+    super.tearDown();
+  }
+
+}

--- a/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/handler/ProxyHandlerTest.java
+++ b/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/handler/ProxyHandlerTest.java
@@ -1,0 +1,39 @@
+package io.vertx.ext.web.proxy.handler;
+
+import io.vertx.core.http.HttpMethod;
+
+import io.vertx.ext.web.proxy.WebProxyTestBase;
+import io.vertx.httpproxy.HttpProxy;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class ProxyHandlerTest extends WebProxyTestBase {
+
+  @Test
+  public void testProxyHandler() throws Exception {
+    HttpProxy backend = HttpProxy.reverseProxy2(proxyClient);
+    backend.target(1234, "localhost");
+    router.route(HttpMethod.GET, "/path").handler(ProxyHandler.create(backend));
+    backendRouter.route(HttpMethod.GET, "/path").handler(rc -> {
+      rc.response().setStatusCode(200);
+      rc.response().setStatusMessage("statusMessage");
+      rc.response().end("data");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "statusMessage", "data");
+  }
+
+  @Test
+  public void testProxyHandlerWithPortHost() throws Exception {
+    HttpProxy backend1 = HttpProxy.reverseProxy2(proxyClient);
+    router.route(HttpMethod.GET, "/path").handler(ProxyHandler.create(backend1, 1234, "localhost"));
+    backendRouter.route(HttpMethod.GET, "/path").handler(rc -> {
+      rc.response().setStatusCode(200);
+      rc.response().setStatusMessage("statusMessage");
+      rc.response().end("data");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "statusMessage", "data");
+  }
+}


### PR DESCRIPTION
Signed-off-by: Emad Alblueshi <emad.albloushi@gmail.com>

Motivation:

Vert.x Web Proxy module provides a handler that handles reverse proxy logic using [Vert.x Http Proxy](https://github.com/eclipse-vertx/vertx-http-proxy).

The documentation is added and marked as _Tech Preview_

