### PR TITLE
routing context fail logging to debug

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -178,8 +178,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public void fail(int statusCode, Throwable throwable) {
     this.statusCode = statusCode;
     this.failure = throwable == null ? new NullPointerException() : throwable;
-    if (LOG.isInfoEnabled()) {
-      LOG.info("RoutingContext failure (" + statusCode + ")", failure);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("RoutingContext failure (" + statusCode + ")", failure);
     }
     doFail();
   }


### PR DESCRIPTION
Motivation:

in a recent commit logging on INFO was added to RoutingContext  ` public void fail(int statusCode, Throwable throwable)` which is also called from `public void fail(Throwable t) `
see: https://github.com/vert-x3/vertx-web/commit/1fc3000071ac5e11d52e137742324e6042211ebe

IMHO this should be debug logging only and VertX users should handle failures in FailureHandlers added to the route as they see fit. 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
