### PR TITLE
Context management with GraphQLContext object

### DIFF
--- a/vertx-web-graphql/src/main/asciidoc/index.adoc
+++ b/vertx-web-graphql/src/main/asciidoc/index.adoc
@@ -196,13 +196,6 @@ You may retrieve this object by inspecting the `DataFetchingEnvironment`:
 
 NOTE: The routing context is available with any kind of data fetchers, not just {@link io.vertx.ext.web.handler.graphql.schema.VertxDataFetcher}.
 
-If you prefer not to expose the routing context to your data fetchers, configure the GraphQL handler to customize the context object:
-
-[source,$lang]
-----
-{@link examples.GraphQLExamples#customContextInDataFetchingEnvironment}
-----
-
 === JSON data results
 
 The default GraphQL data fetcher is `PropertyDataFetcher`.

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.handler.graphql;
 
 import graphql.GraphQL;
+import graphql.GraphQLContext;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -28,6 +29,8 @@ import org.dataloader.DataLoaderRegistry;
 
 import java.util.Locale;
 import java.util.function.Function;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * A handler for GraphQL requests sent over Apollo's {@code subscriptions-transport-ws} transport.
@@ -42,7 +45,7 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
    * <p>
    * The handler will be configured with the default {@link ApolloWSOptions}.
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore(PERMITTED_TYPE)
   static ApolloWSHandler create(GraphQL graphQL) {
     return new ApolloWSHandlerImpl(graphQL, new ApolloWSOptions());
   }
@@ -54,9 +57,20 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
    *
    * @param options options for configuring the {@link ApolloWSOptions}
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore(PERMITTED_TYPE)
   static ApolloWSHandler create(GraphQL graphQL, ApolloWSOptions options) {
     return new ApolloWSHandlerImpl(graphQL, options);
+  }
+
+  /**
+   * Retrieves the {@link ApolloWSMessage} from the {@link GraphQLContext}.
+   *
+   * @param graphQlContext the GraphQL context object
+   * @return the {@link ApolloWSMessage}
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  static ApolloWSMessage getMessage(GraphQLContext graphQlContext) {
+    return graphQlContext.get(ApolloWSMessage.class);
   }
 
   /**
@@ -100,8 +114,10 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
+  @Deprecated
   ApolloWSHandler queryContext(Function<ApolloWSMessage, Object> factory);
 
   /**
@@ -109,9 +125,11 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore(PERMITTED_TYPE)
+  @Deprecated
   ApolloWSHandler dataLoaderRegistry(Function<ApolloWSMessage, DataLoaderRegistry> factory);
 
   /**
@@ -119,8 +137,19 @@ public interface ApolloWSHandler extends Handler<RoutingContext> {
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @GenIgnore(PERMITTED_TYPE)
+  @Deprecated
   ApolloWSHandler locale(Function<ApolloWSMessage, Locale> factory);
+
+  /**
+   * Set a callback to invoke before executing a GraphQL query.
+   *
+   * @param config the callback to invoke
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ApolloWSHandler beforeExecute(Handler<ExecutionInputBuilderWithContext<ApolloWSMessage>> config);
 }

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/GraphQLHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/GraphQLHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.handler.graphql;
 
 import graphql.GraphQL;
+import graphql.GraphQLContext;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -27,6 +28,8 @@ import org.dataloader.DataLoaderRegistry;
 
 import java.util.Locale;
 import java.util.function.Function;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * A {@link io.vertx.ext.web.Route} handler for GraphQL requests.
@@ -59,12 +62,25 @@ public interface GraphQLHandler extends Handler<RoutingContext> {
   }
 
   /**
+   * Retrieves the {@link RoutingContext} from the {@link GraphQLContext}.
+   *
+   * @param graphQlContext the GraphQL context object
+   * @return the {@link RoutingContext}
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  static RoutingContext getRoutingContext(GraphQLContext graphQlContext) {
+    return graphQlContext.get(RoutingContext.class);
+  }
+
+  /**
    * Customize the query context object.
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
+  @Deprecated
   GraphQLHandler queryContext(Function<RoutingContext, Object> factory);
 
   /**
@@ -72,9 +88,11 @@ public interface GraphQLHandler extends Handler<RoutingContext> {
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Deprecated
   GraphQLHandler dataLoaderRegistry(Function<RoutingContext, DataLoaderRegistry> factory);
 
   /**
@@ -82,8 +100,19 @@ public interface GraphQLHandler extends Handler<RoutingContext> {
    * The provided {@code factory} method will be invoked for each incoming GraphQL request.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated as of 4.2, use {@link #beforeExecute(Handler)} instead
    */
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Deprecated
   GraphQLHandler locale(Function<RoutingContext, Locale> factory);
+
+  /**
+   * Set a callback to invoke before executing a GraphQL query.
+   *
+   * @param config the callback to invoke
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  GraphQLHandler beforeExecute(Handler<ExecutionInputBuilderWithContext<RoutingContext>> config);
 }

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -22,10 +22,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.graphql.ApolloWSConnectionInitEvent;
-import io.vertx.ext.web.handler.graphql.ApolloWSHandler;
-import io.vertx.ext.web.handler.graphql.ApolloWSMessage;
-import io.vertx.ext.web.handler.graphql.ApolloWSOptions;
+import io.vertx.ext.web.handler.graphql.*;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.Locale;
@@ -53,6 +50,7 @@ public class ApolloWSHandlerImpl implements ApolloWSHandler {
   private Handler<ApolloWSConnectionInitEvent> connectionInitHandler;
   private Handler<ServerWebSocket> endHandler;
   private Handler<ApolloWSMessage> messageHandler;
+  private Handler<ExecutionInputBuilderWithContext<ApolloWSMessage>> beforeExecute;
 
   public ApolloWSHandlerImpl(GraphQL graphQL, ApolloWSOptions options) {
     Objects.requireNonNull(graphQL, "graphQL");
@@ -137,6 +135,16 @@ public class ApolloWSHandlerImpl implements ApolloWSHandler {
 
   synchronized Function<ApolloWSMessage, Locale> getLocale() {
     return localeFactory;
+  }
+
+  @Override
+  public ApolloWSHandler beforeExecute(Handler<ExecutionInputBuilderWithContext<ApolloWSMessage>> beforeExecute) {
+    this.beforeExecute = beforeExecute;
+    return this;
+  }
+
+  synchronized Handler<ExecutionInputBuilderWithContext<ApolloWSMessage>> getBeforeExecute() {
+    return beforeExecute;
   }
 
   @Override

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/ApolloTestsServer.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/ApolloTestsServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -34,7 +34,8 @@ import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 import org.reactivestreams.Publisher;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
 import static io.vertx.core.http.HttpMethod.GET;
@@ -144,7 +145,7 @@ public class ApolloTestsServer extends AbstractVerticle {
 
   private Publisher<Object> counter(DataFetchingEnvironment env) {
     return subscriber -> {
-      ApolloWSMessage message = env.getContext();
+      ApolloWSMessage message = ApolloWSHandler.getMessage(env.getGraphQlContext());
       JsonObject connectionParams = message.connectionParams() == null
         ? new JsonObject()
         : (JsonObject) message.connectionParams();

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/ApolloWSHandlerTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/ApolloWSHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -105,7 +105,7 @@ public class ApolloWSHandlerTest extends WebTestBase {
 
   private Publisher<Map<String, Object>> getCounter(DataFetchingEnvironment env) {
     boolean finite = env.getArgument("finite");
-    ApolloWSMessage message = env.getContext();
+    ApolloWSMessage message = ApolloWSHandler.getMessage(env.getGraphQlContext());
     JsonObject connectionParams = message.connectionParams() == null
       ? new JsonObject()
       : (JsonObject) message.connectionParams();

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedLocaleTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedLocaleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.graphql;
+
+import io.vertx.ext.web.LanguageHeader;
+
+import java.util.Locale;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedLocaleTest extends LocaleTest {
+
+  @Override
+  protected void setUpGraphQLHandler() {
+    graphQLHandler = GraphQLHandler.create(graphQL()).locale(rc -> {
+      for (LanguageHeader acceptableLocale : rc.acceptableLanguages()) {
+        try {
+          return Locale.forLanguageTag(acceptableLocale.value());
+        } catch (RuntimeException ignored) {
+        }
+      }
+      return null;
+    });
+    router.route("/graphql").order(100).handler(graphQLHandler);
+  }
+}

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedVertxBatchLoaderTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedVertxBatchLoaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.graphql;
+
+import io.vertx.ext.web.handler.graphql.dataloader.VertxBatchLoader;
+import org.dataloader.BatchLoaderWithContext;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
+import org.dataloader.DataLoaderRegistry;
+
+import static java.util.stream.Collectors.toList;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedVertxBatchLoaderTest extends VertxBatchLoaderTest {
+
+  @Override
+  protected void setUpGraphQLHandler() {
+    BatchLoaderWithContext<String, User> userBatchLoader = VertxBatchLoader.create(
+      (keys, environment, listPromise) -> {
+        if (batchloaderInvoked.compareAndSet(false, true)) {
+          listPromise.complete(keys
+            .stream()
+            .map(testData.users::get)
+            .collect(toList())
+          );
+        } else {
+          listPromise.fail(new IllegalStateException());
+        }
+      }
+    );
+
+    graphQLHandler.dataLoaderRegistry(rc -> {
+      DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader);
+      return new DataLoaderRegistry().register("user", userDataLoader);
+    });
+  }
+}

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedVertxMappedBatchLoaderTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/DeprecatedVertxMappedBatchLoaderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.web.handler.graphql;
+
+import io.vertx.ext.web.handler.graphql.dataloader.VertxMappedBatchLoader;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
+import org.dataloader.DataLoaderRegistry;
+import org.dataloader.MappedBatchLoaderWithContext;
+
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedVertxMappedBatchLoaderTest extends VertxMappedBatchLoaderTest {
+
+  @Override
+  protected void setUpGraphQLHandler() {
+    MappedBatchLoaderWithContext<String, User> userBatchLoader = VertxMappedBatchLoader.create(
+      (keys, environment, mapPromise) -> {
+        if (batchloaderInvoked.compareAndSet(false, true)) {
+          mapPromise.complete(keys
+            .stream()
+            .map(testData.users::get)
+            .collect(toMap(User::getId, Function.identity()))
+          );
+        } else {
+          mapPromise.fail(new IllegalStateException());
+        }
+      }
+    );
+
+    graphQLHandler.dataLoaderRegistry(rc -> {
+      DataLoader<String, User> userDataLoader = DataLoaderFactory.newMappedDataLoader(userBatchLoader);
+      return new DataLoaderRegistry().register("user", userDataLoader);
+    });
+  }
+}

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.vertx.ext.web.handler.graphql;
 
 import graphql.GraphQL;
@@ -27,14 +43,18 @@ public class LocaleTest extends WebTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    graphQLHandler = GraphQLHandler.create(graphQL()).locale(rc -> {
-      for (LanguageHeader acceptableLocale : rc.acceptableLanguages()) {
+    setUpGraphQLHandler();
+  }
+
+  protected void setUpGraphQLHandler() {
+    graphQLHandler = GraphQLHandler.create(graphQL()).beforeExecute(bwc -> {
+      for (LanguageHeader acceptableLocale : bwc.context().acceptableLanguages()) {
         try {
-          return Locale.forLanguageTag(acceptableLocale.value());
+          bwc.builder().locale(Locale.forLanguageTag(acceptableLocale.value()));
+          break;
         } catch (RuntimeException ignored) {
         }
       }
-      return null;
     });
     router.route("/graphql").order(100).handler(graphQLHandler);
   }

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/QueryContextTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/QueryContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -28,6 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 /**
  * @author Thomas Segismont
  */
+@SuppressWarnings("deprecation")
 public class QueryContextTest extends GraphQLTestBase {
 
   private AtomicReference<Object> queryContext = new AtomicReference<>();


### PR DESCRIPTION
Closes #2023

With GraphQL-Java 17, te GraphQLContext object becomes the standard to share contextual data between components of a GraphQL Java application (see https://github.com/graphql-java/graphql-java/releases/tag/v17.0 and graphql-java/graphql-java#2368).

This commit:

- deprecates the current context hooks in Vert.x Web GraphQL handlers
- adds a new hook that allows to manipulate the ExecutionInputBuilder
- updates the docs
