### PR TITLE
Add module to render jte templates

### DIFF
--- a/vertx-template-engines/pom.xml
+++ b/vertx-template-engines/pom.xml
@@ -27,6 +27,7 @@
     <module>vertx-web-templ-rocker</module>
     <module>vertx-web-templ-httl</module>
     <module>vertx-web-templ-rythm</module>
+    <module>vertx-web-templ-jte</module>
   </modules>
 
 </project>

--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -62,4 +62,26 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>skip-tests</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-template-engines</artifactId>
+    <version>4.0.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-web-templ-jte</artifactId>
+
+  <properties>
+    <jte.version>1.5.1</jte.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>gg.jte</groupId>
+      <artifactId>jte</artifactId>
+      <version>${jte.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <include>gg.jte:jte</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>vertx-web-templ-jte</artifactId>
 
   <properties>
-    <jte.version>1.5.1</jte.version>
+    <jte.version>1.6.0</jte.version>
   </properties>
 
   <dependencies>
@@ -61,27 +61,5 @@
 
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>skip-tests</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <skipTests>true</skipTests>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.jte;
+
+import gg.jte.ContentType;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.common.WebEnvironment;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import io.vertx.ext.web.templ.jte.impl.JteTemplateEngineImpl;
+import io.vertx.ext.web.templ.jte.impl.VertxDirectoryCodeResolver;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A template engine for <a href="https://jte.gg">jte</a> templates.
+ *
+ * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
+ */
+@VertxGen
+public interface JteTemplateEngine extends TemplateEngine {
+
+  /**
+   * Creates a vert.x template engine for jte templates with sane defaults.
+   * <p>
+   * Hot reloading is active, when {@link WebEnvironment#development()} is true.
+   *
+   * @param vertx the vert.x instance
+   * @param templateRootDirectory the directory where jte templates are located
+   * @return the created vert.x template engine
+   */
+  static JteTemplateEngine create(Vertx vertx, Path templateRootDirectory) {
+    return create(gg.jte.TemplateEngine.create(new VertxDirectoryCodeResolver(vertx, templateRootDirectory), Paths.get("target", "jte-classes"), ContentType.Html));
+  }
+
+  /**
+   * Creates a vert.x template engine for the given jte template engine.
+   * <p>
+   * Use this method if you want full control over the used engine.
+   * <p>
+   * For instance, it is recommended to use the jte-maven-plugin to precompile all jte templates
+   * during maven build. If you do so, you can pass a precompiled engine when running in production.
+   *
+   * @param templateEngine the configured jte template engine
+   * @return the created vert.x template engine
+   */
+  static JteTemplateEngine create(gg.jte.TemplateEngine templateEngine) {
+    return new JteTemplateEngineImpl(templateEngine);
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
@@ -24,7 +24,6 @@ import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.templ.jte.impl.JteTemplateEngineImpl;
 import io.vertx.ext.web.templ.jte.impl.VertxDirectoryCodeResolver;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -40,27 +39,11 @@ public interface JteTemplateEngine extends TemplateEngine {
    * <p>
    * Hot reloading is active, when {@link WebEnvironment#development()} is true.
    *
-   * @param vertx the vert.x instance
+   * @param vertx                 the vert.x instance
    * @param templateRootDirectory the directory where jte templates are located
    * @return the created vert.x template engine
    */
-  static JteTemplateEngine create(Vertx vertx, Path templateRootDirectory) {
-    return create(gg.jte.TemplateEngine.create(new VertxDirectoryCodeResolver(vertx, templateRootDirectory), Paths.get("target", "jte-classes"), ContentType.Html));
+  static JteTemplateEngine create(Vertx vertx, String templateRootDirectory) {
+    return new JteTemplateEngineImpl(gg.jte.TemplateEngine.create(new VertxDirectoryCodeResolver(vertx, templateRootDirectory), Paths.get("target", "jte-classes"), ContentType.Html));
   }
-
-  /**
-   * Creates a vert.x template engine for the given jte template engine.
-   * <p>
-   * Use this method if you want full control over the used engine.
-   * <p>
-   * For instance, it is recommended to use the jte-maven-plugin to precompile all jte templates
-   * during maven build. If you do so, you can pass a precompiled engine when running in production.
-   *
-   * @param templateEngine the configured jte template engine
-   * @return the created vert.x template engine
-   */
-  static JteTemplateEngine create(gg.jte.TemplateEngine templateEngine) {
-    return new JteTemplateEngineImpl(templateEngine);
-  }
-
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.jte.impl;
+
+import gg.jte.TemplateEngine;
+import gg.jte.output.StringOutput;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.templ.jte.JteTemplateEngine;
+
+import java.util.Map;
+
+
+/**
+ * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
+ */
+public class JteTemplateEngineImpl implements JteTemplateEngine {
+
+  private final TemplateEngine templateEngine;
+
+  public JteTemplateEngineImpl(TemplateEngine templateEngine) {
+    this.templateEngine = templateEngine;
+  }
+
+  @Override
+  public void render(Map<String, Object> context, String templateFile, Handler<AsyncResult<Buffer>> handler) {
+    try {
+      StringOutput output = new StringOutput();
+      templateEngine.render(templateFile, context, output);
+      handler.handle(Future.succeededFuture(Buffer.buffer(output.toString())));
+    } catch (RuntimeException ex) {
+      handler.handle(Future.failedFuture(ex));
+    }
+  }
+
+  @Override
+  public void clearCache() {
+    // No-Op
+  }
+
+}

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -34,6 +34,16 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
 
   private final TemplateEngine templateEngine;
 
+  /**
+   * Creates a vert.x template engine for the given jte template engine.
+   * <p>
+   * Use this method if you want full control over the used engine.
+   * <p>
+   * For instance, it is recommended to use the jte-maven-plugin to precompile all jte templates
+   * during maven build. If you do so, you can pass a precompiled engine when running in production.
+   *
+   * @param templateEngine the configured jte template engine
+   */
   public JteTemplateEngineImpl(TemplateEngine templateEngine) {
     this.templateEngine = templateEngine;
   }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
@@ -20,6 +20,8 @@ import gg.jte.CodeResolver;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.WebEnvironment;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -28,12 +30,12 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class VertxDirectoryCodeResolver implements CodeResolver {
   private final Vertx vertx;
-  private final String templateRootDirectory;
+  private final Path templateRootDirectory;
   private final ConcurrentMap<String, Long> modificationTimes;
 
   public VertxDirectoryCodeResolver(Vertx vertx, String templateRootDirectory) {
     this.vertx = vertx;
-    this.templateRootDirectory = templateRootDirectory.endsWith("/") ? templateRootDirectory : templateRootDirectory + "/";
+    this.templateRootDirectory = Paths.get(templateRootDirectory);
 
     if (WebEnvironment.development()) {
       modificationTimes = new ConcurrentHashMap<>();
@@ -43,7 +45,7 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
   }
 
   public String resolve(String name) {
-    name = templateRootDirectory + name;
+    name = templateRootDirectory.resolve(name).toString();
 
     String templateCode = vertx.fileSystem().readFileBlocking(name).toString();
     if (templateCode == null) {
@@ -62,7 +64,7 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
       return false;
     }
 
-    name = templateRootDirectory + name;
+    name = templateRootDirectory.resolve(name).toString();
 
     Long lastResolveTime = this.modificationTimes.get(name);
     if (lastResolveTime == null) {

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ.jte.impl;
+
+import gg.jte.CodeResolver;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.common.WebEnvironment;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
+ */
+public class VertxDirectoryCodeResolver implements CodeResolver {
+  private final Vertx vertx;
+  private final Path templateRootDirectory;
+  private final ConcurrentMap<String, Long> modificationTimes;
+
+  public VertxDirectoryCodeResolver(Vertx vertx, Path templateRootDirectory) {
+    this.vertx = vertx;
+    this.templateRootDirectory = templateRootDirectory;
+
+    if (WebEnvironment.development()) {
+      modificationTimes = new ConcurrentHashMap<>();
+    } else {
+      modificationTimes = null;
+    }
+  }
+
+  public String resolve(String name) {
+    name = templateRootDirectory.resolve(name).toString();
+
+    String templateCode = vertx.fileSystem().readFileBlocking(name).toString();
+    if (templateCode == null) {
+      return null;
+    }
+
+    if (modificationTimes != null) {
+      modificationTimes.put(name, this.getLastModified(name));
+    }
+
+    return templateCode;
+  }
+
+  public boolean hasChanged(String name) {
+    if (modificationTimes == null) {
+      return false;
+    }
+
+    name = templateRootDirectory.resolve(name).toString();
+
+    Long lastResolveTime = this.modificationTimes.get(name);
+    if (lastResolveTime == null) {
+      return true;
+    } else {
+      long lastModified = this.getLastModified(name);
+      return lastModified != lastResolveTime;
+    }
+  }
+
+  private long getLastModified(String name) {
+    return vertx.fileSystem().propsBlocking(name).lastModifiedTime();
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
@@ -20,7 +20,6 @@ import gg.jte.CodeResolver;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.WebEnvironment;
 
-import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -29,12 +28,12 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class VertxDirectoryCodeResolver implements CodeResolver {
   private final Vertx vertx;
-  private final Path templateRootDirectory;
+  private final String templateRootDirectory;
   private final ConcurrentMap<String, Long> modificationTimes;
 
-  public VertxDirectoryCodeResolver(Vertx vertx, Path templateRootDirectory) {
+  public VertxDirectoryCodeResolver(Vertx vertx, String templateRootDirectory) {
     this.vertx = vertx;
-    this.templateRootDirectory = templateRootDirectory;
+    this.templateRootDirectory = templateRootDirectory.endsWith("/") ? templateRootDirectory : templateRootDirectory + "/";
 
     if (WebEnvironment.development()) {
       modificationTimes = new ConcurrentHashMap<>();
@@ -44,7 +43,7 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
   }
 
   public String resolve(String name) {
-    name = templateRootDirectory.resolve(name).toString();
+    name = templateRootDirectory + name;
 
     String templateCode = vertx.fileSystem().readFileBlocking(name).toString();
     if (templateCode == null) {
@@ -63,7 +62,7 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
       return false;
     }
 
-    name = templateRootDirectory.resolve(name).toString();
+    name = templateRootDirectory + name;
 
     Long lastResolveTime = this.modificationTimes.get(name);
     if (lastResolveTime == null) {

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/package-info.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "vertx-web-templ-jte", groupPackage = "io.vertx")
+package io.vertx.ext.web.templ.jte;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Automatic-Module-Name: io.vertx.web.template.jte
+

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteTemplateEngineTest.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteTemplateEngineTest.java
@@ -26,8 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.nio.file.Paths;
-
 /**
  * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
  */
@@ -39,7 +37,7 @@ public class JteTemplateEngineTest {
   @BeforeClass
   public static void before() {
     Vertx vertx = Vertx.vertx();
-    engine = JteTemplateEngine.create(vertx, Paths.get("src", "test", "jte"));
+    engine = JteTemplateEngine.create(vertx, "src/test/jte");
   }
 
   @Test

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteTemplateEngineTest.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteTemplateEngineTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import io.vertx.ext.web.templ.jte.JteTemplateEngine;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Paths;
+
+/**
+ * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class JteTemplateEngineTest {
+
+  private static TemplateEngine engine;
+
+  @BeforeClass
+  public static void before() {
+    Vertx vertx = Vertx.vertx();
+    engine = JteTemplateEngine.create(vertx, Paths.get("src", "test", "jte"));
+  }
+
+  @Test
+  public void testTemplateHandler(TestContext should) {
+    final JsonObject context = new JsonObject()
+      .put("foo", "badger")
+      .put("bar", "fox")
+      .put("context", new JsonObject().put("path", "/testTemplate2.jte"));
+
+    engine.render(context, "testTemplate2.jte", should.asyncAssertSuccess(render ->
+      should.assertEquals("\nHello badger and fox\nRequest path is /testTemplate2.jte\n", normalizeCRLF(render.toString()))
+    ));
+  }
+
+  @Test
+  public void testTemplateHandlerIncludes(TestContext should) {
+    final JsonObject context = new JsonObject()
+      .put("foo", "badger")
+      .put("bar", "fox")
+      .put("context", new JsonObject().put("path", "/base"));
+
+    engine.render(context, "base.jte", should.asyncAssertSuccess(render ->
+      should.assertEquals("Vert.x rules\n\n", normalizeCRLF(render.toString()))
+    ));
+  }
+
+  @Test
+  public void testNoSuchTemplate(TestContext should) {
+    final JsonObject context = new JsonObject();
+
+    engine.render(context, "nosuchtemplate.jte", should.asyncAssertFailure());
+  }
+
+  // For windows testing
+  static String normalizeCRLF(String s) {
+    return s.replace("\r\n", "\n");
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/jte/base.jte
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/jte/base.jte
@@ -1,0 +1,1 @@
+@tag.inc(what = "rules")

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/jte/tag/inc.jte
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/jte/tag/inc.jte
@@ -1,0 +1,2 @@
+@param String what
+Vert.x ${what}

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/jte/testTemplate2.jte
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/jte/testTemplate2.jte
@@ -1,0 +1,7 @@
+@import io.vertx.core.json.JsonObject
+@param JsonObject context
+@param String foo
+@param String bar
+
+Hello ${foo} and ${bar}
+Request path is ${context.getString("path")}


### PR DESCRIPTION
Motivation:

Hey, I'm the maintainer of [jte](https://jte.gg), a compile time checked, fast and secure template engine for Java. The main reasons to create jte were productivity, performance and security. All templates are type safe and there's a pretty smart IntelliJ plugin helping with refactorings, completions and formatting. It's also [very fast](https://github.com/casid/jte#performance), since all templates compile to Java and there's no expression language to evaluate. Finally, it provides users with [context-sensitive output escaping](https://github.com/casid/jte/blob/master/DOCUMENTATION.md#html-escaping) and [quality of life when generating HMTL](https://github.com/casid/jte/blob/master/DOCUMENTATION.md#html-rendering).

I've written a vert.x template module for jte and it looks like it would integrate very nicely.

Would you be interested in adding jte to the supported vert.x template engines? Let me know what you think!

PS: I read the contribution guidelines, but I haven't signed a Eclipse Contributor Agreement.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
