### PR TITLE
Fix #1995: propagate the authorization header

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
@@ -2,9 +2,11 @@ package io.vertx.ext.web.api.service.impl;
 
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.MultiMap;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -30,6 +32,21 @@ public class RouteToEBServiceHandlerImpl implements RouteToEBServiceHandler {
 
   @Override
   public void handle(RoutingContext routingContext) {
+    // pass authorization header if present to the eventbus
+    DeliveryOptions deliveryOptions;
+
+    if (routingContext.request().headers().contains(HttpHeaders.AUTHORIZATION)) {
+      deliveryOptions = new DeliveryOptions(this.deliveryOptions);
+      MultiMap headers = deliveryOptions.getHeaders();
+      if (headers == null) {
+        headers = MultiMap.caseInsensitiveMultiMap();
+        deliveryOptions.setHeaders(headers);
+      }
+      headers.set(HttpHeaders.AUTHORIZATION, routingContext.request().getHeader(HttpHeaders.AUTHORIZATION));
+    } else {
+      deliveryOptions = this.deliveryOptions;
+    }
+
     eventBus.request(address, buildPayload(routingContext), deliveryOptions, (AsyncResult<Message<JsonObject>> res) -> {
       if (res.succeeded()) {
         ServiceResponse op = new ServiceResponse(res.result().body());

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/TestService.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/TestService.java
@@ -12,6 +12,7 @@ public interface TestService {
   void testEmptyServiceResponse(ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
   void testUser(ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
   void extraPayload(ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
+  void testAuthorization(ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
 
   static TestService create(Vertx vertx) {
     return new TestServiceImpl(vertx);

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/TestServiceImpl.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/TestServiceImpl.java
@@ -48,4 +48,11 @@ public class TestServiceImpl implements TestService {
       ServiceResponse.completedWithJson(new JsonObject().put("result", "Hello " + context.getExtra().getString("username") + "!")))
     );
   }
+
+  @Override
+  public void testAuthorization(ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(
+      ServiceResponse.completedWithJson(new JsonObject().put("result", context.getHeaders().get("Authorization"))))
+    );
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #1995 

To allow further secure openapi -> eventbus messages, this PR propagates the http authentication header downstream