### PR TITLE
[graphql] support an initialValue param as execution root

### DIFF
--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLQuery.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLQuery.java
@@ -28,18 +28,25 @@ public class GraphQLQuery implements GraphQLInput {
   private String query;
   private String operationName;
   private Map<String, Object> variables;
+  private Object initialValue;
 
   public GraphQLQuery(JsonObject value) {
     query = value.getString("query");
     operationName = value.getString("operationName");
     JsonObject vars = value.getJsonObject("variables");
     this.variables = vars != null ? vars.getMap() : null;
+    this.initialValue = value.getValue("initialValue");
   }
 
   public GraphQLQuery(String query, String operationName, Map<String, Object> variables) {
     this.query = query;
     this.operationName = operationName;
     this.variables = variables;
+  }
+
+  public GraphQLQuery(String query, String operationName, Map<String, Object> variables, Object initialValue) {
+    this(query, operationName, variables);
+    this.initialValue = initialValue;
   }
 
   public String getQuery() {
@@ -66,6 +73,15 @@ public class GraphQLQuery implements GraphQLInput {
 
   public GraphQLQuery setVariables(Map<String, Object> variables) {
     this.variables = variables;
+    return this;
+  }
+
+  public Object getInitialValue() {
+    return initialValue;
+  }
+
+  public GraphQLQuery setInitialValue(Object initialValue) {
+    this.initialValue = initialValue;
     return this;
   }
 

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GetRequestsTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GetRequestsTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.handler.graphql;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 import java.util.List;
@@ -78,6 +79,41 @@ public class GetRequestsTest extends GraphQLTestBase {
         .filter(url -> url.startsWith("https://"))
         .collect(toList());
       if (testData.checkLinkUrls(expected, body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimpleGetWithInitialValue() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setGraphQLQuery("query { allLinks { description } }")
+      .setInitialValueAsParam(true)
+      .setInitialValue("100");
+    request.send(client, onSuccess(body -> {
+      String[] descriptions = new String[testData.links.size()];
+      Arrays.fill(descriptions,"100");
+      List<String> expected = Arrays.asList(descriptions);
+      if (testData.checkLinkDescriptions(expected, body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimpleGetNoInitialValue() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setMethod(GET)
+      .setGraphQLQuery("query { allLinks { description } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkDescriptions(testData.descriptions(), body)) {
         testComplete();
       } else {
         fail(body.toString());

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLRequest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLRequest.java
@@ -22,6 +22,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
 import java.io.UnsupportedEncodingException;
@@ -52,6 +53,8 @@ public class GraphQLRequest {
   private String contentType = JSON;
   private Buffer requestBody;
   private String locale;
+  private boolean initialValueAsParam;
+  private Object initialValue;
 
   GraphQLRequest setMethod(HttpMethod method) {
     this.method = method;
@@ -113,6 +116,16 @@ public class GraphQLRequest {
 
   GraphQLRequest setLocale(String locale) {
     this.locale = locale;
+    return this;
+  }
+
+  GraphQLRequest setInitialValueAsParam(boolean initialValueAsParam) {
+    this.initialValueAsParam = initialValueAsParam;
+    return this;
+  }
+
+  GraphQLRequest setInitialValue(Object initialValue) {
+    this.initialValue = initialValue;
     return this;
   }
 
@@ -181,6 +194,9 @@ public class GraphQLRequest {
     if (variablesAsParam && !variables.isEmpty()) {
       params.put("variables", variables.toString());
     }
+    if (initialValueAsParam && initialValue != null) {
+      params.put("initialValue", Json.encode(initialValue));
+    }
     if (!params.isEmpty()) {
       uri.append("?");
       uri.append(params.entrySet().stream()
@@ -205,6 +221,9 @@ public class GraphQLRequest {
     }
     if (!variables.isEmpty()) {
       json.put("variables", variables);
+    }
+    if (initialValue != null) {
+      json.put("initialValue", Json.encode(initialValue));
     }
     return json.isEmpty() ? null : json.toBuffer();
   }

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLTestBase.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/GraphQLTestBase.java
@@ -70,6 +70,13 @@ public class GraphQLTestBase extends WebTestBase {
     boolean secureOnly = env.getArgument("secureOnly");
     return testData.links.stream()
       .filter(link -> !secureOnly || link.getUrl().startsWith("https://"))
+      .map(link -> {
+        if (env.getRoot() != null) {
+          return new Link(link.getUrl(), env.getRoot().toString(), link.getUserId());
+        } else {
+          return link;
+        }
+      })
       .collect(toList());
   }
 }

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/PostRequestsTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/PostRequestsTest.java
@@ -21,6 +21,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
 import org.junit.Test;
 
 import java.util.List;
@@ -125,6 +126,57 @@ public class PostRequestsTest extends GraphQLTestBase {
         .filter(url -> url.startsWith("https://"))
         .collect(toList());
       if (testData.checkLinkUrls(expected, body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimplePostWithInitialValueInParam() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setGraphQLQuery("query { allLinks { description } }")
+      .setInitialValue(12345)
+      .setInitialValueAsParam(true);
+    request.send(client, onSuccess(body -> {
+      String[] values = new String[testData.links.size()];
+      Arrays.fill(values, "12345");
+      List<String> expected = Arrays.asList(values);
+      if (testData.checkLinkDescriptions(expected, body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimplePostWithInitialValue() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setGraphQLQuery("query { allLinks { description } }")
+      .setInitialValue(12345);
+    request.send(client, onSuccess(body -> {
+      String[] values = new String[testData.links.size()];
+      Arrays.fill(values, "12345");
+      List<String> expected = Arrays.asList(values);
+      if (testData.checkLinkDescriptions(expected, body)) {
+        testComplete();
+      } else {
+        fail(body.toString());
+      }
+    }));
+    await();
+  }
+
+  @Test
+  public void testSimplePostWithNoInitialValue() throws Exception {
+    GraphQLRequest request = new GraphQLRequest()
+      .setGraphQLQuery("query { allLinks { description } }");
+    request.send(client, onSuccess(body -> {
+      if (testData.checkLinkDescriptions(testData.descriptions(), body)) {
         testComplete();
       } else {
         fail(body.toString());

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/TestData.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/TestData.java
@@ -50,6 +50,10 @@ public class TestData {
     return links.stream().map(Link::getUrl).collect(toList());
   }
 
+  List<String> descriptions() {
+    return links.stream().map(Link::getDescription).collect(toList());
+  }
+
   boolean checkLinkUrls(List<String> expected, JsonObject body) {
     if (body.containsKey("errors")) {
       return false;
@@ -60,6 +64,18 @@ public class TestData {
       .map(json -> json.getString("url"))
       .collect(toList());
     return expected.equals(urls);
+  }
+
+  boolean checkLinkDescriptions(List<String> expected, JsonObject body) {
+    if (body.containsKey("errors")) {
+      return false;
+    }
+    JsonObject data = body.getJsonObject("data");
+    List<String> descriptions = data.getJsonArray("allLinks").stream()
+      .map(JsonObject.class::cast)
+      .map(json -> json.getString("description"))
+      .collect(toList());
+    return expected.equals(descriptions);
   }
 
   List<String> posters() {


### PR DESCRIPTION
Motivation:

The GraphQL spec documents the execution methods, or more specifically the field execution, as accepting an `initialValue` to be used to resolve the field value. In graphql-java, this initialValue is represented by the `root` field on the `ExecutionInput`. Currently, there is no way to get anything into the `root` field on the execution input with the GraphQL handler.

This can be particularly useful in the case of subscriptions, where the event triggering a subscription resolution may contain data that should be included in the results.

`ExecuteRequest` reference: [link](https://spec.graphql.org/June2018/#ExecuteRequest())
`ExecuteSubscriptionEvent` reference: [link](https://spec.graphql.org/June2018/#ExecuteSubscriptionEvent())

both of those methods pass `initialValue` into the `objectValue` parameter of `ExecuteSelectionSet`

`ExecuteSelectionSet` reference: [link](https://spec.graphql.org/June2018/#ExecuteSelectionSet())
`ExecuteField` reference: [link](https://spec.graphql.org/June2018/#sec-Executing-Fields)

This PR attempts to solve that by adding support for an `initialValue` parameter, both as a query param and a JSON body key. This value is assumed to be some form of valid JSON that can be decoded to an object. After decoding the value, if we end up with a valid result, I then set that object as the `root` of the execution input.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
