### PR TITLE
Retain unmodified OpenAPI JsonObject in OpenAPIHolderImpl

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
@@ -76,7 +76,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
       })
       .compose(openapi -> {
         absolutePaths.put(initialScope, openapi); // Circular refs hell!
-        openapiRoot = openapi;
+        openapiRoot = openapi.copy();
         return walkAndSolve(openapi, initialScope).map(openapi);
       })
       .compose(openapi -> {

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
@@ -224,6 +224,20 @@ public class OpenAPIHolderTest {
                 "src/test/resources/yaml/valid/local_refs.yaml#/components/schemas/Simple"
               ).toString());
 
+            // Verify the OpenAPI object stored by the OpenAPIHolder retains local refs.
+            assertThat(loader.getOpenAPI())
+              .extracting(JsonPointer.create()
+                .append("paths")
+                .append("/simple")
+                .append("post")
+                .append("requestBody")
+                .append("content")
+                .append("multipart/form-data")
+                .append("schema")
+                .append("$ref")
+              )
+              .isEqualTo("#/components/schemas/Simple");
+
             assertThat(loader)
               .hasCached(resolveAbsoluteURIFromFS("src/test/resources/yaml/valid/refs/Simple.yaml"));
 
@@ -645,7 +659,7 @@ public class OpenAPIHolderTest {
         )).append(Arrays.asList(
           "paths", "/test8", "post", "requestBody", "content", "application/json", "schema"
         ));
-        JsonObject resolved = (JsonObject) schemaPointer.query(loader.getOpenAPI(),
+        JsonObject resolved = (JsonObject) schemaPointer.query(l.result(),
           new JsonPointerIteratorWithLoader(loader));
 
         Map<JsonPointer, JsonObject> additionalSchemasToRegister = new HashMap<>();


### PR DESCRIPTION
Create a copy of the JsonObject before making modifications/updating `$ref` values. Fixes #1996 .

Motivation:

As described in #1996, the OpenAPILoadImpl current replaces `$ref`s with absolute file paths. The resulting OpenAPI is not suitable for hosting when using the contract endpoint option (`io.vertx.ext.web.openapi.RouterBuilderOptions#setContractEndpoint`). This change retains the unmodified OpenAPI JsonObject within the `OpenAPIHolderImpl` for retrieval via `getOpenAPI`, which is the source utilized by `ContractEndpointHandler`, activated when setting a contract endpoint to a non-null path.
