### PR TITLE
Web client create request phase

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientPhase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientPhase.java
@@ -26,6 +26,12 @@ public enum ClientPhase {
    * The {@link io.vertx.core.http.HttpClientRequest} has been created but not yet sent, the HTTP method, URI or request parameters
    * cannot be modified anymore.
    */
+  CREATE_REQUEST,
+
+  /**
+   * The {@link io.vertx.core.http.HttpClientRequest} has been created but not yet sent, the HTTP method, URI or request parameters
+   * cannot be modified anymore.
+   */
   SEND_REQUEST,
 
   /**

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -519,7 +519,6 @@ public class HttpContext<T> {
         multipartForm.headers().forEach(header -> {
           requestOptions.putHeader(header.getKey(), header.getValue());
         });
-        multipartForm.run();
       }
       if (body instanceof ReadStream<?>) {
         ReadStream<Buffer> stream = (ReadStream<Buffer>) body;
@@ -537,6 +536,9 @@ public class HttpContext<T> {
                 req.reset(0L, ar2.cause());
               }
             });
+            if (body instanceof MultipartFormUpload) {
+              ((MultipartFormUpload) body).run();
+            }
           } else {
             // Test this
             clientRequest = null;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -170,7 +170,7 @@ public class HttpContext<T> {
    * Prepare the HTTP request, this executes the {@link ClientPhase#PREPARE_REQUEST} phase:
    * <ul>
    *   <li>Traverse the interceptor chain</li>
-   *   <li>Execute the {@link ClientPhase#SEND_REQUEST} phase</li>
+   *   <li>Execute the {@link ClientPhase#CREATE_REQUEST} phase</li>
    * </ul>
    */
   public void prepareRequest(HttpRequest<T> request, String contentType, Object body) {
@@ -181,15 +181,26 @@ public class HttpContext<T> {
   }
 
   /**
+   * Create the HTTP request, this executes the {@link ClientPhase#CREATE_REQUEST} phase:
+   * <ul>
+   *   <li>Traverse the interceptor chain</li>
+   *   <li>Create the {@link HttpClientRequest}</li>
+   * </ul>
+   */
+  public void createRequest(RequestOptions requestOptions) {
+    this.requestOptions = requestOptions;
+    fire(ClientPhase.CREATE_REQUEST);
+  }
+
+  /**
    * Send the HTTP request, this executes the {@link ClientPhase#SEND_REQUEST} phase:
    * <ul>
-   *   <li>Create the {@link HttpClientRequest}</li>
    *   <li>Traverse the interceptor chain</li>
    *   <li>Send the actual request</li>
    * </ul>
    */
-  public void sendRequest(RequestOptions requestOptions) {
-    this.requestOptions = requestOptions;
+  public void sendRequest() {
+    // this.clientRequest = clientRequest;
     fire(ClientPhase.SEND_REQUEST);
   }
 
@@ -201,7 +212,7 @@ public class HttpContext<T> {
    * </ul>
    */
   public void followRedirect() {
-    fire(ClientPhase.SEND_REQUEST);
+    fire(ClientPhase.CREATE_REQUEST);
   }
 
   /**
@@ -328,6 +339,9 @@ public class HttpContext<T> {
       case PREPARE_REQUEST:
         handlePrepareRequest();
         break;
+      case CREATE_REQUEST:
+        handleCreateRequest();
+        break;
       case SEND_REQUEST:
         handleSendRequest();
         break;
@@ -401,7 +415,11 @@ public class HttpContext<T> {
       }
       options.setHost(request.virtualHost);
     }
-    sendRequest(options);
+    createRequest(options);
+  }
+
+  private void handleCreateRequest() {
+    sendRequest();
   }
 
   private void handleReceiveResponse() {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -58,6 +58,7 @@ public class HttpContext<T> {
   private RequestOptions requestOptions;
   private HttpClientRequest clientRequest;
   private HttpClientResponse clientResponse;
+  private Promise<HttpClientRequest> requestPromise;
   private HttpResponse<T> response;
   private Throwable failure;
   private int redirects;
@@ -419,6 +420,97 @@ public class HttpContext<T> {
   }
 
   private void handleCreateRequest() {
+    if (request.headers != null) {
+      MultiMap headers = requestOptions.getHeaders();
+      if (headers == null) {
+        headers = MultiMap.caseInsensitiveMultiMap();
+        requestOptions.setHeaders(headers);
+      }
+      headers.addAll(request.headers);
+    }
+    if (contentType != null) {
+      String prev = requestOptions.getHeaders().get(HttpHeaders.CONTENT_TYPE);
+      if (prev == null) {
+        requestOptions.addHeader(HttpHeaders.CONTENT_TYPE, contentType);
+      } else {
+        contentType = prev;
+      }
+    }
+    requestOptions.setTimeout(this.request.timeout);
+    requestPromise = Promise.promise();
+    if (body != null || "application/json".equals(contentType)) {
+      if (body instanceof MultiMap) {
+        MultipartForm parts = MultipartForm.create();
+        MultiMap attributes = (MultiMap) body;
+        for (Map.Entry<String, String> attribute : attributes) {
+          parts.attribute(attribute.getKey(), attribute.getValue());
+        }
+        body = parts;
+      }
+      if (body instanceof MultipartForm) {
+        MultipartFormUpload multipartForm;
+        try {
+          boolean multipart = "multipart/form-data".equals(contentType);
+          HttpPostRequestEncoder.EncoderMode encoderMode = this.request.multipartMixed ? HttpPostRequestEncoder.EncoderMode.RFC1738 : HttpPostRequestEncoder.EncoderMode.HTML5;
+          multipartForm = new MultipartFormUpload(context,  (MultipartForm) this.body, multipart, encoderMode);
+          this.body = multipartForm;
+        } catch (Exception e) {
+          fail(e);
+          return;
+        }
+        for (String headerName : this.request.headers().names()) {
+          requestOptions.putHeader(headerName, this.request.headers().get(headerName));
+        }
+        multipartForm.headers().forEach(header -> {
+          requestOptions.putHeader(header.getKey(), header.getValue());
+        });
+      }
+      if (body instanceof ReadStream<?>) {
+        ReadStream<Buffer> stream = (ReadStream<Buffer>) body;
+        Pipe<Buffer> pipe = stream.pipe(); // Shouldn't this be called in an earlier phase ?
+        requestPromise.future().onComplete(ar -> {
+          if (ar.succeeded()) {
+            HttpClientRequest req = ar.result();
+            if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
+              req.setChunked(true);
+            }
+            pipe.endOnFailure(false);
+            pipe.to(req, ar2 -> {
+              clientRequest = null;
+              if (ar2.failed()) {
+                req.reset(0L, ar2.cause());
+              }
+            });
+            if (body instanceof MultipartFormUpload) {
+              ((MultipartFormUpload) body).run();
+            }
+          } else {
+            // Test this
+            clientRequest = null;
+            pipe.close();
+          }
+        });
+      } else {
+        Buffer buffer;
+        if (body instanceof Buffer) {
+          buffer = (Buffer) body;
+        } else if (body instanceof JsonObject) {
+          buffer = Buffer.buffer(((JsonObject)body).encode());
+        } else {
+          buffer = Buffer.buffer(Json.encode(body));
+        }
+        requestPromise.future().onSuccess(request -> {
+          clientRequest = null;
+          request.putHeader(HttpHeaders.CONTENT_LENGTH, "" + buffer.length());
+          request.end(buffer);
+        });
+      }
+    } else {
+      requestPromise.future().onSuccess(request -> {
+        clientRequest = null;
+        request.end();
+      });
+    }
     sendRequest();
   }
 
@@ -475,103 +567,6 @@ public class HttpContext<T> {
   }
 
   private void handleSendRequest() {
-    if (request.headers != null) {
-      MultiMap headers = requestOptions.getHeaders();
-      if (headers == null) {
-        headers = MultiMap.caseInsensitiveMultiMap();
-        requestOptions.setHeaders(headers);
-      }
-      headers.addAll(request.headers);
-    }
-    if (contentType != null) {
-      String prev = requestOptions.getHeaders().get(HttpHeaders.CONTENT_TYPE);
-      if (prev == null) {
-        requestOptions.addHeader(HttpHeaders.CONTENT_TYPE, contentType);
-      } else {
-        contentType = prev;
-      }
-    }
-    requestOptions.setTimeout(this.request.timeout);
-    Handler<AsyncResult<HttpClientRequest>> continuation;
-    if (body != null || "application/json".equals(contentType)) {
-      if (body instanceof MultiMap) {
-        MultipartForm parts = MultipartForm.create();
-        MultiMap attributes = (MultiMap) body;
-        for (Map.Entry<String, String> attribute : attributes) {
-          parts.attribute(attribute.getKey(), attribute.getValue());
-        }
-        body = parts;
-      }
-      if (body instanceof MultipartForm) {
-        MultipartFormUpload multipartForm;
-        try {
-          boolean multipart = "multipart/form-data".equals(contentType);
-          HttpPostRequestEncoder.EncoderMode encoderMode = this.request.multipartMixed ? HttpPostRequestEncoder.EncoderMode.RFC1738 : HttpPostRequestEncoder.EncoderMode.HTML5;
-          multipartForm = new MultipartFormUpload(context,  (MultipartForm) this.body, multipart, encoderMode);
-          this.body = multipartForm;
-        } catch (Exception e) {
-          fail(e);
-          return;
-        }
-        for (String headerName : this.request.headers().names()) {
-          requestOptions.putHeader(headerName, this.request.headers().get(headerName));
-        }
-        multipartForm.headers().forEach(header -> {
-          requestOptions.putHeader(header.getKey(), header.getValue());
-        });
-      }
-      if (body instanceof ReadStream<?>) {
-        ReadStream<Buffer> stream = (ReadStream<Buffer>) body;
-        Pipe<Buffer> pipe = stream.pipe(); // Shouldn't this be called in an earlier phase ?
-        continuation = ar -> {
-          if (ar.succeeded()) {
-            HttpClientRequest req = ar.result();
-            if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
-              req.setChunked(true);
-            }
-            pipe.endOnFailure(false);
-            pipe.to(req, ar2 -> {
-              clientRequest = null;
-              if (ar2.failed()) {
-                req.reset(0L, ar2.cause());
-              }
-            });
-            if (body instanceof MultipartFormUpload) {
-              ((MultipartFormUpload) body).run();
-            }
-          } else {
-            // Test this
-            clientRequest = null;
-            pipe.close();
-          }
-        };
-      } else {
-        Buffer buffer;
-        if (body instanceof Buffer) {
-          buffer = (Buffer) body;
-        } else if (body instanceof JsonObject) {
-          buffer = Buffer.buffer(((JsonObject)body).encode());
-        } else {
-          buffer = Buffer.buffer(Json.encode(body));
-        }
-        continuation = ar -> {
-          if (ar.succeeded()) {
-            clientRequest = null;
-            HttpClientRequest req = ar.result();
-            req.putHeader(HttpHeaders.CONTENT_LENGTH, "" + buffer.length());
-            req.end(buffer);
-          }
-        };
-      }
-    } else {
-      continuation = ar -> {
-        if (ar.succeeded()) {
-          clientRequest = null;
-          HttpClientRequest req = ar.result();
-          req.end();
-        }
-      };
-    }
     Future<HttpClientRequest> f = client.request(requestOptions);
     f.onComplete(ar1 -> {
       if (ar1.succeeded()) {
@@ -589,7 +584,7 @@ public class HttpContext<T> {
       } else {
         fail(ar1.cause());
       }
-      continuation.handle(ar1);
+      requestPromise.handle(ar1);
     });
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -499,9 +499,9 @@ public class HttpContext<T> {
         } else {
           buffer = Buffer.buffer(Json.encode(body));
         }
+        requestOptions.putHeader(HttpHeaders.CONTENT_LENGTH, "" + buffer.length());
         requestPromise.future().onSuccess(request -> {
           clientRequest = null;
-          request.putHeader(HttpHeaders.CONTENT_LENGTH, "" + buffer.length());
           request.end(buffer);
         });
       }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/MultipartFormUpload.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/MultipartFormUpload.java
@@ -123,10 +123,7 @@ public class MultipartFormUpload implements ReadStream<Buffer> {
 
   public void run() {
     if (Vertx.currentContext() != context) {
-      context.runOnContext(v -> {
-        run();
-      });
-      return;
+      throw new IllegalArgumentException();
     }
     while (!ended) {
       if (encoder.isChunked()) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
@@ -157,6 +157,7 @@ public class InterceptorTest extends HttpTestBase {
     builder.send(onSuccess(resp -> {
       assertEquals(Arrays.asList(
         "PREPARE_REQUEST_1", "PREPARE_REQUEST_2",
+        "CREATE_REQUEST_1", "CREATE_REQUEST_2",
         "SEND_REQUEST_1", "SEND_REQUEST_2",
         "RECEIVE_RESPONSE_1", "RECEIVE_RESPONSE_2",
         "DISPATCH_RESPONSE_1", "DISPATCH_RESPONSE_2"), events);
@@ -169,7 +170,7 @@ public class InterceptorTest extends HttpTestBase {
   public void testPhasesThreadFromNonVertxThread() throws Exception {
     server.requestHandler(req -> req.response().end());
     startServer();
-    testPhasesThread((t1, t2) -> Arrays.asList(t1, t1, t2, t2));
+    testPhasesThread((t1, t2) -> Arrays.asList(t1, t1, t1, t2, t2));
     await();
   }
 
@@ -180,7 +181,7 @@ public class InterceptorTest extends HttpTestBase {
     startServer();
     vertx.getOrCreateContext().runOnContext(v -> {
       setUpClient();
-      testPhasesThread((t1, t2) -> Arrays.asList(t2, t2, t2, t2));
+      testPhasesThread((t1, t2) -> Arrays.asList(t2, t2, t2, t2, t2));
     });
     await();
   }
@@ -359,8 +360,10 @@ public class InterceptorTest extends HttpTestBase {
       assertEquals(200, resp.statusCode());
       assertEquals(Arrays.asList(
         ClientPhase.PREPARE_REQUEST,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.RECEIVE_RESPONSE,
         ClientPhase.DISPATCH_RESPONSE), phases);
@@ -388,38 +391,55 @@ public class InterceptorTest extends HttpTestBase {
       assertEquals(302, resp.statusCode());
       assertEquals(Arrays.asList(
         ClientPhase.PREPARE_REQUEST,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.FOLLOW_REDIRECT,
+        ClientPhase.CREATE_REQUEST,
         ClientPhase.SEND_REQUEST,
         ClientPhase.RECEIVE_RESPONSE,
         ClientPhase.DISPATCH_RESPONSE

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/MultipartFormUploadTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/MultipartFormUploadTest.java
@@ -63,14 +63,15 @@ public class MultipartFormUploadTest {
   public void testSimpleAttribute(TestContext ctx) throws Exception {
     Async async = ctx.async();
     Buffer result = Buffer.buffer();
-    MultipartFormUpload upload = new MultipartFormUpload(vertx.getOrCreateContext(), MultipartForm.create().attribute("foo", "bar"), false, HttpPostRequestEncoder.EncoderMode.RFC1738);
-    upload.run();
+    Context context = vertx.getOrCreateContext();
+    MultipartFormUpload upload = new MultipartFormUpload(context, MultipartForm.create().attribute("foo", "bar"), false, HttpPostRequestEncoder.EncoderMode.RFC1738);
     upload.endHandler(v -> {
       assertEquals("foo=bar", result.toString());
       async.complete();
     });
     upload.handler(result::appendBuffer);
     upload.resume();
+    context.runOnContext(v -> upload.run());
   }
 
   @Test


### PR DESCRIPTION
Add a new web client _CREATE_REQUEST_ phase between _PREPARE_REQUEST_  and _SEND_REQUEST_.

- `sendRequest` takes now an `HttpClientRequest` as argument instead of `RequestOptions`
- a new `createRequest` method takes `RequestOptions` as argument, triggers the interceptor chain and call `handlePrepareRequest`
- `handleCreateRequest` is created from the portion of `handleSendRequest` that was preparing the request options and body before sending the request. This method uses the HTTP client to create the request and then calls `sendRequest`
- `handlePrepareRequest` now calls `createRequest` instead of `sendRequest`

fixes #1855
fixes #1851
