### PR TITLE
Sockjs: handle Strings on EventBus.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
@@ -46,7 +46,7 @@ import java.util.UUID;
 
 public abstract class SockJSSocketBase implements SockJSSocket {
 
-  private final MessageConsumer<Buffer> registration;
+  private final MessageConsumer<Object> registration;
   protected final Vertx vertx;
   protected RoutingContext routingContext;
 
@@ -67,9 +67,16 @@ public abstract class SockJSSocketBase implements SockJSSocket {
     this.vertx = vertx;
     this.routingContext = rc;
     if (options.isRegisterWriteHandler()) {
-      Handler<Message<Buffer>> writeHandler = msg -> write(msg.body());
+      Handler<Message<Object>> writeHandler = msg -> {
+        Object body = msg.body();
+        if (body instanceof String) {
+          write((String) msg.body());
+        } else {
+          write((Buffer) msg.body());
+        }
+      };
       writeHandlerID = UUID.randomUUID().toString();
-      MessageConsumer<Buffer> consumer;
+      MessageConsumer<Object> consumer;
       if (options.isLocalWriteHandler()) {
         consumer = vertx.eventBus().localConsumer(writeHandlerID);
       } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSEventBusTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSEventBusTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.handler.sockjs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.test.core.TestUtils;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class SockJSEventBusTest extends SockJSTestBase {
+
+  @Test
+  public void testWriteText() throws Exception {
+    testWrite(true);
+  }
+
+  @Test
+  public void testWriteBinary() throws Exception {
+    testWrite(false);
+  }
+
+  private void testWrite(boolean text) throws Exception {
+    String expected = TestUtils.randomAlphaString(64);
+    socketHandler = () -> socket -> {
+      if (text) {
+        vertx.eventBus().send(socket.writeHandlerID(), expected);
+      } else {
+        vertx.eventBus().send(socket.writeHandlerID(), Buffer.buffer(expected));
+      }
+      socket.endHandler(v -> {
+        testComplete();
+      });
+    };
+    startServers();
+    client.webSocket("/test/websocket", onSuccess(ws -> {
+      ws.frameHandler(frame -> {
+        if (frame.isClose()) {
+          //
+        } else {
+          if (text) {
+            assertTrue(frame.isText());
+            assertEquals(expected, frame.textData());
+          } else {
+            assertTrue(frame.isBinary());
+            assertEquals(Buffer.buffer(expected), frame.binaryData());
+          }
+          ws.end();
+        }
+      });
+    }));
+    await();
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSTestBase.java
@@ -64,7 +64,9 @@ abstract class SockJSTestBase extends VertxTestBase {
           preSockJSHandlerSetup.accept(router);
         }
 
-        SockJSHandlerOptions options = new SockJSHandlerOptions().setHeartbeatInterval(2000);
+        SockJSHandlerOptions options = new SockJSHandlerOptions();
+        options.setHeartbeatInterval(2000);
+        options.setRegisterWriteHandler(true);
         SockJSHandler sockJSHandler = SockJSHandler.create(vertx, options);
         sockJSHandler.socketHandler(socketHandler.get());
         router.route("/test/*").handler(sockJSHandler);


### PR DESCRIPTION
Since we can write strings over a sockjs connection we should handle them properly when sent over the eventbus write handler.

This is neccesary if one wants to send text(non-binary) messages using the eventbus write handler.