### PR TITLE
JSON content type should follow IANA registry rules

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -679,14 +679,20 @@ public interface RoutingContext {
     final HttpServerResponse res = response();
 
     if (json == null) {
-      // apply the content type header
-      res.putHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8");
+      // http://www.iana.org/assignments/media-types/application/json
+      // No "charset" parameter is defined for this registration.
+      // Adding one really has no effect on compliant recipients.
+      res.putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
       return res.end("null");
     } else {
       try {
         Buffer buffer = Json.encodeToBuffer(json);
         // apply the content type header only if the encoding succeeds
-        res.putHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8");
+
+        // http://www.iana.org/assignments/media-types/application/json
+        // No "charset" parameter is defined for this registration.
+        // Adding one really has no effect on compliant recipients.
+        res.putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
         return res.end(buffer);
       } catch (EncodeException | UnsupportedOperationException e) {
         // handle the failure

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -101,7 +101,7 @@ public class RouterTest extends WebTestBase {
       HttpMethod.GET,
       "/hello",
       null,
-      res -> assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type")),
+      res -> assertEquals("application/json", res.getHeader("Content-Type")),
       200,
       "OK",
       "{\"hello\":\"world\"}");

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
@@ -209,7 +209,7 @@ public class RoutingContextImplTest extends WebTestBase {
       ctx.json(new JsonObject());
     });
     testRequest(HttpMethod.GET, "/", null, res -> {
-      assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type"));
+      assertEquals("application/json", res.getHeader("Content-Type"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
   }
 
@@ -219,7 +219,7 @@ public class RoutingContextImplTest extends WebTestBase {
       ctx.json(new JsonArray());
     });
     testRequest(HttpMethod.GET, "/", null, res -> {
-      assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type"));
+      assertEquals("application/json", res.getHeader("Content-Type"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), null);
   }
 
@@ -229,7 +229,7 @@ public class RoutingContextImplTest extends WebTestBase {
       ctx.json(true);
     });
     testRequest(HttpMethod.GET, "/", null, res -> {
-      assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type"));
+      assertEquals("application/json", res.getHeader("Content-Type"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), "true");
   }
 
@@ -239,7 +239,7 @@ public class RoutingContextImplTest extends WebTestBase {
       ctx.json(null);
     });
     testRequest(HttpMethod.GET, "/", null, res -> {
-      assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type"));
+      assertEquals("application/json", res.getHeader("Content-Type"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), "null");
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/it/RoutingContextDatabindTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/it/RoutingContextDatabindTest.java
@@ -71,7 +71,7 @@ public class RoutingContextDatabindTest extends WebTestBase {
     });
 
     testRequest(HttpMethod.GET, "/", null, res -> {
-      assertEquals("application/json; charset=utf-8", res.getHeader("Content-Type"));
+      assertEquals("application/json", res.getHeader("Content-Type"));
     }, HttpResponseStatus.OK.code(), HttpResponseStatus.OK.reasonPhrase(), "{\"x\":10,\"y\":20}");
   }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

By default vert.x `ctx.json()` returns the content type `application/json;charset=UTF-8` however IANA the standards registry states that:

> No "charset" parameter is defined for this registration. Adding one really has no effect on compliant recipients.