### PR TITLE
Issue-1966 : Making the method "processException" back to protected

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthenticationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthenticationHandlerImpl.java
@@ -96,7 +96,7 @@ public abstract class AuthenticationHandlerImpl<T extends AuthenticationProvider
    * This method is protected so custom auth handlers can override the default
    * error handling
    */
-  private void processException(RoutingContext ctx, Throwable exception) {
+  protected void processException(RoutingContext ctx, Throwable exception) {
     if (exception != null) {
       if (exception instanceof HttpException) {
         final int statusCode = ((HttpException) exception).getStatusCode();


### PR DESCRIPTION
Motivation:

As stated in issue https://github.com/vert-x3/vertx-web/issues/1966 we needed to change back to "protected" the visibility of the `processException` method.

Change method visbility for `AuthenticationHandlerImpl#processException`
