### PR TITLE
Attach an error to a context failure to give better context

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Session.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Session.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -43,7 +43,7 @@ import io.vertx.ext.web.impl.RoutingContextInternal;
  */
 public class BodyHandlerImpl implements BodyHandler {
 
-  private static final Logger log = LoggerFactory.getLogger(BodyHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BodyHandlerImpl.class);
 
   private long bodyLimit = DEFAULT_BODY_LIMIT;
   private boolean handleFileUploads;
@@ -324,7 +324,7 @@ public class BodyHandlerImpl implements BodyHandler {
             String uploadedFileName = fileUpload.uploadedFileName();
             fileSystem.delete(uploadedFileName, deleteResult -> {
               if (deleteResult.failed()) {
-                log.warn("Delete of uploaded file failed: " + uploadedFileName, deleteResult.cause());
+                LOG.warn("Delete of uploaded file failed: " + uploadedFileName, deleteResult.cause());
               }
             });
           }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -209,7 +209,7 @@ public class CorsHandlerImpl implements CorsHandler {
         .response()
         .setStatusMessage("CORS Rejected - Invalid origin");
       context
-        .fail(403);
+        .fail(403, new IllegalStateException("CORS Rejected - Invalid origin"));
     }
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
@@ -37,7 +37,7 @@ import java.util.Objects;
  */
 public class ErrorHandlerImpl implements ErrorHandler {
 
-  private final Logger log = LoggerFactory.getLogger(ErrorHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ErrorHandlerImpl.class);
 
   /**
    * Flag to enable/disable printing the full stack trace of exceptions.
@@ -67,8 +67,8 @@ public class ErrorHandlerImpl implements ErrorHandler {
     if (response.headWritten()) {
       // response is already being processed, so we can't really
       // format the error as a "pretty print" message
-      if (log.isDebugEnabled()) {
-        log.debug("Unexpected error on route", failure);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Unexpected error on route", failure);
       }
 
       try {
@@ -156,7 +156,7 @@ public class ErrorHandlerImpl implements ErrorHandler {
         errorTemplate
           .replace("{title}", title)
           .replace("{errorCode}", Integer.toString(errorCode))
-          .replace("{errorMessage}", errorMessage)
+          .replace("{errorMessage}", htmlFormat(errorMessage))
           .replace("{stackTrace}", stack.toString())
       );
       return true;
@@ -194,5 +194,36 @@ public class ErrorHandlerImpl implements ErrorHandler {
     }
 
     return false;
+  }
+
+  /**
+   * Very incomplete html escape that will escape the most common characters on error messages.
+   * This is to avoid pulling a full dependency to perform a compliant escape. Error messages
+   * are created by developers as such that they should not be to complex for logging.
+   */
+  private static String escapeHTML(String s) {
+    StringBuilder out = new StringBuilder(Math.max(16, s.length()));
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c > 127 || c == '"' || c == '\'' || c == '<' || c == '>' || c == '&') {
+        out.append("&#");
+        out.append((int) c);
+        out.append(';');
+      } else {
+        out.append(c);
+      }
+    }
+    return out.toString();
+  }
+
+  private static String htmlFormat(String errorMessage) {
+    if (errorMessage == null) {
+      return null;
+    }
+
+    // step #1 (escape html entities)
+    String escaped = escapeHTML(errorMessage);
+    // step #2 (replace line endings with breaks)
+    return escaped.replaceAll("\\r?\\n", "<br>");
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FaviconHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FaviconHandlerImpl.java
@@ -35,7 +35,7 @@ import static io.vertx.core.http.HttpHeaders.*;
  */
 public class FaviconHandlerImpl implements FaviconHandler {
 
-  private static final Logger logger = LoggerFactory.getLogger(FaviconHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FaviconHandler.class);
 
   // default framework branding
   private static final String DEFAULT_VERTX_ICON = "META-INF/vertx/web/favicon.ico";
@@ -128,7 +128,7 @@ public class FaviconHandlerImpl implements FaviconHandler {
       try {
         buffer = readFile(fs, path);
       } catch (RuntimeException e) {
-        logger.error("Could not load favicon " + path);
+        LOG.error("Could not load favicon " + path);
         // this will ensure the response is a 404 (Not Found)
       }
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
@@ -24,7 +24,6 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
@@ -83,7 +82,7 @@ public class FormLoginHandlerImpl extends AuthenticationHandlerImpl<Authenticati
       handler.handle(Future.failedFuture(BAD_METHOD)); // Must be a POST
     } else {
       if (!((RoutingContextInternal) context).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
-        handler.handle(Future.failedFuture(new NoStackTraceThrowable("BodyHandler is required to process POST requests")));
+        handler.handle(Future.failedFuture("BodyHandler is required to process POST requests"));
       } else {
         MultiMap params = req.formAttributes();
         String username = params.get(usernameParam);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
  */
 public class LoggerHandlerImpl implements LoggerHandler {
 
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private static final Logger LOG = LoggerFactory.getLogger(LoggerHandlerImpl.class);
 
   /** log before request or after
    */
@@ -157,11 +157,11 @@ public class LoggerHandlerImpl implements LoggerHandler {
 
   protected void doLog(int status, String message) {
     if (status >= 500) {
-      logger.error(message);
+      LOG.error(message);
     } else if (status >= 400) {
-      logger.warn(message);
+      LOG.warn(message);
     } else {
-      logger.info(message);
+      LOG.info(message);
     }
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -42,7 +42,7 @@ public class SessionHandlerImpl implements SessionHandler {
   private static final String SESSION_FLUSHED_KEY = "__vertx.session-flushed";
   private static final String SESSION_STOREUSER_KEY = "__vertx.session-storeuser";
 
-  private static final Logger log = LoggerFactory.getLogger(SessionHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SessionHandlerImpl.class);
 
   private final SessionStore sessionStore;
 
@@ -272,10 +272,10 @@ public class SessionHandlerImpl implements SessionHandler {
   @Override
   public void handle(RoutingContext context) {
     HttpServerRequest request = context.request();
-    if (nagHttps && log.isDebugEnabled()) {
+    if (nagHttps && LOG.isDebugEnabled()) {
       String uri = request.absoluteURI();
       if (!uri.startsWith("https:")) {
-        log.debug(
+        LOG.debug(
           "Using session cookies without https could make you susceptible to session hijacking: " + uri);
       }
     }
@@ -398,7 +398,7 @@ public class SessionHandlerImpl implements SessionHandler {
       if (flushed == null || !flushed) {
         flush(context, true, flush -> {
           if (flush.failed()) {
-            log.warn("Failed to flush the session to the underlying store", flush.cause());
+            LOG.warn("Failed to flush the session to the underlying store", flush.cause());
           }
         });
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -50,7 +50,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.*;
  */
 public class StaticHandlerImpl implements StaticHandler {
 
-  private static final Logger log = LoggerFactory.getLogger(StaticHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StaticHandlerImpl.class);
 
   private String webRoot = DEFAULT_WEB_ROOT;
   private long maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS; // One day
@@ -71,7 +71,6 @@ public class StaticHandlerImpl implements StaticHandler {
 
   private final FSTune tune = new FSTune();
   private final FSPropsCache cache = new FSPropsCache();
-  private FileSystem fileSystem;
 
   private String directoryTemplate(FileSystem fileSystem) {
     if (directoryTemplate == null) {
@@ -111,14 +110,14 @@ public class StaticHandlerImpl implements StaticHandler {
   public void handle(RoutingContext context) {
     HttpServerRequest request = context.request();
     if (request.method() != HttpMethod.GET && request.method() != HttpMethod.HEAD) {
-      if (log.isTraceEnabled()) log.trace("Not GET or HEAD so ignoring request");
+      if (LOG.isTraceEnabled()) LOG.trace("Not GET or HEAD so ignoring request");
       context.next();
     } else {
       // decode URL path
       String uriDecodedPath = URIDecoder.decodeURIComponent(context.normalizedPath(), false);
       // if the normalized path is null it cannot be resolved
       if (uriDecodedPath == null) {
-        log.warn("Invalid path: " + context.request().path());
+        LOG.warn("Invalid path: " + context.request().path());
         context.next();
         return;
       }
@@ -131,7 +130,7 @@ public class StaticHandlerImpl implements StaticHandler {
       }
 
       // Access fileSystem once here to be safe
-      FileSystem fs = fileSystem = context.vertx().fileSystem();
+      FileSystem fs = context.vertx().fileSystem();
 
       // can be called recursive for index pages
       sendStatic(context, fs, path);
@@ -571,7 +570,9 @@ public class StaticHandlerImpl implements StaticHandler {
 
   private String getFile(String path, RoutingContext context) {
     String file = webRoot + Utils.pathOffset(path, context);
-    if (log.isTraceEnabled()) log.trace("File to serve is " + file);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("File to serve is " + file);
+    }
     return file;
   }
 
@@ -759,7 +760,9 @@ public class StaticHandlerImpl implements StaticHandler {
         double avg = (double) totalTime / numServesBlocking;
         if (avg > maxAvgServeTimeNanoSeconds) {
           useAsyncFS = true;
-          log.info("Switching to async file system access in static file server as fs access is slow! (Average access time of " + avg + " ns)");
+          if (LOG.isInfoEnabled()) {
+            LOG.info("Switching to async file system access in static file server as fs access is slow! (Average access time of " + avg + " ns)");
+          }
           enabled = false;
         }
         nextAvgCheck += NUM_SERVES_TUNING_FS_ACCESS;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
@@ -64,7 +64,7 @@ import static io.vertx.core.http.HttpHeaders.*;
  */
 class BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(BaseTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BaseTransport.class);
 
   protected final Vertx vertx;
   protected final LocalMap<String, SockJSSession> sessions;
@@ -85,7 +85,9 @@ class BaseTransport {
   }
 
   protected void sendInvalidJSON(HttpServerResponse response) {
-    if (log.isTraceEnabled()) log.trace("Broken JSON");
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Broken JSON");
+    }
     response.setStatusCode(500);
     response.end("Broken JSON encoding.");
   }
@@ -94,7 +96,7 @@ class BaseTransport {
     try {
        str = StringEscapeUtils.escapeJavaScript(str);
     } catch (Exception e) {
-      log.error("Failed to escape", e);
+      LOG.error("Failed to escape", e);
       str = null;
     }
     return str;
@@ -111,7 +113,9 @@ class BaseTransport {
     }
     protected void addCloseHandler(HttpServerResponse resp, final SockJSSession session) {
       resp.closeHandler(v -> {
-          if (log.isTraceEnabled()) log.trace("Connection closed (from client?), closing session");
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Connection closed (from client?), closing session");
+          }
           // Connection has been closed from the client or network error so
           // we remove the session
           session.shutdown();
@@ -175,7 +179,9 @@ class BaseTransport {
     return new Handler<RoutingContext>() {
       final boolean websocket = !options.getDisabledTransports().contains(Transport.WEBSOCKET.toString());
       public void handle(RoutingContext rc) {
-        if (log.isTraceEnabled()) log.trace("In Info handler");
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("In Info handler");
+        }
         rc.response().putHeader(CONTENT_TYPE, "application/json; charset=UTF-8");
         setNoCacheHeaders(rc);
         JsonObject json = new JsonObject();
@@ -197,7 +203,9 @@ class BaseTransport {
 
   static Handler<RoutingContext> createCORSOptionsHandler(SockJSHandlerOptions options, String methods) {
     return rc -> {
-      if (log.isTraceEnabled()) log.trace("In CORS options handler");
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("In CORS options handler");
+      }
       rc.response().putHeader(CACHE_CONTROL, "public,max-age=31536000");
       long oneYearSeconds = 365 * 24 * 60 * 60;
       long oneYearms = oneYearSeconds * 1000;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventSourceTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventSourceTransport.java
@@ -54,7 +54,7 @@ import static io.vertx.core.buffer.Buffer.buffer;
  */
 class EventSourceTransport extends BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(EventSourceTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(EventSourceTransport.class);
 
   EventSourceTransport(Vertx vertx, Router router, LocalMap<String, SockJSSession> sessions, SockJSHandlerOptions options,
                        Handler<SockJSSocket> sockHandler) {
@@ -63,7 +63,7 @@ class EventSourceTransport extends BaseTransport {
     String eventSourceRE = COMMON_PATH_ELEMENT_RE + "eventsource";
 
     router.getWithRegex(eventSourceRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("EventSource transport, get: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("EventSource transport, get: " + rc.request().uri());
       String sessionID = rc.request().getParam("param0");
       SockJSSession session = getSession(rc, options, sessionID, sockHandler);
       HttpServerRequest req = rc.request();
@@ -86,7 +86,7 @@ class EventSourceTransport extends BaseTransport {
 
     @Override
     public void sendFrame(String body, Handler<AsyncResult<Void>> handler) {
-      if (log.isTraceEnabled()) log.trace("EventSource, sending frame");
+      if (LOG.isTraceEnabled()) LOG.trace("EventSource, sending frame");
       if (!headersWritten) {
         // event stream data is always UTF8
         // https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format
@@ -104,7 +104,7 @@ class EventSourceTransport extends BaseTransport {
       rc.response().write(buff, handler);
       bytesSent += buff.length();
       if (bytesSent >= maxBytesStreaming) {
-        if (log.isTraceEnabled()) log.trace("More than maxBytes sent so closing connection");
+        if (LOG.isTraceEnabled()) LOG.trace("More than maxBytes sent so closing connection");
         // Reset and close the connection
         close();
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/HtmlFileTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/HtmlFileTransport.java
@@ -56,7 +56,7 @@ import static io.vertx.core.buffer.Buffer.buffer;
  */
 class HtmlFileTransport extends BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(HtmlFileTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HtmlFileTransport.class);
 
   private static final Pattern CALLBACK_VALIDATION = Pattern.compile("[^a-zA-Z0-9-_.]");
 
@@ -93,7 +93,7 @@ class HtmlFileTransport extends BaseTransport {
     String htmlFileRE = COMMON_PATH_ELEMENT_RE + "htmlfile.*";
 
     router.getWithRegex(htmlFileRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("HtmlFile, get: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("HtmlFile, get: " + rc.request().uri());
       String callback = rc.request().getParam("callback");
       if (callback == null) {
         callback = rc.request().getParam("c");
@@ -133,7 +133,7 @@ class HtmlFileTransport extends BaseTransport {
 
     @Override
     public void sendFrame(String body, Handler<AsyncResult<Void>> handler) {
-      if (log.isTraceEnabled()) log.trace("HtmlFile, sending frame");
+      if (LOG.isTraceEnabled()) LOG.trace("HtmlFile, sending frame");
       if (!headersWritten) {
         String htmlFile = HTML_FILE_TEMPLATE.replace("{{ callback }}", callback);
         rc.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
@@ -151,7 +151,7 @@ class HtmlFileTransport extends BaseTransport {
       rc.response().write(buff, handler);
       bytesSent += buff.length();
       if (bytesSent >= maxBytesStreaming) {
-        if (log.isTraceEnabled()) log.trace("More than maxBytes sent so closing connection");
+        if (LOG.isTraceEnabled()) LOG.trace("More than maxBytes sent so closing connection");
         // Reset and close the connection
         close();
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/JsonPTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/JsonPTransport.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
  */
 class JsonPTransport extends BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(JsonPTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JsonPTransport.class);
 
   private static final Pattern CALLBACK_VALIDATION = Pattern.compile("[^a-zA-Z0-9-_.]");
 
@@ -65,7 +65,7 @@ class JsonPTransport extends BaseTransport {
     String jsonpRE = COMMON_PATH_ELEMENT_RE + "jsonp";
 
     router.getWithRegex(jsonpRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("JsonP, get: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("JsonP, get: " + rc.request().uri());
       String callback = rc.request().getParam("callback");
       if (callback == null) {
         callback = rc.request().getParam("c");
@@ -92,7 +92,7 @@ class JsonPTransport extends BaseTransport {
     String jsonpSendRE = COMMON_PATH_ELEMENT_RE + "jsonp_send";
 
     router.postWithRegex(jsonpSendRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("JsonP, post: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("JsonP, post: " + rc.request().uri());
       String sessionID = rc.request().getParam("param0");
       final SockJSSession session = sessions.get(sessionID);
       if (session != null && !session.isClosed()) {
@@ -137,7 +137,7 @@ class JsonPTransport extends BaseTransport {
         rc.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
         setNoCacheHeaders(rc);
         rc.response().end("ok");
-        if (log.isTraceEnabled()) log.trace("send handled ok");
+        if (LOG.isTraceEnabled()) LOG.trace("send handled ok");
       }
     });
   }
@@ -156,7 +156,7 @@ class JsonPTransport extends BaseTransport {
 
     @Override
     public void sendFrame(String body, Handler<AsyncResult<Void>> handler) {
-      if (log.isTraceEnabled()) log.trace("JsonP, sending frame");
+      if (LOG.isTraceEnabled()) LOG.trace("JsonP, sending frame");
 
       if (!headersWritten) {
         rc.response()

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -59,7 +59,7 @@ import static io.vertx.core.buffer.Buffer.buffer;
  */
 public class SockJSHandlerImpl implements SockJSHandler {
 
-  private static final Logger log = LoggerFactory.getLogger(SockJSHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SockJSHandlerImpl.class);
 
   private final Vertx vertx;
   private final Router router;
@@ -77,8 +77,8 @@ public class SockJSHandlerImpl implements SockJSHandler {
   @Override
   @Deprecated
   public void handle(RoutingContext context) {
-    if (log.isTraceEnabled()) {
-      log.trace("Got request in sockjs server: " + context.request().uri());
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Got request in sockjs server: " + context.request().uri());
     }
     router.handleContext(context);
   }
@@ -91,7 +91,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
   @Override
   public Router socketHandler(Handler<SockJSSocket> sockHandler) {
     router.route("/").useNormalizedPath(false).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("Returning welcome response");
+      if (LOG.isTraceEnabled()) LOG.trace("Returning welcome response");
       rc.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8").end("Welcome to SockJS!\n");
     });
 
@@ -216,7 +216,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
     String etag = getMD5String(iframeHTML);
     return rc -> {
       try {
-        if (log.isTraceEnabled()) log.trace("In Iframe handler");
+        if (LOG.isTraceEnabled()) LOG.trace("In Iframe handler");
         if (etag != null && etag.equals(rc.request().getHeader(HttpHeaders.IF_NONE_MATCH))) {
           rc.response().setStatusCode(304);
           rc.response().end();
@@ -231,7 +231,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
             .end(iframeHTML);
         }
       } catch (Exception e) {
-        log.error("Failed to server iframe", e);
+        LOG.error("Failed to server iframe", e);
       }
     };
   }
@@ -247,7 +247,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
         return sb.toString();
     }
     catch (Exception e) {
-        log.error("Failed to generate MD5 for iframe, If-None-Match headers will be ignored");
+        LOG.error("Failed to generate MD5 for iframe, If-None-Match headers will be ignored");
         return null;
     }
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSession.java
@@ -65,7 +65,7 @@ import static io.vertx.core.buffer.Buffer.buffer;
  */
 class SockJSSession extends SockJSSocketBase implements Shareable {
 
-  private static final Logger log = LoggerFactory.getLogger(SockJSSession.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SockJSSession.class);
 
   private final LocalMap<String, SockJSSession> sessions;
   private final Deque<String> pendingWrites = new LinkedList<>();
@@ -407,7 +407,7 @@ class SockJSSession extends SockJSSocketBase implements Shareable {
         context.runOnContext(v -> handleException(t));
       }
     } else {
-      log.error("Unhandled exception", t);
+      LOG.error("Unhandled exception", t);
     }
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -53,7 +53,7 @@ import io.vertx.ext.web.handler.sockjs.SockJSSocket;
  */
 class WebSocketTransport extends BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(WebSocketTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(WebSocketTransport.class);
 
   WebSocketTransport(Vertx vertx,
                      Router router, LocalMap<String, SockJSSession> sessions,
@@ -79,8 +79,8 @@ class WebSocketTransport extends BaseTransport {
         // upgrade
         req.toWebSocket(toWebSocket -> {
           if (toWebSocket.succeeded()) {
-            if (log.isTraceEnabled()) {
-              log.trace("WS, handler");
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("WS, handler");
             }
             // resume the parsing
             if (!parseEnded) {
@@ -98,13 +98,13 @@ class WebSocketTransport extends BaseTransport {
     });
 
     router.getWithRegex(wsRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("WS, get: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("WS, get: " + rc.request().uri());
       rc.response().setStatusCode(400);
       rc.response().end("Can \"Upgrade\" only to \"WebSocket\".");
     });
 
     router.routeWithRegex(wsRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("WS, all: " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("WS, all: " + rc.request().uri());
       rc.response().putHeader(HttpHeaders.ALLOW, "GET").setStatusCode(405).end();
     });
   }
@@ -146,7 +146,7 @@ class WebSocketTransport extends BaseTransport {
 
     @Override
     public void sendFrame(String body, Handler<AsyncResult<Void>> handler) {
-      if (log.isTraceEnabled()) log.trace("WS, sending frame");
+      if (LOG.isTraceEnabled()) LOG.trace("WS, sending frame");
       if (!closed) {
         ws.writeTextMessage(body, handler);
       } else {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
@@ -58,7 +58,7 @@ import static io.vertx.core.buffer.Buffer.buffer;
  */
 class XhrTransport extends BaseTransport {
 
-  private static final Logger log = LoggerFactory.getLogger(XhrTransport.class);
+  private static final Logger LOG = LoggerFactory.getLogger(XhrTransport.class);
 
   private static final Buffer H_BLOCK;
 
@@ -91,7 +91,7 @@ class XhrTransport extends BaseTransport {
     router.optionsWithRegex(xhrSendRE).handler(xhrOptionsHandler);
 
     router.postWithRegex(xhrSendRE).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("XHR send, post, " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("XHR send, post, " + rc.request().uri());
       String sessionID = rc.request().getParam("param0");
       final SockJSSession session = sessions.get(sessionID);
       if (session != null && !session.isClosed()) {
@@ -107,7 +107,7 @@ class XhrTransport extends BaseTransport {
   private void registerHandler(Router router, Handler<SockJSSocket> sockHandler, String re,
                                boolean streaming, SockJSHandlerOptions options) {
     router.postWithRegex(re).handler(rc -> {
-      if (log.isTraceEnabled()) log.trace("XHR, post, " + rc.request().uri());
+      if (LOG.isTraceEnabled()) LOG.trace("XHR, post, " + rc.request().uri());
       setNoCacheHeaders(rc);
       String sessionID = rc.request().getParam("param0");
       SockJSSession session = getSession(rc, options, sessionID, sockHandler);
@@ -121,7 +121,7 @@ class XhrTransport extends BaseTransport {
     if (body != null) {
       handleSendMessage(rc, session, body);
     } else if (rc.request().isEnded()) {
-      log.error("Request ended before SockJS handler could read the body. Do you have an asynchronous request "
+      LOG.error("Request ended before SockJS handler could read the body. Do you have an asynchronous request "
           + "handler before the SockJS handler? If so, add a BodyHandler before the SockJS handler "
           + "(see the docs).");
       rc.fail(500);
@@ -147,7 +147,7 @@ class XhrTransport extends BaseTransport {
       rc.response().setStatusCode(204);
       rc.response().end();
     }
-    if (log.isTraceEnabled()) log.trace("XHR send processed ok");
+    if (LOG.isTraceEnabled()) LOG.trace("XHR send processed ok");
   }
 
   private abstract class BaseXhrListener extends BaseListener {
@@ -159,7 +159,7 @@ class XhrTransport extends BaseTransport {
     }
 
     final void beforeSend() {
-      if (log.isTraceEnabled()) log.trace("XHR sending frame");
+      if (LOG.isTraceEnabled()) LOG.trace("XHR sending frame");
       if (!headersWritten) {
         HttpServerResponse resp = rc.response();
         resp.putHeader(HttpHeaders.CONTENT_TYPE, "application/javascript; charset=UTF-8");
@@ -193,7 +193,7 @@ class XhrTransport extends BaseTransport {
     }
 
     public void close() {
-      if (log.isTraceEnabled()) log.trace("XHR poll closing listener");
+      if (LOG.isTraceEnabled()) LOG.trace("XHR poll closing listener");
       if (!closed) {
         try {
           session.resetListener();
@@ -235,7 +235,7 @@ class XhrTransport extends BaseTransport {
     }
 
     public void close() {
-      if (log.isTraceEnabled()) log.trace("XHR stream closing listener");
+      if (LOG.isTraceEnabled()) LOG.trace("XHR stream closing listener");
       if (!closed) {
         session.resetListener();
         try {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -31,7 +31,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class ForwardedParser {
-  private static final Logger log = LoggerFactory.getLogger(RouterImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RouterImpl.class);
 
   private static final String HTTP_SCHEME = "http";
   private static final String HTTPS_SCHEME = "https";
@@ -212,7 +212,7 @@ class ForwardedParser {
     try {
       return Integer.parseInt(portToParse);
     } catch (NumberFormatException ignored) {
-      log.error("Failed to parse a port from \"forwarded\"-type headers.");
+      LOG.error("Failed to parse a port from \"forwarded\"-type headers.");
       return defaultPort;
     }
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HeaderParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HeaderParser.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
  * <a href="https://tools.ietf.org/html/rfc7231#section-5.3.1">rfc7231,section-5.3.1</a>'s specification.<br>
  */
 public class HeaderParser {
-  private static final Logger log = LoggerFactory.getLogger(HeaderParser.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HeaderParser.class);
 
   private static final Comparator<ParsedHeaderValue> HEADER_SORTER =
     (ParsedHeaderValue left, ParsedHeaderValue right) -> right.weightedOrder() - left.weightedOrder();
@@ -71,8 +71,8 @@ public class HeaderParser {
               try {
                 weightCallback.accept(Float.parseFloat(val));
               } catch (NumberFormatException e) {
-                if (log.isTraceEnabled())
-                log.trace("Found a \"q\" parameter with value \""+val+"\" that was unparsable");
+                if (LOG.isTraceEnabled())
+                LOG.trace("Found a \"q\" parameter with value \""+val+"\" that was unparsable");
               }
             } else {
               parameterCallback.accept(key, unquote(val));

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -36,7 +36,7 @@ import java.util.*;
  */
 public class RouterImpl implements Router {
 
-  private static final Logger log = LoggerFactory.getLogger(RouterImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RouterImpl.class);
 
   private final Vertx vertx;
 
@@ -49,8 +49,8 @@ public class RouterImpl implements Router {
 
   @Override
   public void handle(HttpServerRequest request) {
-    if (log.isTraceEnabled()) {
-      log.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
     }
     new RoutingContextImpl(null, this, request, state.getRoutes()).next();
   }
@@ -252,13 +252,13 @@ public class RouterImpl implements Router {
         try {
           previousHandler.handle(router);
         } catch (RuntimeException e) {
-          log.error("Router modified notification failed", e);
+          LOG.error("Router modified notification failed", e);
         }
         // invoke the next
         try {
           handler.handle(router);
         } catch (RuntimeException e) {
-          log.error("Router modified notification failed", e);
+          LOG.error("Router modified notification failed", e);
         }
       });
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -31,7 +31,6 @@ import io.vertx.ext.web.codec.impl.BodyCodecImpl;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/sstore/AbstractSession.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/sstore/AbstractSession.java
@@ -23,7 +23,6 @@ import io.vertx.ext.web.sstore.impl.SessionInternal;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

In some web handlers failures are signaled just by it's HTTP error code without context. So having an error handler in the cases is not useful as it just shows the error code.

This PR adds a context error to most of the places where handlers are just failing the responses.