### PR TITLE
Added case for "https" in switch statement

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
@@ -375,6 +375,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
     try {
       switch (uri.getScheme()) {
         case "http":
+        case "https":
           return Paths.get(uri.getPath());
         case "file":
           return Paths.get(uri);


### PR DESCRIPTION
Signed-off-by: Deven Phillips <deven.phillips@redhat.com>

Motivation:

Resolves https://github.com/vert-x3/vertx-web/issues/1817 by adding an additional case for "https" to `io.vertx.ext.web.openapi.impl.OpenAPIHolderImpl`
