### PR TITLE
Reset interceptor index always after call HttpContext `fire` function

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -296,8 +296,8 @@ public class HttpContext<T> {
   private void fire(ClientPhase phase) {
     Objects.requireNonNull(phase);
     this.phase = phase;
+    this.interceptorIdx = 0;
     if (invoking) {
-      this.interceptorIdx = 0;
       this.invokeNext = true;
     } else {
       next();


### PR DESCRIPTION
Motivation:

Now the interceptor index is restarted only when any of the methods using `fire(ClientPhase phase)` are called from within the interceptor function `handle(X)`, but if `fire(ClientPhase phase)` is executed from outside the interceptor function `handle(X)` then the interceptors before the last executed interceptor and this interceptor itself are ignored for the new `phase`.

This change modifies the current logic to always reset the interceptor index.