### PR TITLE
backport routing context fail logging to debug (https://github.com/vert-x3/vertx-web/pull/1994)

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -178,8 +178,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public void fail(int statusCode, Throwable throwable) {
     this.statusCode = statusCode;
     this.failure = throwable == null ? new NullPointerException() : throwable;
-    if (LOG.isInfoEnabled()) {
-      LOG.info("RoutingContext failure (" + statusCode + ")", failure);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("RoutingContext failure (" + statusCode + ")", failure);
     }
     doFail();
   }


### PR DESCRIPTION
Motivation:

backport of [this PR](https://github.com/vert-x3/vertx-web/pull/1994) in case there is a 4.1.3
@pmlopes


Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
