### PR TITLE
Remove redundant tech preview warning

### DIFF
--- a/vertx-web-graphql/src/main/asciidoc/index.adoc
+++ b/vertx-web-graphql/src/main/asciidoc/index.adoc
@@ -6,8 +6,6 @@ TIP: This is the reference documentation for Vert.x Web GraphQL.
 It is highly recommended to get familiar with the GraphQL-Java API first.
 You may start by reading the https://www.graphql-java.com/documentation/${graphql.java.doc.version}/[GraphQL-Java documentation].
 
-WARNING: This module has _Tech Preview_ status, this means the API can change between versions.
-
 == Getting started
 
 To use this module, add the following to the _dependencies_ section of your Maven POM file:


### PR DESCRIPTION
Signed-off-by: chengen.zhao@mail.mcgill.ca <chengen.zhao@mail.mcgill.ca>

Motivation:

Remove redundant tech preview warning apparently this module is not in tech preview status anymore 

previous pr:
https://github.com/vert-x3/vertx-web/pull/1941

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
