### PR TITLE
Try to handle star properly

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -233,6 +233,14 @@ public interface Route {
   boolean isRegexPath();
 
   /**
+   * Returns true of the path ends with a wildcard {@code *}. Regular expression paths are always assumed to be
+   * wildcard.
+   *
+   * @return true if the path is exact.
+   */
+  boolean isWildcard();
+
+  /**
    * @return the http methods accepted by this route
    */
   Set<HttpMethod> methods();

--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -233,12 +233,12 @@ public interface Route {
   boolean isRegexPath();
 
   /**
-   * Returns true of the path ends with a wildcard {@code *}. Regular expression paths are always assumed to be
-   * wildcard.
+   * Returns true of the path doesn't end with a wildcard {@code *} or is {@code null}.
+   * Regular expression paths are always assumed to be exact.
    *
    * @return true if the path is exact.
    */
-  boolean isWildcard();
+  boolean isExactPath();
 
   /**
    * @return the http methods accepted by this route

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -149,7 +149,7 @@ public class RouteImpl implements Route {
   public synchronized Route subRouter(Router subRouter) {
 
     // The route path must end with a wild card
-    if (state.getPath() != null && state.isStar()) {
+    if (state.getPath() != null && state.isExactPath()) {
       throw new IllegalStateException("Sub router cannot be mounted on an exact path.");
     }
     // Parameters are allowed but full regex patterns not
@@ -225,8 +225,8 @@ public class RouteImpl implements Route {
   }
 
   @Override
-  public boolean isWildcard() {
-    return state.isStar();
+  public boolean isExactPath() {
+    return state.isExactPath();
   }
 
   @Override
@@ -267,10 +267,10 @@ public class RouteImpl implements Route {
     // See if the path contains ":" - if so then it contains parameter capture groups and we have to generate
     // a regex for that
     if (path.charAt(path.length() - 1) != '*') {
-      state = state.setStar(true);
+      state = state.setExactPath(true);
       state = state.setPath(path);
     } else {
-      state = state.setStar(false);
+      state = state.setExactPath(false);
       state = state.setPath(path.substring(0, path.length() - 1));
     }
 
@@ -283,7 +283,7 @@ public class RouteImpl implements Route {
 
   private synchronized void setRegex(String regex) {
     state = state.setPattern(Pattern.compile(regex));
-    state = state.setStar(true);
+    state = state.setExactPath(true);
     findNamedGroups(state.getPattern().pattern());
   }
 
@@ -306,9 +306,9 @@ public class RouteImpl implements Route {
     // allow usage of * at the end as per documentation
     if (path.charAt(path.length() - 1) == '*') {
       path = path.substring(0, path.length() - 1) + "(?<rest>.*)";
-      state = state.setStar(false);
+      state = state.setExactPath(false);
     } else {
-      state = state.setStar(true);
+      state = state.setExactPath(true);
     }
 
     // We need to search for any :<token name> tokens in the String and replace them with named capture groups

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -55,9 +55,9 @@ final class RouteState {
   private final Pattern virtualHostPattern;
   private final boolean pathEndsWithSlash;
   private final boolean exclusive;
-  private final boolean star;
+  private final boolean exactPath;
 
-  private RouteState(RouteImpl route, String path, String name, int order, boolean enabled, Set<HttpMethod> methods, Set<MIMEHeader> consumes, boolean emptyBodyPermittedWithConsumes, Set<MIMEHeader> produces, List<Handler<RoutingContext>> contextHandlers, List<Handler<RoutingContext>> failureHandlers, boolean added, Pattern pattern, List<String> groups, boolean useNormalizedPath, Set<String> namedGroupsInRegex, Pattern virtualHostPattern, boolean pathEndsWithSlash, boolean exclusive, boolean star) {
+  private RouteState(RouteImpl route, String path, String name, int order, boolean enabled, Set<HttpMethod> methods, Set<MIMEHeader> consumes, boolean emptyBodyPermittedWithConsumes, Set<MIMEHeader> produces, List<Handler<RoutingContext>> contextHandlers, List<Handler<RoutingContext>> failureHandlers, boolean added, Pattern pattern, List<String> groups, boolean useNormalizedPath, Set<String> namedGroupsInRegex, Pattern virtualHostPattern, boolean pathEndsWithSlash, boolean exclusive, boolean exactPath) {
     this.route = route;
     this.path = path;
     this.name = name;
@@ -77,7 +77,7 @@ final class RouteState {
     this.virtualHostPattern = virtualHostPattern;
     this.pathEndsWithSlash = pathEndsWithSlash;
     this.exclusive = exclusive;
-    this.star = star;
+    this.exactPath = exactPath;
   }
 
   RouteState(RouteImpl route, int order) {
@@ -101,7 +101,7 @@ final class RouteState {
       null,
       false,
       false,
-      false);
+      true);
   }
 
   public RouteImpl getRoute() {
@@ -137,7 +137,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public int getOrder() {
@@ -165,7 +165,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public boolean isEnabled() {
@@ -193,7 +193,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public Set<HttpMethod> getMethods() {
@@ -221,7 +221,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public RouteState addMethod(HttpMethod method) {
@@ -245,7 +245,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.methods.add(method);
     return newState;
@@ -276,7 +276,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addConsume(MIMEHeader mime) {
@@ -300,7 +300,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.consumes.add(mime);
     return newState;
@@ -331,7 +331,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public Set<MIMEHeader> getProduces() {
@@ -359,7 +359,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addProduce(MIMEHeader mime) {
@@ -383,7 +383,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.produces.add(mime);
     return newState;
@@ -418,7 +418,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addContextHandler(Handler<RoutingContext> contextHandler) {
@@ -442,7 +442,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.contextHandlers.add(contextHandler);
     return newState;
@@ -477,7 +477,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addFailureHandler(Handler<RoutingContext> failureHandler) {
@@ -501,7 +501,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.failureHandlers.add(failureHandler);
     return newState;
@@ -532,7 +532,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public Pattern getPattern() {
@@ -560,7 +560,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public List<String> getGroups() {
@@ -588,7 +588,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addGroup(String group) {
@@ -612,7 +612,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.groups.add(group);
     return newState;
@@ -643,7 +643,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public Set<String> getNamedGroupsInRegex() {
@@ -671,7 +671,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   RouteState addNamedGroupInRegex(String namedGroupInRegex) {
@@ -695,7 +695,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
 
     newState.namedGroupsInRegex.add(namedGroupInRegex);
     return newState;
@@ -726,7 +726,7 @@ final class RouteState {
       virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public boolean isPathEndsWithSlash() {
@@ -754,7 +754,7 @@ final class RouteState {
       this.virtualHostPattern,
       pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
 
   public boolean isExclusive() {
@@ -782,14 +782,14 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       exclusive,
-      this.star);
+      this.exactPath);
   }
 
-  public boolean isStar() {
-    return star;
+  public boolean isExactPath() {
+    return exactPath;
   }
 
-  RouteState setStar(boolean star) {
+  RouteState setExactPath(boolean exactPath) {
     return new RouteState(
       this.route,
       this.path,
@@ -810,7 +810,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      star);
+      exactPath);
   }
   RouteState setName(String name) {
     return new RouteState(
@@ -833,7 +833,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.star);
+      this.exactPath);
   }
   private boolean containsMethod(HttpServerRequest request) {
     if (!isEmpty(methods)) {
@@ -884,7 +884,7 @@ final class RouteState {
         context.matchNormalized = useNormalizedPath;
 
         if (m.groupCount() > 0) {
-          if (!star) {
+          if (!exactPath) {
             context.matchRest = m.start("rest");
             // always replace
             context.pathParams()
@@ -1017,7 +1017,7 @@ final class RouteState {
       }
     }
 
-    if (star) {
+    if (exactPath) {
       return pathMatchesExact(thePath, requestPath, pathEndsWithSlash);
     } else {
       if (pathEndsWithSlash) {
@@ -1147,7 +1147,7 @@ final class RouteState {
       ", virtualHostPattern=" + virtualHostPattern +
       ", pathEndsWithSlash=" + pathEndsWithSlash +
       ", exclusive=" + exclusive +
-      ", star=" + star +
+      ", partial=" + exactPath +
       '}';
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -55,9 +55,9 @@ final class RouteState {
   private final Pattern virtualHostPattern;
   private final boolean pathEndsWithSlash;
   private final boolean exclusive;
-  private final boolean exactPath;
+  private final boolean star;
 
-  private RouteState(RouteImpl route, String path, String name, int order, boolean enabled, Set<HttpMethod> methods, Set<MIMEHeader> consumes, boolean emptyBodyPermittedWithConsumes, Set<MIMEHeader> produces, List<Handler<RoutingContext>> contextHandlers, List<Handler<RoutingContext>> failureHandlers, boolean added, Pattern pattern, List<String> groups, boolean useNormalizedPath, Set<String> namedGroupsInRegex, Pattern virtualHostPattern, boolean pathEndsWithSlash, boolean exclusive, boolean exactPath) {
+  private RouteState(RouteImpl route, String path, String name, int order, boolean enabled, Set<HttpMethod> methods, Set<MIMEHeader> consumes, boolean emptyBodyPermittedWithConsumes, Set<MIMEHeader> produces, List<Handler<RoutingContext>> contextHandlers, List<Handler<RoutingContext>> failureHandlers, boolean added, Pattern pattern, List<String> groups, boolean useNormalizedPath, Set<String> namedGroupsInRegex, Pattern virtualHostPattern, boolean pathEndsWithSlash, boolean exclusive, boolean star) {
     this.route = route;
     this.path = path;
     this.name = name;
@@ -77,7 +77,7 @@ final class RouteState {
     this.virtualHostPattern = virtualHostPattern;
     this.pathEndsWithSlash = pathEndsWithSlash;
     this.exclusive = exclusive;
-    this.exactPath = exactPath;
+    this.star = star;
   }
 
   RouteState(RouteImpl route, int order) {
@@ -137,7 +137,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public int getOrder() {
@@ -165,7 +165,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public boolean isEnabled() {
@@ -193,7 +193,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public Set<HttpMethod> getMethods() {
@@ -221,7 +221,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public RouteState addMethod(HttpMethod method) {
@@ -245,7 +245,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.methods.add(method);
     return newState;
@@ -276,7 +276,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addConsume(MIMEHeader mime) {
@@ -300,7 +300,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.consumes.add(mime);
     return newState;
@@ -331,7 +331,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public Set<MIMEHeader> getProduces() {
@@ -359,7 +359,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addProduce(MIMEHeader mime) {
@@ -383,7 +383,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.produces.add(mime);
     return newState;
@@ -418,7 +418,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addContextHandler(Handler<RoutingContext> contextHandler) {
@@ -442,7 +442,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.contextHandlers.add(contextHandler);
     return newState;
@@ -477,7 +477,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addFailureHandler(Handler<RoutingContext> failureHandler) {
@@ -501,7 +501,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.failureHandlers.add(failureHandler);
     return newState;
@@ -532,7 +532,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public Pattern getPattern() {
@@ -560,7 +560,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public List<String> getGroups() {
@@ -588,7 +588,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addGroup(String group) {
@@ -612,7 +612,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.groups.add(group);
     return newState;
@@ -643,7 +643,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public Set<String> getNamedGroupsInRegex() {
@@ -671,7 +671,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   RouteState addNamedGroupInRegex(String namedGroupInRegex) {
@@ -695,7 +695,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
 
     newState.namedGroupsInRegex.add(namedGroupInRegex);
     return newState;
@@ -726,7 +726,7 @@ final class RouteState {
       virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public boolean isPathEndsWithSlash() {
@@ -754,7 +754,7 @@ final class RouteState {
       this.virtualHostPattern,
       pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
 
   public boolean isExclusive() {
@@ -782,14 +782,14 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       exclusive,
-      this.exactPath);
+      this.star);
   }
 
-  public boolean isExactPath() {
-    return exactPath;
+  public boolean isStar() {
+    return star;
   }
 
-  RouteState setExactPath(boolean exactPath) {
+  RouteState setStar(boolean star) {
     return new RouteState(
       this.route,
       this.path,
@@ -810,7 +810,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      exactPath);
+      star);
   }
   RouteState setName(String name) {
     return new RouteState(
@@ -833,7 +833,7 @@ final class RouteState {
       this.virtualHostPattern,
       this.pathEndsWithSlash,
       this.exclusive,
-      this.exactPath);
+      this.star);
   }
   private boolean containsMethod(HttpServerRequest request) {
     if (!isEmpty(methods)) {
@@ -884,7 +884,7 @@ final class RouteState {
         context.matchNormalized = useNormalizedPath;
 
         if (m.groupCount() > 0) {
-          if (!exactPath) {
+          if (!star) {
             context.matchRest = m.start("rest");
             // always replace
             context.pathParams()
@@ -1017,7 +1017,7 @@ final class RouteState {
       }
     }
 
-    if (exactPath) {
+    if (star) {
       return pathMatchesExact(thePath, requestPath, pathEndsWithSlash);
     } else {
       if (pathEndsWithSlash) {
@@ -1147,7 +1147,7 @@ final class RouteState {
       ", virtualHostPattern=" + virtualHostPattern +
       ", pathEndsWithSlash=" + pathEndsWithSlash +
       ", exclusive=" + exclusive +
-      ", exactPath=" + exactPath +
+      ", star=" + star +
       '}';
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1147,7 +1147,7 @@ final class RouteState {
       ", virtualHostPattern=" + virtualHostPattern +
       ", pathEndsWithSlash=" + pathEndsWithSlash +
       ", exclusive=" + exclusive +
-      ", partial=" + exactPath +
+      ", exactPath=" + exactPath +
       '}';
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -20,6 +20,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
 import java.time.*;
@@ -55,7 +56,9 @@ public class Utils extends io.vertx.core.impl.Utils {
   }
 
   public static String pathOffset(String path, RoutingContext context) {
-    if (context.currentRoute().isWildcard()) {
+    final Route route = context.currentRoute();
+
+    if (!route.isExactPath()) {
       final String rest = context.pathParam("*");
       if (rest != null) {
         // normalize
@@ -79,12 +82,15 @@ public class Utils extends io.vertx.core.impl.Utils {
         prefixLen--;
       }
     }
-    String routePath = context.currentRoute().getPath();
-    if (routePath != null) {
-      prefixLen += routePath.length();
-      // special case we need to verify if a trailing slash  is present and exclude
-      if (routePath.charAt(routePath.length() - 1) == '/') {
-        prefixLen--;
+    // we can only safely skip the route path if there are no variables or regex
+    if (!route.isRegexPath()) {
+      String routePath = route.getPath();
+      if (routePath != null) {
+        prefixLen += routePath.length();
+        // special case we need to verify if a trailing slash  is present and exclude
+        if (routePath.charAt(routePath.length() - 1) == '/') {
+          prefixLen--;
+        }
       }
     }
     return prefixLen != 0 ? path.substring(prefixLen) : path;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -55,17 +55,19 @@ public class Utils extends io.vertx.core.impl.Utils {
   }
 
   public static String pathOffset(String path, RoutingContext context) {
-    final String rest = context.pathParam("*");
-    if (rest != null) {
-      // normalize
-      if (rest.length() > 0) {
-        if (rest.charAt(0) == '/') {
-          return rest;
+    if (context.currentRoute().isWildcard()) {
+      final String rest = context.pathParam("*");
+      if (rest != null) {
+        // normalize
+        if (rest.length() > 0) {
+          if (rest.charAt(0) == '/') {
+            return rest;
+          } else {
+            return "/" + rest;
+          }
         } else {
-          return "/" + rest;
+          return "/";
         }
-      } else {
-        return "/";
       }
     }
     int prefixLen = 0;

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -54,6 +54,12 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testSimpleRoute2() throws Exception {
+    router.route("/*").handler(rc -> rc.response().end());
+    testRequest(HttpMethod.GET, "/", 200, "OK");
+  }
+
+  @Test
   public void testSimpleFunction() throws Exception {
     router.route()
       .respond(rc -> vertx.fileSystem().readFile(rc.queryParams().get("file")));

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -487,7 +487,8 @@ public class SubRouterTest extends WebTestBase {
 
     router.route("/v/:version/*")
       .subRouter(subRouter)
-      .handler(ctx -> {});
+      .handler(ctx -> {
+      });
   }
 
   @Test(expected = IllegalStateException.class)
@@ -503,7 +504,8 @@ public class SubRouterTest extends WebTestBase {
     });
 
     router.route("/v/:version/*")
-      .handler(ctx -> {})
+      .handler(ctx -> {
+      })
       .subRouter(subRouter);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -27,6 +27,7 @@ import io.vertx.ext.web.Http2PushMapping;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.impl.Utils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -939,5 +940,20 @@ public class StaticHandlerTest extends WebTestBase {
 
   private long fileSize(String filename) {
     return new File(filename).length();
+  }
+
+  @Test
+  public void testSubRouterBeforeStaticHandler() throws Exception {
+    Router subRouter = Router.router(vertx);
+
+    router.clear();
+    router
+      .mountSubRouter("/test", subRouter);
+
+    router
+      .route()
+      .handler(stat);
+
+    testRequest(HttpMethod.GET, "/test", 404, "Not Found");
   }
 }

--- a/vertx-web/src/test/resources/templates/index.ftl
+++ b/vertx-web/src/test/resources/templates/index.ftl
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+<h1>Top index!</h1>
+</body>
+</html>

--- a/vertx-web/src/test/resources/templates/sub/index.ftl
+++ b/vertx-web/src/test/resources/templates/sub/index.ftl
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+<h1>Sub index!</h1>
+</body>
+</html>


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

This PR attempts to handle issues related to the use of `*` wildcards.

Fixes #1849, #1819

Currently, when calculating path offsets, the `*` param is always taken in consideration, when we should only consider it when a route "explicitly" defines it.