### PR TITLE
Suggest an alternative for precompiled templates

### DIFF
--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -58,7 +58,24 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>gg.jte</groupId>
+        <artifactId>jte-maven-plugin</artifactId>
+        <version>${jte.version}</version>
+        <configuration>
+          <sourceDirectory>src/test/templates</sourceDirectory>
+          <targetDirectory>target/test-classes</targetDirectory>
+          <contentType>Html</contentType>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>precompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -63,8 +63,8 @@
         <artifactId>jte-maven-plugin</artifactId>
         <version>${jte.version}</version>
         <configuration>
-          <sourceDirectory>src/test/templates</sourceDirectory>
-          <targetDirectory>target/test-classes</targetDirectory>
+          <sourceDirectory>${project.basedir}/src/test/templates</sourceDirectory>
+          <targetDirectory>${project.build.directory}/test-classes</targetDirectory>
           <contentType>Html</contentType>
         </configuration>
         <executions>

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
@@ -16,15 +16,11 @@
 
 package io.vertx.ext.web.templ.jte;
 
-import gg.jte.ContentType;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.WebEnvironment;
 import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.templ.jte.impl.JteTemplateEngineImpl;
-import io.vertx.ext.web.templ.jte.impl.VertxDirectoryCodeResolver;
-
-import java.nio.file.Paths;
 
 /**
  * A template engine for <a href="https://jte.gg">jte</a> templates.
@@ -44,6 +40,17 @@ public interface JteTemplateEngine extends TemplateEngine {
    * @return the created vert.x template engine
    */
   static JteTemplateEngine create(Vertx vertx, String templateRootDirectory) {
-    return new JteTemplateEngineImpl(gg.jte.TemplateEngine.create(new VertxDirectoryCodeResolver(vertx, templateRootDirectory), Paths.get("target", "jte-classes"), ContentType.Html));
+    return new JteTemplateEngineImpl(vertx, templateRootDirectory);
+  }
+
+  /**
+   * Creates a vert.x template engine for <b>precompiled</b> jte templates with sane defaults.
+   * <p>
+   * Hot reloading is never active.
+   *
+   * @return the created vert.x template engine
+   */
+  static JteTemplateEngine create() {
+    return new JteTemplateEngineImpl();
   }
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.templ.jte;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.WebEnvironment;
@@ -31,7 +32,7 @@ import io.vertx.ext.web.templ.jte.impl.JteTemplateEngineImpl;
 public interface JteTemplateEngine extends TemplateEngine {
 
   /**
-   * Creates a vert.x template engine for jte templates with sane defaults.
+   * Creates a vert.x template engine for jte HTML templates with sane defaults.
    * <p>
    * Hot reloading is active, when {@link WebEnvironment#development()} is true.
    *
@@ -44,7 +45,7 @@ public interface JteTemplateEngine extends TemplateEngine {
   }
 
   /**
-   * Creates a vert.x template engine for <b>precompiled</b> jte templates with sane defaults.
+   * Creates a vert.x template engine for <b>precompiled</b> HTML jte templates with sane defaults.
    * <p>
    * Hot reloading is never active.
    *
@@ -52,5 +53,16 @@ public interface JteTemplateEngine extends TemplateEngine {
    */
   static JteTemplateEngine create() {
     return new JteTemplateEngineImpl();
+  }
+
+
+  /**
+   * Creates a vert.x template engine for jte templates with a user custom engine.
+   *
+   * @return the created vert.x template engine
+   */
+  @GenIgnore
+  static JteTemplateEngine create(gg.jte.TemplateEngine engine) {
+    return new JteTemplateEngineImpl(engine);
   }
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -45,9 +45,13 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
    * For instance, it is recommended to use the jte-maven-plugin to precompile all jte templates
    * during maven build. If you do so, you can pass a precompiled engine when running in production.
    *
-   * @param vertx the vertx instance
-   * @param templateRootDirectory the template root directory
+   * @param engine a configured engine instance
    */
+  public JteTemplateEngineImpl(gg.jte.TemplateEngine engine) {
+    templateEngine = engine;
+    codeResolver = null;
+  }
+
   public JteTemplateEngineImpl(Vertx vertx, String templateRootDirectory) {
     codeResolver = new VertxDirectoryCodeResolver(vertx, templateRootDirectory);
     templateEngine = TemplateEngine.create(codeResolver, ContentType.Html);

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -16,14 +16,17 @@
 
 package io.vertx.ext.web.templ.jte.impl;
 
+import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.output.StringOutput;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.templ.jte.JteTemplateEngine;
 
+import java.nio.file.Paths;
 import java.util.Map;
 
 
@@ -42,10 +45,17 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
    * For instance, it is recommended to use the jte-maven-plugin to precompile all jte templates
    * during maven build. If you do so, you can pass a precompiled engine when running in production.
    *
-   * @param templateEngine the configured jte template engine
+   * @param vertx the vertx instance
+   * @param templateRootDirectory the template root directory
    */
-  public JteTemplateEngineImpl(TemplateEngine templateEngine) {
-    this.templateEngine = templateEngine;
+  public JteTemplateEngineImpl(Vertx vertx, String templateRootDirectory) {
+    this.templateEngine = TemplateEngine.create(
+      new VertxDirectoryCodeResolver(vertx, templateRootDirectory),
+      ContentType.Html);
+  }
+
+  public JteTemplateEngineImpl() {
+    this.templateEngine = TemplateEngine.createPrecompiled(Paths.get("target", "jte-classes"), ContentType.Html);
   }
 
   @Override
@@ -64,4 +74,9 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
     // No-Op
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T unwrap() throws ClassCastException {
+    return (T) templateEngine;
+  }
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -26,7 +26,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.templ.jte.JteTemplateEngine;
 
-import java.nio.file.Paths;
 import java.util.Map;
 
 
@@ -36,6 +35,7 @@ import java.util.Map;
 public class JteTemplateEngineImpl implements JteTemplateEngine {
 
   private final TemplateEngine templateEngine;
+  private final VertxDirectoryCodeResolver codeResolver;
 
   /**
    * Creates a vert.x template engine for the given jte template engine.
@@ -49,13 +49,13 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
    * @param templateRootDirectory the template root directory
    */
   public JteTemplateEngineImpl(Vertx vertx, String templateRootDirectory) {
-    this.templateEngine = TemplateEngine.create(
-      new VertxDirectoryCodeResolver(vertx, templateRootDirectory),
-      ContentType.Html);
+    codeResolver = new VertxDirectoryCodeResolver(vertx, templateRootDirectory);
+    templateEngine = TemplateEngine.create(codeResolver, ContentType.Html);
   }
 
   public JteTemplateEngineImpl() {
-    this.templateEngine = TemplateEngine.createPrecompiled(Paths.get("target", "jte-classes"), ContentType.Html);
+    codeResolver = null;
+    templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
   }
 
   @Override
@@ -71,7 +71,9 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
 
   @Override
   public void clearCache() {
-    // No-Op
+    if (codeResolver != null) {
+      codeResolver.clear();
+    }
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
@@ -80,6 +80,8 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
   }
 
   public void clear() {
-    modificationTimes.clear();
+    if (modificationTimes != null) {
+      modificationTimes.clear();
+    }
   }
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/VertxDirectoryCodeResolver.java
@@ -78,4 +78,8 @@ public class VertxDirectoryCodeResolver implements CodeResolver {
   private long getLastModified(String name) {
     return vertx.fileSystem().propsBlocking(name).lastModifiedTime();
   }
+
+  public void clear() {
+    modificationTimes.clear();
+  }
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteCompiledTemplateEngineTest.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/java/io/vertx/ext/web/templ/JteCompiledTemplateEngineTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.templ;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import io.vertx.ext.web.templ.jte.JteTemplateEngine;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:andy@mazebert.com">Andreas Hager</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class JteCompiledTemplateEngineTest {
+
+  private static TemplateEngine engine;
+
+  @BeforeClass
+  public static void before() {
+    engine = JteTemplateEngine.create();
+  }
+
+  @Test
+  public void testTemplateHandler(TestContext should) {
+    final JsonObject context = new JsonObject()
+      .put("foo", "badger")
+      .put("bar", "fox")
+      .put("context", new JsonObject().put("path", "/testTemplate2.jte"));
+
+    engine.render(context, "compiled.jte", should.asyncAssertSuccess(render ->
+      should.assertEquals("\nHello compiled badger and fox\nRequest path is /testTemplate2.jte\n", normalizeCRLF(render.toString()))
+    ));
+  }
+
+  // For windows testing
+  static String normalizeCRLF(String s) {
+    return s.replace("\r\n", "\n");
+  }
+}

--- a/vertx-template-engines/vertx-web-templ-jte/src/test/templates/compiled.jte
+++ b/vertx-template-engines/vertx-web-templ-jte/src/test/templates/compiled.jte
@@ -1,0 +1,7 @@
+@import io.vertx.core.json.JsonObject
+@param JsonObject context
+@param String foo
+@param String bar
+
+Hello compiled ${foo} and ${bar}
+Request path is ${context.getString("path")}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

`jte` templates support both runtime and compile time compilation. This PR tries to expose both use cases to the vert.x API:

The previous `create` factory work as is. A small change was made to avoid having a "custom" class path entry as with vert.x 4 we wanted to be as static as possible, so we only load code from the classpath jars. 

A new factory was added without arguments. This factory is different in the sense that instead of relying on the runtime it expects the templates to be already compiled **and** available on the current classpath.

Further the `unwrap` method was implemented to allow users to further customize the underlying engine just like on the other implementations.

@casid let me know what you think about this? I'm just learning and hacking :)