### PR TITLE
WebClient: provide MalformedURLException cause when using requestAbs with invalid URL

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -15,15 +15,8 @@
  */
 package io.vertx.ext.web.client.impl;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -36,6 +29,11 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.impl.predicate.PredicateInterceptor;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -233,7 +231,7 @@ public class WebClientBase implements WebClientInternal {
     try {
       url = new URL(surl);
     } catch (MalformedURLException e) {
-      throw new VertxException("Invalid url: " + surl);
+      throw new VertxException("Invalid url: " + surl, e);
     }
     boolean ssl = false;
     int port = url.getPort();

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -27,12 +27,12 @@ import io.vertx.ext.web.multipart.MultipartForm;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.tls.Cert;
-
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
+import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
@@ -47,10 +47,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -1987,6 +1984,15 @@ public class WebClientTest extends WebClientTestBase {
     public WriteStream<Buffer> drainHandler(Handler<Void> handler) {
       drainHandler = handler;
       return this;
+    }
+  }
+
+  @Test
+  public void testMalformedURLExceptionNotSwallowed() {
+    try {
+      webClient.requestAbs(HttpMethod.POST, "blah://foo@bar");
+    } catch (VertxException e) {
+      assertThat(e.getCause(), instanceOf(MalformedURLException.class));
     }
   }
 }


### PR DESCRIPTION
See #1926

Troubleshooting will be simplified by creating the VertxException using the MalformedURLException cause.