### PR TITLE
Improve memory efficiency of Handlers registration in RoutingContextImpl

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.ext.web.impl;
+
+/**
+ * Internal container which replaces the need for allocating
+ * expensive instances of TreeMap(s) of Integer,Handler tuples,
+ * which were being used for the sole purpose of reverse iteration
+ * on the registered handlers.
+ * This should be slightly more efficient in terms of memory
+ * pressure, including during the iteration process.
+ * Please do not reuse: this was specifically designed for a
+ * specific purpose and assumes a very dense data set.
+ *
+ * @param <H>
+ * @author Sanne Grinovero
+ */
+final class SparseArray<H> {
+
+  private Object[] elements;
+
+  void forEachInReverseOrder(final java.util.function.Consumer<H> action) {
+    if (elements != null) {
+      for (int i = elements.length - 1; i >= 0; i--) {
+        final Object element = elements[i];
+        if (element != null) {
+          action.accept((H) element);
+        }
+      }
+    }
+  }
+
+  void clear() {
+    elements = null;
+  }
+
+  void put(final int seq, final H handler) {
+    if (elements == null || seq >= elements.length) {
+      resizeToFit(seq);
+    }
+    elements[seq] = handler;
+  }
+
+  private void resizeToFit(final int seq) {
+    final int existingLength = elements == null ? 0 : elements.length;
+    //2,5,12.. seems like a reasonable scaling sequence for this use case:
+    //not many elements are expected, on the other hand we don't want to have
+    //to re-size the array frequently when we lose this bet.
+    //But also, always make sure to reach at least the value of seq.
+    if (existingLength != 0) {
+      final int targetLength = Math.max((seq + 1), ((existingLength + 1) * 2));
+      final Object[] newArray = new Object[targetLength];
+      System.arraycopy(elements, 0, newArray, 0, existingLength);
+      elements = newArray;
+    } else {
+      final int targetLength = Math.max((seq + 1), 2);
+      elements = new Object[targetLength];
+    }
+  }
+
+  H remove(final int handlerID) {
+    if (handlerID < elements.length) {
+      final H removed = (H) elements[handlerID];
+      elements[handlerID] = null;
+      return removed;
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
@@ -10,6 +10,8 @@
  */
 package io.vertx.ext.web.impl;
 
+import java.util.Arrays;
+
 /**
  * Internal container which replaces the need for allocating
  * expensive instances of TreeMap(s) of Integer,Handler tuples,
@@ -39,7 +41,9 @@ final class SparseArray<H> {
   }
 
   void clear() {
-    elements = null;
+    if (elements!=null) {
+      Arrays.fill(elements, null);
+    }
   }
 
   void put(final int seq, final H handler) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/SparseArray.java
@@ -55,12 +55,12 @@ final class SparseArray<H> {
 
   private void resizeToFit(final int seq) {
     final int existingLength = elements == null ? 0 : elements.length;
-    //2,5,12.. seems like a reasonable scaling sequence for this use case:
+    //2,4,8.. seems like a reasonable scaling sequence for this use case:
     //not many elements are expected, on the other hand we don't want to have
     //to re-size the array frequently when we lose this bet.
     //But also, always make sure to reach at least the value of seq.
     if (existingLength != 0) {
-      final int targetLength = Math.max((seq + 1), ((existingLength + 1) * 2));
+      final int targetLength = Math.max((seq + 1), (existingLength * 2));
       final Object[] newArray = new Object[targetLength];
       System.arraycopy(elements, 0, newArray, 0, existingLength);
       elements = newArray;

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/SparseArrayTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/SparseArrayTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.ext.web.impl;
+
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SparseArrayTest {
+
+  @Test
+  public void empty() {
+    CapturingConsumer c = new CapturingConsumer();
+    SparseArray m = new SparseArray();
+    m.clear();
+    m.forEachInReverseOrder(c);
+    Assert.assertEquals(0, c.acceptedInvocations);
+  }
+
+  @Test
+  public void one() {
+    CapturingConsumer c = new CapturingConsumer();
+    SparseArray m = new SparseArray();
+    m.clear();
+    m.forEachInReverseOrder(c);
+    Assert.assertEquals(0, c.acceptedInvocations);
+    Object objectSeven = new Object();
+    m.put(7, objectSeven);
+    m.forEachInReverseOrder(c);
+    Assert.assertEquals(1, c.acceptedInvocations);
+    Assert.assertEquals(objectSeven, c.accepted.get(0));
+  }
+
+  @Test
+  public void multi() {
+    SparseArray m = new SparseArray();
+
+    Object objectSeven = new Object();
+    m.put(7, objectSeven);
+
+    Object objectFour = new Object();
+    m.put(4, objectFour);
+
+    Object objectFive = new Object();
+    m.put(5, objectFive);
+
+    final Object removed = m.remove(5);
+    Assert.assertEquals(objectFive, removed);
+
+    CapturingConsumer c = new CapturingConsumer();
+    m.forEachInReverseOrder(c);
+    //Two invocations:
+    Assert.assertEquals(2, c.acceptedInvocations);
+    //In reversed index order:
+    Assert.assertEquals(objectSeven, c.accepted.get(0));
+    Assert.assertEquals(objectFour, c.accepted.get(1));
+
+    //Can iterate multiple times:
+    CapturingConsumer c2 = new CapturingConsumer();
+    m.forEachInReverseOrder(c2);
+    //Two invocations:
+    Assert.assertEquals(2, c2.acceptedInvocations);
+    //In reversed index order:
+    Assert.assertEquals(objectSeven, c2.accepted.get(0));
+    Assert.assertEquals(objectFour, c2.accepted.get(1));
+
+    m.clear();
+    //Post-clear iteration:
+    CapturingConsumer c3 = new CapturingConsumer();
+    m.forEachInReverseOrder(c3);
+    Assert.assertEquals(0, c3.acceptedInvocations);
+  }
+
+  private static class CapturingConsumer implements Consumer {
+
+    private ArrayList accepted = new ArrayList();
+    private int acceptedInvocations = 0;
+
+    @Override
+    public void accept(Object o) {
+      accepted.add(o);
+      acceptedInvocations++;
+    }
+  }
+
+}


### PR DESCRIPTION
Motivation:

I've noticed some easy and low risk optimisations by running Quarkus 2 previews with the Techempower benchmark;
specifically the use of an inverted sorted `TreeMap` using `Integer` as a key for the sole purpose of iterating the elements in inverse order.

`TreeMap`s aren't particularly efficient, and its internal bucket structure also comes with a cost on top of the obvious `int` wrapping; not least the used iteration required a copy (`values().forEach`)

I don't have much experience with the HTTP layer, but I'm having the impression that this code is also expecting a "dense map", which made me suspect a simple array could be used, at cost of using a sparse array in case of gaps.

Verified with the benchmark, this seems effective; I'm noticing about ~4% less memory being allocated during the "plaintext" benchmark.

I have not tried different scaling sequences (see  method "IntMap#resizeToFit"), I suppose this could be further optimised if you have better familiarity of the expected numbers and possible use cases - but this first shot seemed effective, at least in this trivial benchmark.