### PR TITLE
Allow exact path patterns to have a trailing slash

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -344,6 +344,8 @@ public class RouteImpl implements Route {
       index++;
     }
     m.appendTail(sb);
+    if (state.isExactPath() && !state.isPathEndsWithSlash())
+    	sb.append("/?");
     path = sb.toString();
 
     state = state.setGroups(groups);


### PR DESCRIPTION
Mimic the behavior of `RouteState.pathMatchesExact()` that allows a route with an exact path without a trailing slash but where the route's trailing slash is insignificant to ignore a trailing slash in the request's path.

Motivation:
Fixes issue #786 as per [Paulo Lopes comment](https://github.com/vert-x3/vertx-web/issues/786#issuecomment-371621042)

Conformance:

ECA was signed.
