### PR TITLE
[documentation] Updated GraphiQL localhost URL

### DIFF
--- a/vertx-web-graphql/src/main/asciidoc/index.adoc
+++ b/vertx-web-graphql/src/main/asciidoc/index.adoc
@@ -70,7 +70,7 @@ To do so, create a route for GraphiQL resources and a {@link io.vertx.ext.web.ha
 {@link examples.GraphQLExamples#handlerSetupGraphiQL}
 ----
 
-Then browse to http://localhost:8080/graphiql/.
+Then browse to http://localhost:8080/graphiql/index.html
 
 NOTE: The GraphiQL user interface is disabled by default for security reasons.
 This is why you must configure the {@link io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions} to enable it.


### PR DESCRIPTION
Previous URL was leading to `http://localhost:8080/graphiql` which rendered as white page in web browser (as there were `404`s for static resources).

**Proof**:

```kotlin
val graphiQLHandlerOptions: GraphiQLHandlerOptions = graphiQLHandlerOptionsOf(
      enabled = true,
      graphQLUri = "/graphql"
)
router.route("/graphiql/*").handler(GraphiQLHandler.create(graphiQLHandlerOptions))
```

![Screenshot 2021-06-24 at 10 13 13](https://user-images.githubusercontent.com/16356036/123227785-365b2e80-d4d5-11eb-9c8f-77948d20c802.png)

I've done some research, and cause of `404`s can be found in `GraphiQLHandlerImpl` class:

```kotlin
@Override
public void handle(RoutingContext rc) {
  String filename = Utils.pathOffset(rc.normalizedPath(), rc);
  ...
  if ("/".equals(filename) || "/index.html".equals(filename)) {
  ...
  } else {
    staticHandler.handle(rc);
  }
}
```

When you're using `http://localhost:8080/graphiql` path, `handle` function is invoked only once (with `"/"` filename). But when you're using `http://localhost:8080/graphiql/index.html` path, `handle` function is invoked for all static resources (and `staticHandler` handles them properly). 

Reason for this handling difference is caused by missing `graphiql` prefix in URLs from browser:

`http://localhost:8080/graphiql`
![Screenshot 2021-06-24 at 10 43 39](https://user-images.githubusercontent.com/16356036/123232407-6c9aad00-d4d9-11eb-9cd8-96b2d3950055.png)

vs

`http://localhost:8080/graphiql/index.html`
![Screenshot 2021-06-24 at 10 44 20](https://user-images.githubusercontent.com/16356036/123232449-74f2e800-d4d9-11eb-8865-a24594fcde19.png)

But I don't have enough knowledge to fix this, so I've just updated documentation with working URL 😄 
