### PR TITLE
add test for @Fluent and for Future<ServiceResponse>

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyMethodInfo.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyMethodInfo.java
@@ -21,8 +21,9 @@ public class WebApiProxyMethodInfo extends ProxyMethodInfo {
 
   public WebApiProxyMethodInfo(Set<ClassTypeInfo> ownerTypes, String name, TypeInfo returnType, Text returnDescription, boolean fluent, boolean cacheReturn, List<ParamInfo> params, String comment, Doc doc, boolean staticMethod, boolean defaultMethod, List<TypeParamInfo.Method> typeParams, boolean proxyIgnore, boolean proxyClose, boolean deprecated, Text deprecatedDesc, boolean useFutures) {
     super(ownerTypes, name, returnType, returnDescription, fluent, cacheReturn, params, comment, doc, staticMethod, defaultMethod, typeParams, proxyIgnore, proxyClose, deprecated, deprecatedDesc, useFutures);
-    paramsToExtract = params.subList(0, params.size() - 2);
-    requestContextName = params.get(params.size() - 2).getName();
+    final int truncateParamsToIndex = useFutures ? 1 : 2;
+    paramsToExtract = params.subList(0, params.size() - truncateParamsToIndex);
+    requestContextName = params.get(params.size() - truncateParamsToIndex).getName();
   }
 
   public WebApiProxyMethodInfo(ProxyMethodInfo info) {

--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyModel.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyModel.java
@@ -27,7 +27,7 @@ public class WebApiProxyModel extends ProxyModel {
 
   private static final String SIGNATURE_CONSTRAINT_ERROR = "Method must respect signature Future<io.vertx.ext.web.api.ServiceResponse> foo(extractedParams..., io.vertx.ext.web.api.ServiceRequest request) or foo(extractedParams..., io.vertx.ext.web.api.ServiceRequest request, Handler<AsyncResult<io.vertx.ext.web.api.ServiceResponse>> handler)";
 
-  public WebApiProxyModel(ProcessingEnvironment env, TypeMirrorFactory typeFactory,TypeElement modelElt) {
+  public WebApiProxyModel(ProcessingEnvironment env, TypeMirrorFactory typeFactory, TypeElement modelElt) {
     super(env, typeFactory, modelElt);
   }
 
@@ -51,7 +51,9 @@ public class WebApiProxyModel extends ProxyModel {
       // Check signature constraints
 
       TypeInfo ret;
-      if (baseInfo.getKind() == MethodKind.CALLBACK) {
+      if (baseInfo.getKind() == MethodKind.FUTURE && baseInfo.isUseFutures()) {
+        ret = ((ParameterizedTypeInfo)returnType).getArg(0);
+      } else if (baseInfo.getKind() == MethodKind.CALLBACK && !baseInfo.isUseFutures()) {
         ret = ((ParameterizedTypeInfo) ((ParameterizedTypeInfo) mParams.get(mParams.size() - 1).getType()).getArg(0)).getArg(0);
       } else {
         throw new GenException(methodElt, SIGNATURE_CONSTRAINT_ERROR);

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/FuturesService.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/FuturesService.java
@@ -1,0 +1,17 @@
+package io.vertx.ext.web.api.service.futures;
+
+import io.vertx.core.Future;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.api.service.WebApiServiceGen;
+import io.vertx.ext.web.validation.RequestParameter;
+
+@WebApiServiceGen
+public interface FuturesService {
+
+  Future<ServiceResponse> testFutureWithRequestParameter(RequestParameter param, ServiceRequest context);
+
+  Future<ServiceResponse> testFutureWithIntParameter(int param, ServiceRequest context);
+
+  Future<ServiceResponse> testFuture(ServiceRequest context);
+}

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/FuturesServiceImpl.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/FuturesServiceImpl.java
@@ -1,0 +1,25 @@
+package io.vertx.ext.web.api.service.futures;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.validation.RequestParameter;
+
+public class FuturesServiceImpl implements FuturesService {
+
+  @Override
+  public Future<ServiceResponse> testFutureWithRequestParameter(final RequestParameter param, final ServiceRequest context) {
+    return Future.succeededFuture(ServiceResponse.completedWithJson(new JsonObject().put("param", param.getInteger())));
+  }
+
+  @Override
+  public Future<ServiceResponse> testFutureWithIntParameter(final int param, final ServiceRequest context) {
+    return Future.succeededFuture(ServiceResponse.completedWithJson(new JsonObject().put("param", param)));
+  }
+
+  @Override
+  public Future<ServiceResponse> testFuture(final ServiceRequest context) {
+    return Future.succeededFuture(ServiceResponse.completedWithJson(new JsonObject().put("foo", "bar")));
+  }
+}

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/RouteToEBServiceFuturesHandlerTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/RouteToEBServiceFuturesHandlerTest.java
@@ -1,0 +1,97 @@
+package io.vertx.ext.web.api.service.futures;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.api.service.RouteToEBServiceHandler;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.validation.BaseValidationHandlerTest;
+import io.vertx.ext.web.validation.ValidationHandler;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.serviceproxy.ServiceBinder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static io.vertx.ext.web.validation.builder.Parameters.param;
+import static io.vertx.ext.web.validation.testutils.TestRequest.*;
+import static io.vertx.json.schema.draft7.dsl.Schemas.intSchema;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(VertxExtension.class)
+public class RouteToEBServiceFuturesHandlerTest extends BaseValidationHandlerTest {
+
+  MessageConsumer<JsonObject> consumer;
+
+  @AfterEach
+  public void tearDown() {
+    if (consumer != null) consumer.unregister();
+  }
+
+  @Test
+  public void serviceProxyTypedTestWithRequestParameter(final Vertx vertx, final VertxTestContext testContext) {
+    final Checkpoint checkpoint = testContext.checkpoint();
+
+    final FuturesService service = new FuturesServiceImpl();
+    final ServiceBinder serviceBinder = new ServiceBinder(vertx).setAddress("someAddress");
+    consumer = serviceBinder.register(FuturesService.class, service);
+
+    router
+      .post("/testFutureWithRequestParameter/:param")
+      .handler(BodyHandler.create())
+      .handler(ValidationHandler.builder(parser).pathParameter(param("param", intSchema())).build())
+      .handler(
+        RouteToEBServiceHandler.build(vertx.eventBus(), "someAddress", "testFutureWithRequestParameter"));
+
+    testRequest(client, HttpMethod.POST, "/testFutureWithRequestParameter/123")
+      .expect(statusCode(200), statusMessage("OK"))
+      .expect(jsonBodyResponse(new JsonObject().put("param", 123)))
+      .send(testContext, checkpoint);
+  }
+
+  @Test
+  public void serviceProxyTypedTestWithIntParameter(final Vertx vertx, final VertxTestContext testContext) {
+    final Checkpoint checkpoint = testContext.checkpoint();
+
+    final FuturesService service = new FuturesServiceImpl();
+    final ServiceBinder serviceBinder = new ServiceBinder(vertx).setAddress("someAddress");
+    consumer = serviceBinder.register(FuturesService.class, service);
+
+    router
+      .post("/testFutureWithIntParameter/:param")
+      .handler(BodyHandler.create())
+      .handler(ValidationHandler.builder(parser).pathParameter(param("param", intSchema())).build())
+      .handler(
+        RouteToEBServiceHandler.build(vertx.eventBus(), "someAddress", "testFutureWithIntParameter"));
+
+    testRequest(client, HttpMethod.POST, "/testFutureWithIntParameter/123")
+      .expect(statusCode(200), statusMessage("OK"))
+      .expect(jsonBodyResponse(new JsonObject().put("param", 123)))
+      .send(testContext, checkpoint);
+  }
+
+  @Test
+  public void serviceProxyTypedTest(final Vertx vertx, final VertxTestContext testContext) {
+    final Checkpoint checkpoint = testContext.checkpoint();
+
+    final FuturesService service = new FuturesServiceImpl();
+    final ServiceBinder serviceBinder = new ServiceBinder(vertx).setAddress("someAddress");
+    consumer = serviceBinder.register(FuturesService.class, service);
+
+    router
+      .post("/testFuture")
+      .handler(BodyHandler.create())
+      .handler(ValidationHandler.builder(parser).build())
+      .handler(
+        RouteToEBServiceHandler.build(vertx.eventBus(), "someAddress", "testFuture"));
+
+    testRequest(client, HttpMethod.POST, "/testFuture")
+      .expect(statusCode(200), statusMessage("OK"))
+      .expect(jsonBodyResponse(new JsonObject().put("foo", "bar")))
+      .send(testContext, checkpoint);
+  }
+
+}

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/package-info.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/futures/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "dummy", groupPackage = "io.vertx.ext.web.api.service.futures", useFutures = true)
+package io.vertx.ext.web.api.service.futures;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/WebApiServiceHandlerTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/WebApiServiceHandlerTest.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.GenException;
 import io.vertx.ext.web.api.service.WebApiServiceGen;
 import io.vertx.ext.web.api.service.generator.model.WebApiProxyModel;
 import io.vertx.ext.web.api.service.generator.models.*;
+import io.vertx.ext.web.api.service.generator.models.futures.ValidWebApiProxyWithFutures;
 import io.vertx.test.codegen.GeneratorHelper;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,13 @@ public class WebApiServiceHandlerTest {
 
   public WebApiProxyModel generateWebApiProxyModel(Class c, Class... rest) throws Exception {
     return new GeneratorHelper().generateClass(codegen -> (WebApiProxyModel) codegen.getModel(c.getCanonicalName(), "webapi_proxy"), WebApiServiceGen.class, c, rest);
+  }
+
+  @Test
+  public void testValidWithFutures() throws Exception {
+    final WebApiProxyModel model = generateWebApiProxyModel(ValidWebApiProxyWithFutures.class);
+    assertEquals(ValidWebApiProxyWithFutures.class.getName(), model.getIfaceFQCN());
+    assertEquals(ValidWebApiProxyWithFutures.class.getSimpleName(), model.getIfaceSimpleName());
   }
 
   @Test

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/models/futures/ValidWebApiProxyWithFutures.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/models/futures/ValidWebApiProxyWithFutures.java
@@ -1,0 +1,17 @@
+package io.vertx.ext.web.api.service.generator.models.futures;
+
+import io.vertx.core.Future;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.api.service.WebApiServiceGen;
+import io.vertx.ext.web.validation.RequestParameter;
+
+@WebApiServiceGen
+public interface ValidWebApiProxyWithFutures {
+
+  Future<ServiceResponse> testFutureWithRequestParameter(RequestParameter param, ServiceRequest context);
+
+  Future<ServiceResponse> testFutureWithParam(String param, ServiceRequest context);
+
+  Future<ServiceResponse> testFuture(ServiceRequest context);
+}

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/models/futures/package-info.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/generator/models/futures/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "dummy", groupPackage = "io.vertx.ext.web.api.service.generator.models.futures", useFutures = true)
+package io.vertx.ext.web.api.service.generator.models.futures;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
https://github.com/vert-x3/vertx-web/issues/1948

Motivation:

Add unit test for Furutre<ServiceResponse> proxy methods, fix return-type and parameter checking for same.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
