### PR TITLE
Issues/more offset fixes

### DIFF
--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -129,9 +129,13 @@ public class WebExamples {
       // `/some/path/subdir`
       // `/some/path/subdir/blah.html`
       //
-      // but not:
-      // `/some/path` the path is strict because it ends with slash
-      // `/some/bath`
+      // but **ALSO**:
+      // `/some/path` the final slash is always optional with a wildcard to preserve
+      //              compatibility with many client libraries.
+      // but **NOT**:
+      // `/some/patha`
+      // `/some/patha/`
+      // etc...
     });
 
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -2,11 +2,7 @@ package io.vertx.ext.web.impl;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.NetSocket;
@@ -324,6 +320,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   }
 
   @Override
+  public int streamId() {
+    return delegate.streamId();
+  }
+
+  @Override
   public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
     delegate.toWebSocket(toWebSocket -> {
       if (toWebSocket.succeeded()) {
@@ -391,6 +392,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   public HttpServerRequest routed(String route) {
     delegate.routed(route);
     return this;
+  }
+
+  @Override
+  public Context context() {
+    return delegate.context();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -320,6 +320,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   }
 
   @Override
+  public int streamId() {
+    return delegate.streamId();
+  }
+
+  @Override
   public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
     delegate.toWebSocket(toWebSocket -> {
       if (toWebSocket.succeeded()) {
@@ -387,6 +392,11 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   public HttpServerRequest routed(String route) {
     delegate.routed(route);
     return this;
+  }
+
+  @Override
+  public Context context() {
+    return delegate.context();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -70,11 +70,6 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   }
 
   @Override
-  public Context context() {
-    return delegate.context();
-  }
-
-  @Override
   public HttpServerRequest body(Handler<AsyncResult<Buffer>> handler) {
     delegate.body(handler);
     return this;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -320,11 +320,6 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   }
 
   @Override
-  public int streamId() {
-    return delegate.streamId();
-  }
-
-  @Override
   public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
     delegate.toWebSocket(toWebSocket -> {
       if (toWebSocket.succeeded()) {
@@ -392,11 +387,6 @@ class HttpServerRequestWrapper implements HttpServerRequest {
   public HttpServerRequest routed(String route) {
     delegate.routed(route);
     return this;
-  }
-
-  @Override
-  public Context context() {
-    return delegate.context();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -264,8 +264,7 @@ public class RouteImpl implements Route {
   }
 
   private synchronized void setPath(String path) {
-    // See if the path contains ":" - if so then it contains parameter capture groups and we have to generate
-    // a regex for that
+    // See if the path is a wildcard "*" is present - If so we need to configure this path to be not exact
     if (path.charAt(path.length() - 1) != '*') {
       state = state.setExactPath(true);
       state = state.setPath(path);
@@ -274,6 +273,8 @@ public class RouteImpl implements Route {
       state = state.setPath(path.substring(0, path.length() - 1));
     }
 
+    // See if the path contains ":" - if so then it contains parameter capture groups and we have to generate
+    // a regex for that
     if (path.indexOf(':') != -1) {
       createPatternRegex(path);
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -862,7 +862,12 @@ final class RouteState {
       return 404;
     }
     if (pattern != null) {
+      // need to reset "rest"
+      context.pathParams()
+        .remove("*");
+
       String path = useNormalizedPath ? context.normalizedPath() : context.request().path();
+
       if (mountPoint != null) {
         int strip = mountPoint.length();
         // mount point can have significant slash
@@ -1018,6 +1023,10 @@ final class RouteState {
     }
 
     if (exactPath) {
+      // exact path has no "rest"
+      ctx.pathParams()
+        .remove("*");
+
       return pathMatchesExact(thePath, requestPath, pathEndsWithSlash);
     } else {
       if (pathEndsWithSlash) {
@@ -1036,16 +1045,14 @@ final class RouteState {
           // request misses 1 character, there is the chance that this request doesn't include the final slash
           // because the mount path ended with a wildcard we are relaxed in the check
           if (thePath.regionMatches(0, requestPath, 0, pathLen - 1)) {
+            // handle the "rest" as path param *, always known to be empty
+            ctx.pathParams()
+              .put("*", "/");
             return true;
           }
         }
-
-        // we have at least the same amount of characters as the mount path, we can match
-        // the mount path safely
-        if (thePath.regionMatches(0, requestPath, 0, thePath.length())) {
-          return true;
-        }
       }
+
       if (requestPath.startsWith(thePath)) {
         // handle the "rest" as path param *
         ctx.pathParams()

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1021,14 +1021,29 @@ final class RouteState {
       return pathMatchesExact(thePath, requestPath, pathEndsWithSlash);
     } else {
       if (pathEndsWithSlash) {
-        if (requestPath.charAt(requestPath.length() - 1) == '/') {
-          if (requestPath.equals(thePath)) {
+        // the route expects a path that ends in "/*". This is a special case
+        // we need to optionally allow any request just like if it was a "*" but
+        // treat the slash
+        final int pathLen = thePath.length();
+        final int reqLen = requestPath.length();
+
+        if (reqLen < pathLen - 2) {
+          // we miss at least 2 characters
+          return false;
+        }
+
+        if (reqLen == pathLen - 1) {
+          // request misses 1 character, there is the chance that this request doesn't include the final slash
+          // because the mount path ended with a wildcard we are relaxed in the check
+          if (thePath.regionMatches(0, requestPath, 0, pathLen - 1)) {
             return true;
           }
-        } else {
-          if (thePath.regionMatches(0, requestPath, 0, thePath.length())) {
-            return true;
-          }
+        }
+
+        // we have at least the same amount of characters as the mount path, we can match
+        // the mount path safely
+        if (thePath.regionMatches(0, requestPath, 0, thePath.length())) {
+          return true;
         }
       }
       if (requestPath.startsWith(thePath)) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2948,4 +2948,17 @@ public class RouterTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/help/abcd/", 200, "OK");
     testRequest(HttpMethod.GET, "/help/abcd/txt", 200, "OK");
   }
+
+  @Test
+  public void testQuarkusStar() throws Exception {
+    String path = "/swagger";
+    router.route(path + "/*")
+      .handler(RoutingContext::end);
+
+    testRequest(HttpMethod.GET, "/swagge", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/swagger", 200, "OK");
+    testRequest(HttpMethod.GET, "/swaggery", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/swagger/", 200, "OK");
+    testRequest(HttpMethod.GET, "/swagger/index.html", 200, "OK");
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2951,14 +2951,20 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testQuarkusStar() throws Exception {
-    String path = "/swagger";
-    router.route(path + "/*")
+
+    router.clear();
+
+    Router swagger = Router.router(vertx);
+
+    swagger.route("/swagger/*")
       .handler(RoutingContext::end);
 
-    testRequest(HttpMethod.GET, "/swagge", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/swagger", 200, "OK");
-    testRequest(HttpMethod.GET, "/swaggery", 404, "Not Found");
-    testRequest(HttpMethod.GET, "/swagger/", 200, "OK");
-    testRequest(HttpMethod.GET, "/swagger/index.html", 200, "OK");
+    router.mountSubRouter("/q", swagger);
+
+    testRequest(HttpMethod.GET, "/q/swagge", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/q/swagger", 200, "OK");
+    testRequest(HttpMethod.GET, "/q/swaggery", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/q/swagger/", 200, "OK");
+    testRequest(HttpMethod.GET, "/q/swagger/index.html", 200, "OK");
   }
 }


### PR DESCRIPTION
Motivation:

Path offset and multiple routers was not being calculated correctly as the last evaluation would remain on the context. This set of commits solves those problems + relaxes the rule on `/*` to not be strict on the requirement of the final `/`

These fixes reduce the breaking changes downstream, namely quarkus users.