### PR TITLE
mountPoint problems with hierarchical routers

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -62,7 +62,9 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
           this.mountPoint = mountPoint;
         } else
         // * otherwise it's extending the parent path
-        {
+        if (parentMountPoint.endsWith("/")) {
+          this.mountPoint = parentMountPoint.substring(0, parentMountPoint.length() - 1) + mountPoint;
+        } else {
           this.mountPoint = parentMountPoint + mountPoint;
         }
     }


### PR DESCRIPTION
When using a hierarchy of router handlers (min depth 3) with `handleContext`, routing fails because the `RoutingContextWrapper` instances end up with duplicate slashes in their `mountPoint`. The reason is that the `RoutingContextWrapper` no longer checks if the `parentMountPoint` ends with a `'/'` (like it did before Vert.x 4). This PR re-adds this check. Also see issue #1853 for details and a reproducer.