### PR TITLE
Fix template engines shaded artifact generation

### DIFF
--- a/vertx-template-engines/pom.xml
+++ b/vertx-template-engines/pom.xml
@@ -49,9 +49,11 @@
                 <shadedClassifierName>shaded</shadedClassifierName>
                 <artifactSet>
                   <excludes>
-                    <exclude>io.vertx:*</exclude>
+                    <exclude>io.vertx:vertx-core</exclude>
+                    <exclude>io.vertx:vertx-web-common</exclude>
                     <exclude>io.netty:*</exclude>
                     <exclude>com.fasterxml.jackson.core:jackson-core:*</exclude>
+                    <exclude>org.slf4j:*</exclude>
                   </excludes>
                 </artifactSet>
               </configuration>


### PR DESCRIPTION
Fixes #1952

- Vert.x API of template engine missing (because all io.vertx artifacts were excluded)
- SLF4J included in shaded JAR