### PR TITLE
Update CSRF session data on non GET, othwerwise tokens will never mat…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
@@ -130,6 +130,14 @@ public class CSRFHandlerImpl implements CSRFHandler {
         // it's not an option to change the same site policy
         .setSameSite(CookieSameSite.STRICT));
 
+    Session session = ctx.session();
+
+    if (session != null) {
+      // storing will include the session id too. The reason is that if a session is upgraded
+      // we don't want to allow the token to be valid anymore
+      session.put(headerName, session.id() + "/" + token);
+    }
+
     return token;
   }
 
@@ -340,9 +348,6 @@ public class CSRFHandlerImpl implements CSRFHandler {
           // create a new token, but we also store it in the session for the next runs
           if (sessionToken == null) {
             token = generateAndStoreToken(ctx);
-            // storing will include the session id too. The reason is that if a session is upgraded
-            // we don't want to allow the token to be valid anymore
-            session.put(headerName, session.id() + "/" + token);
           } else {
             String[] parts = sessionToken.split("\\.");
             final long ts = parseLong(parts[1]);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ErrorHandlerImpl.java
@@ -67,8 +67,8 @@ public class ErrorHandlerImpl implements ErrorHandler {
     if (response.headWritten()) {
       // response is already being processed, so we can't really
       // format the error as a "pretty print" message
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Unexpected error on route", failure);
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("Response headers are already written", failure);
       }
 
       try {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -178,6 +178,9 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public void fail(int statusCode, Throwable throwable) {
     this.statusCode = statusCode;
     this.failure = throwable == null ? new NullPointerException() : throwable;
+    if (LOG.isInfoEnabled()) {
+      LOG.info("RoutingContext failure (" + statusCode + ")", failure);
+    }
     doFail();
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -196,13 +196,13 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
     }
   }
 
-
   protected void unhandledFailure(int statusCode, Throwable failure, RouterImpl router) {
     int code = statusCode != -1 ?
       statusCode :
       (failure instanceof HttpException) ?
         ((HttpException) failure).getStatusCode() :
         500;
+
     Handler<RoutingContext> errorHandler = router.getErrorHandlerByStatusCode(code);
     if (errorHandler != null) {
       try {
@@ -211,6 +211,7 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
         LOG.error("Error in error handler", t);
       }
     }
+
     if (!response().ended() && !response().closed()) {
       try {
         response().setStatusCode(code);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CSRFHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CSRFHandlerTest.java
@@ -98,7 +98,7 @@ public class CSRFHandlerTest extends WebTestBase {
     router.route().handler(rc -> rc.response().end());
 
     testRequest(HttpMethod.POST, "/", req -> req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME,
-        "4CYp9vQsr2VSQEsi/oVsMu35Ho9TlR0EovcYovlbiBw=.1437037602082.41jwU0FPl/n7ZNZAZEA07GyIUnpKSTKQ8Eju7Nicb34="), null, 403, "Forbidden", null);
+      "4CYp9vQsr2VSQEsi/oVsMu35Ho9TlR0EovcYovlbiBw=.1437037602082.41jwU0FPl/n7ZNZAZEA07GyIUnpKSTKQ8Eju7Nicb34="), null, 403, "Forbidden", null);
   }
 
   @Test
@@ -121,7 +121,7 @@ public class CSRFHandlerTest extends WebTestBase {
       String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
       Buffer buffer = Buffer.buffer();
       String str =
-          "--" + boundary + "\r\n" +
+        "--" + boundary + "\r\n" +
           "Content-Disposition: form-data; name=\"" + CSRFHandler.DEFAULT_HEADER_NAME + "\"\r\n\r\n" + tmpCookie + "\r\n" +
           "--" + boundary + "--\r\n";
       buffer.appendString(str);
@@ -170,9 +170,9 @@ public class CSRFHandlerTest extends WebTestBase {
       String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
       Buffer buffer = Buffer.buffer();
       String str =
-          "--" + boundary + "\r\n" +
-              "Content-Disposition: form-data; name=\"" + CSRFHandler.DEFAULT_HEADER_NAME + "\"\r\n\r\n" + tmpCookie + "\r\n" +
-              "--" + boundary + "--\r\n";
+        "--" + boundary + "\r\n" +
+          "Content-Disposition: form-data; name=\"" + CSRFHandler.DEFAULT_HEADER_NAME + "\"\r\n\r\n" + tmpCookie + "\r\n" +
+          "--" + boundary + "--\r\n";
       buffer.appendString(str);
       req.headers().set("content-length", String.valueOf(buffer.length()));
       req.headers().set("content-type", "multipart/form-data; boundary=" + boundary);
@@ -337,6 +337,7 @@ public class CSRFHandlerTest extends WebTestBase {
 
     final AtomicReference<String> cookieJar = new AtomicReference<>();
 
+    //router.route().handler(BodyHandler.create());
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
     router.route().handler(CSRFHandler.create(vertx, "Abracadabra"));
     router.route().handler(rc -> rc.response().end());
@@ -390,6 +391,65 @@ public class CSRFHandlerTest extends WebTestBase {
       req.putHeader("cookie", cookieJar.get());
       req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME, tmpCookie);
     }, null, 200, "OK", null);
+    // third POST should not be fine (as the token cannot be reused
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.putHeader("cookie", cookieJar.get());
+      req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME, tmpCookie);
+    }, null, 403, "Forbidden", null);
+  }
 
+  @Test
+  public void testPostAfterPostNoState() throws Exception {
+
+    final AtomicReference<String> cookieJar = new AtomicReference<>();
+
+    router.route().handler(BodyHandler.create());
+    router.route().handler(CSRFHandler.create(vertx, "Abracadabra"));
+    router.route().handler(rc -> rc.response().end());
+
+    testRequest(HttpMethod.GET, "/", null, resp -> {
+      List<String> cookies = resp.headers().getAll("set-cookie");
+      assertEquals(1, cookies.size());
+      String encodedCookie;
+      // save the cookie
+      encodedCookie = cookies.get(0).substring(0, cookies.get(0).indexOf(';'));
+      tmpCookie = cookies.get(0).substring(cookies.get(0).indexOf('=') + 1, cookies.get(0).indexOf(';'));
+      cookieJar.set(encodedCookie);
+    }, 200, "OK", null);
+
+    // POST shall be OK as the token is on the session
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.putHeader("cookie", cookieJar.get());
+      req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME, tmpCookie);
+    }, resp -> {
+      // re-extract the new cookie
+      List<String> cookies = resp.headers().getAll("set-cookie");
+      // only the XSRF cookie is updated
+      assertEquals(1, cookies.size());
+      String encodedCookie = "";
+      // save the cookie
+      for (String cookie : cookieJar.get().split(";")) {
+        cookie = cookie.trim();
+        if ("".equals(cookie)) {
+          continue;
+        }
+        if (cookie.startsWith(CSRFHandler.DEFAULT_COOKIE_NAME)) {
+          // replace with new one
+          tmpCookie = cookies.get(0).substring(cookies.get(0).indexOf('=') + 1, cookies.get(0).indexOf(';'));
+          encodedCookie += CSRFHandler.DEFAULT_COOKIE_NAME + "=" + tmpCookie;
+        } else {
+          encodedCookie += cookie;
+        }
+        encodedCookie += "; ";
+      }
+      // cookies must be different now
+      assertFalse(cookieJar.get().equals(encodedCookie));
+      cookieJar.set(encodedCookie);
+    }, 200, "OK", null);
+    // second POST should be fine
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.putHeader("cookie", cookieJar.get());
+      req.putHeader(CSRFHandler.DEFAULT_HEADER_NAME, tmpCookie);
+    }, null, 200, "OK", null);
   }
 }


### PR DESCRIPTION
…ch if a requests don't interleave GET/POST

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

when working with CSRF, the token updates are only propagated to the session store if a request is a GET, when they should always be propagated.