### PR TITLE
Enable vertxgen

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
@@ -11,6 +11,8 @@
 package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.ext.web.client.impl.WebClientSessionAware;
 import io.vertx.ext.web.client.spi.CookieStore;
 
@@ -35,11 +37,12 @@ import io.vertx.ext.web.client.spi.CookieStore;
  *
  * @author <a href="mailto:tommaso.nolli@gmail.com">Tommaso Nolli</a>
  */
+@VertxGen
 public interface WebClientSession extends WebClient {
 
   /**
    * Create a session aware web client using the provided {@code webClient} instance.
-   * 
+   *
    * @param webClient the web client instance
    * @return the created client
    */
@@ -49,7 +52,7 @@ public interface WebClientSession extends WebClient {
 
   /**
    * Create a session aware web client using the provided {@code webClient} instance.
-   * 
+   *
    * @param webClient the web client instance
    * @return the created client
    */
@@ -65,6 +68,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   WebClientSession addHeader(CharSequence name, CharSequence value);
 
   /**
@@ -85,6 +89,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   WebClientSession addHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
@@ -95,32 +100,34 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   WebClientSession addHeader(String name, Iterable<String> values);
 
   /**
    * Removes a previously added header.
-   * 
+   *
    * @param name the header name
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   WebClientSession removeHeader(CharSequence name);
 
   /**
    * Removes a previously added header.
-   * 
+   *
    * @param name the header name
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   WebClientSession removeHeader(String name);
-  
+
   /**
    * Returns this client's {@code CookieStore}
    * <p>
    * All cookies added to this store will be send with every request.
    * The CookieStore honors the domain, path, secure and max-age properties of received cookies
-   * and is automatically updated with cookies present in responses received by this client.  
+   * and is automatically updated with cookies present in responses received by this client.
    * @return this client's cookie store
    */
   CookieStore cookieStore();

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
@@ -56,6 +56,7 @@ public interface WebClientSession extends WebClient {
    * @param webClient the web client instance
    * @return the created client
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static WebClientSession create(WebClient webClient, CookieStore cookieStore) {
     return new WebClientSessionAware(webClient, cookieStore);
   }
@@ -130,5 +131,6 @@ public interface WebClientSession extends WebClient {
    * and is automatically updated with cookies present in responses received by this client.
    * @return this client's cookie store
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   CookieStore cookieStore();
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
@@ -56,7 +56,7 @@ public interface WebClientSession extends WebClient {
    * @param webClient the web client instance
    * @return the created client
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   static WebClientSession create(WebClient webClient, CookieStore cookieStore) {
     return new WebClientSessionAware(webClient, cookieStore);
   }
@@ -69,7 +69,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   WebClientSession addHeader(CharSequence name, CharSequence value);
 
   /**
@@ -90,7 +90,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   WebClientSession addHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
@@ -101,7 +101,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   WebClientSession addHeader(String name, Iterable<String> values);
 
   /**
@@ -111,7 +111,7 @@ public interface WebClientSession extends WebClient {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   WebClientSession removeHeader(CharSequence name);
 
   /**
@@ -131,6 +131,6 @@ public interface WebClientSession extends WebClient {
    * and is automatically updated with cookies present in responses received by this client.
    * @return this client's cookie store
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore
   CookieStore cookieStore();
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CookieStoreImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CookieStoreImpl.java
@@ -25,8 +25,8 @@ import io.vertx.ext.web.client.spi.CookieStore;
  */
 public class CookieStoreImpl implements CookieStore {
 
-  private ConcurrentHashMap<Key, Cookie> noDomainCookies;
-  private ConcurrentSkipListMap<Key, Cookie> domainCookies;
+  private final ConcurrentHashMap<Key, Cookie> noDomainCookies;
+  private final ConcurrentSkipListMap<Key, Cookie> domainCookies;
 
   public CookieStoreImpl() {
     noDomainCookies = new ConcurrentHashMap<>();
@@ -130,18 +130,14 @@ public class CookieStoreImpl implements CookieStore {
         while (domain.charAt(domain.length() - 1) == '.') {
           domain = domain.substring(0, domain.length() - 1);
         }
-        if (domain.length() == 0) {
-          this.domain = NO_DOMAIN;
-        } else {
-          String[] tokens = domain.split("\\.");
-          String tmp;
-          for (int i = 0, j = tokens.length - 1; i < tokens.length / 2; ++i, --j) {
-            tmp = tokens[j];
-            tokens[j] = tokens[i];
-            tokens[i] = tmp;
-          }
-          this.domain = String.join(".", tokens);
+        String[] tokens = domain.split("\\.");
+        String tmp;
+        for (int i = 0, j = tokens.length - 1; i < tokens.length / 2; ++i, --j) {
+          tmp = tokens[j];
+          tokens[j] = tokens[i];
+          tokens[i] = tmp;
         }
+        this.domain = String.join(".", tokens);
       }
       this.path = path == null ? "" : path;
       this.name = name;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/spi/CookieStore.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/spi/CookieStore.java
@@ -11,9 +11,6 @@
 package io.vertx.ext.web.client.spi;
 
 import io.netty.handler.codec.http.cookie.Cookie;
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.ext.web.client.impl.CookieStoreImpl;
 
 /**
@@ -21,7 +18,6 @@ import io.vertx.ext.web.client.impl.CookieStoreImpl;
  *
  * @author <a href="mailto:tommaso.nolli@gmail.com">Tommaso Nolli</a>
  */
-@VertxGen
 public interface CookieStore {
 
   /**
@@ -43,7 +39,6 @@ public interface CookieStore {
    * @param path the path we are calling
    * @return the matched cookies
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Iterable<Cookie> get(Boolean ssl, String domain, String path);
 
   /**
@@ -54,8 +49,6 @@ public interface CookieStore {
    * @param cookie the {@link Cookie} to add
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  @GenIgnore
   CookieStore put(Cookie cookie);
   /**
    * Removes a previously added cookie.
@@ -63,7 +56,5 @@ public interface CookieStore {
    * @param cookie the {@link Cookie} to remove
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  @GenIgnore
   CookieStore remove(Cookie cookie);
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/spi/CookieStore.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/spi/CookieStore.java
@@ -12,13 +12,16 @@ package io.vertx.ext.web.client.spi;
 
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.ext.web.client.impl.CookieStoreImpl;
 
 /**
  * A cookie store that manages cookies for a single user; received for different domains and valid for different paths.
- * 
+ *
  * @author <a href="mailto:tommaso.nolli@gmail.com">Tommaso Nolli</a>
  */
+@VertxGen
 public interface CookieStore {
 
   /**
@@ -28,36 +31,39 @@ public interface CookieStore {
   static CookieStore build() {
     return new CookieStoreImpl();
   }
-  
+
   /**
    * Returns and {@link Iterable} of cookies satisfying the filters passed as paraemters.
    * <p>
    * It is implementation responsibility to return the appropriate cookies between the ones stored in this store
    * and to clean up the path.
-   * 
+   *
    * @param ssl true if is the connection secure
    * @param domain the domain we are calling
    * @param path the path we are calling
    * @return the matched cookies
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Iterable<Cookie> get(Boolean ssl, String domain, String path);
-  
+
   /**
    * Add a cookie to this {@code CookieStore}.
    * <p>
    * If a cookie with the same name is received from the server, it will overwrite this setting.
-   * 
+   *
    * @param cookie the {@link Cookie} to add
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore
   CookieStore put(Cookie cookie);
   /**
    * Removes a previously added cookie.
-   * 
+   *
    * @param cookie the {@link Cookie} to remove
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @GenIgnore
   CookieStore remove(Cookie cookie);
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #1862 

This PR although addresses the lack of the annotation, also uncovered an API design issue. The usage of `Cookie` is referring to `netty` classes, instead of the polyglot/vert.x ones.

@cescoffier @vietj are we happy with just this fix for now, or do you need to fully address the issue and make a breaking change? Note that since the annotations were missing from the beginning users of rx, mutiny, quarkus, etc... would never use the "wrong" types on a normal application. Although power users/framework developers could.