### PR TITLE
Allow scopes in JWT just like in OAuth2

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
@@ -18,10 +18,10 @@ package io.vertx.ext.web.handler;
 
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.Handler;
 import io.vertx.ext.auth.jwt.JWTAuth;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.JWTAuthHandlerImpl;
+
+import java.util.List;
 
 /**
  * An auth handler that provides JWT Authentication support.
@@ -38,6 +38,46 @@ public interface JWTAuthHandler extends AuthenticationHandler {
    * @return the auth handler
    */
   static JWTAuthHandler create(JWTAuth authProvider) {
-    return new JWTAuthHandlerImpl(authProvider);
+    return create(authProvider, null);
   }
+
+  /**
+   * Create a JWT auth handler
+   *
+   * @param authProvider  the auth provider to use
+   * @return the auth handler
+   */
+  static JWTAuthHandler create(JWTAuth authProvider, String realm) {
+    return new JWTAuthHandlerImpl(authProvider, realm);
+  }
+
+  /**
+   * Return a new instance with the internal state copied from the caller but the scopes delimiter set
+   * to be unique to the instance.
+   *
+   * @param delimiter scope delimiter.
+   * @return new instance of this interface.
+   */
+  @Fluent
+  JWTAuthHandler scopeDelimiter(String delimiter);
+
+  /**
+   * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
+   * request are unique to the instance.
+   *
+   * @param scope scope.
+   * @return new instance of this interface.
+   */
+  @Fluent
+  JWTAuthHandler withScope(String scope);
+
+  /**
+   * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
+   * request are unique to the instance.
+   *
+   * @param scopes scopes.
+   * @return new instance of this interface.
+   */
+  @Fluent
+  JWTAuthHandler withScopes(List<String> scopes);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -19,20 +19,37 @@ package io.vertx.ext.web.handler.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.authentication.TokenCredentials;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BasicAuthHandler;
 import io.vertx.ext.web.handler.JWTAuthHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 public class JWTAuthHandlerImpl extends HTTPAuthorizationHandler<JWTAuth> implements JWTAuthHandler {
 
-  public JWTAuthHandlerImpl(JWTAuth authProvider) {
-    super(authProvider, Type.BEARER);
+  private final List<String> scopes;
+  private final String delimiter;
+
+  public JWTAuthHandlerImpl(JWTAuth authProvider, String realm) {
+    super(authProvider, Type.BEARER, realm);
+    scopes = new ArrayList<>();
+    this.delimiter  = " ";
+  }
+
+  private JWTAuthHandlerImpl(JWTAuthHandlerImpl base, List<String> scopes, String delimiter) {
+    super(base.authProvider, Type.BEARER, base.realm);
+    this.scopes = scopes;
+    this.delimiter = delimiter;
   }
 
   @Override
@@ -46,5 +63,58 @@ public class JWTAuthHandlerImpl extends HTTPAuthorizationHandler<JWTAuth> implem
 
       handler.handle(Future.succeededFuture(new TokenCredentials(parseAuthorization.result())));
     });
+  }
+
+  @Override
+  public JWTAuthHandler withScope(String scope) {
+    List<String> updatedScopes = new ArrayList<>(this.scopes);
+    updatedScopes.add(scope);
+    return new JWTAuthHandlerImpl(this, updatedScopes, delimiter);
+  }
+
+  @Override
+  public JWTAuthHandler withScopes(List<String> scopes) {
+    return new JWTAuthHandlerImpl(this, scopes, delimiter);
+  }
+
+  @Override
+  public JWTAuthHandler scopeDelimiter(String delimeter) {
+    return new JWTAuthHandlerImpl(this, scopes, delimeter);
+  }
+
+  /**
+   * The default behavior for post-authentication
+   */
+  @Override
+  public void postAuthentication(RoutingContext ctx) {
+    // the user is authenticated, however the user may not have all the required scopes
+    if (scopes.size() > 0) {
+      final JsonObject jwt = ctx.user().get("accessToken");
+      if (jwt == null) {
+        ctx.fail(403, new IllegalStateException("Invalid JWT: null"));
+        return;
+      }
+
+      if(jwt.getValue("scope") == null) {
+        ctx.fail(403, new IllegalStateException("Invalid JWT: scope claim is required"));
+        return;
+      }
+
+      List<?> target;
+      if (jwt.getValue("scope") instanceof String) {
+        target =
+          Stream.of(jwt.getString("scope")
+            .split(delimiter))
+            .collect(Collectors.toList());
+      } else {
+        target = jwt.getJsonArray("scope").getList();
+      }
+
+      if(target == null || !target.containsAll(scopes)) {
+        ctx.fail(403, new IllegalStateException("JWT scopes != handler scopes"));
+        return;
+      }
+    }
+    ctx.next();
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -54,6 +54,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
   private final MessageDigest sha256;
 
   private final List<String> scopes;
+  private final boolean openId;
   private JsonObject extraParams;
   private String prompt;
   private int pkce = -1;
@@ -82,6 +83,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
     }
     // scopes are empty by default
     this.scopes = new ArrayList<>();
+    this.openId = false;
   }
 
   private OAuth2AuthHandlerImpl(OAuth2AuthHandlerImpl base, List<String> scopes) {
@@ -104,6 +106,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
     }
     // apply the new scopes
     this.scopes = scopes;
+    this.openId = scopes != null && scopes.contains("openid");
   }
 
   @Override
@@ -417,10 +420,9 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
         if (scopes != null) {
           // user principal contains scope, a basic assertion is require to ensure that
           // the scopes present match the required ones
-          final boolean isOpenId = this.scopes.contains("openid");
           for (String scope : this.scopes) {
             // do not assert openid scopes if openid is active
-            if (isOpenId && OPENID_SCOPES.contains(scope)) {
+            if (openId && OPENID_SCOPES.contains(scope)) {
               continue;
             }
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

This completes the deprecation in auth, where JWT scopes are not expected to be used in that module + gets JWT Handler ready for OpenAPI 3.1