### PR TITLE
Add a setUser method to the SessionHandler.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SessionHandler.java
@@ -25,6 +25,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.impl.SessionHandlerImpl;
@@ -269,4 +270,27 @@ public interface SessionHandler extends Handler<RoutingContext> {
    * @return the session
    */
   Session newSession(RoutingContext context);
+
+  /**
+   * Set the user for the session
+   *
+   * @param context the routing context
+   * @param user the user
+   * @return future that will be called when complete, or a failure
+   */
+  Future<Void> setUser(RoutingContext context, User user);
+
+  /**
+   * Set the user for the session
+   *
+   * @param context the routing context
+   * @param user the user
+   * @param handler the event handler to signal a asynchronous response.
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  default SessionHandler setUser(RoutingContext context, User user, Handler<AsyncResult<Void>> handler) {
+    setUser(context, user).onComplete(handler);
+    return this;
+  }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.handler.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.CookieSameSite;
@@ -27,6 +28,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
@@ -351,6 +353,19 @@ public class SessionHandlerImpl implements SessionHandler {
       }
     });
     return session;
+  }
+
+  public Future<Void> setUser(RoutingContext context, User user) {
+    if (!cookieless) {
+      context.removeCookie(sessionCookieName, false);
+    }
+    context.setUser(user);
+    // signal we must store the user to link it to the session
+    context.put(SESSION_STOREUSER_KEY, true);
+    Promise<Void> promise = Promise.promise();
+    flush(context, true, true, promise);
+    promise.future().onFailure(flush -> LOG.warn("Failed to flush the user to the underlying session store", flush));
+    return promise.future();
   }
 
   private String getSessionId(RoutingContext  context) {


### PR DESCRIPTION
Motivation:

Allows for setting and flushing a new user to the `RoutingContext` and `SessionStore`.