### PR TITLE
Allow Future with #mountServiceInterface

### DIFF
--- a/vertx-web-api-service/src/main/asciidoc/index.adoc
+++ b/vertx-web-api-service/src/main/asciidoc/index.adoc
@@ -95,9 +95,18 @@ Now we can build the interface *TransactionService* that handles those endpoints
 For each endpoint you need to write a method with name corresponding to `action` specified when you build the {@link io.vertx.ext.web.api.service.RouteToEBServiceHandler}.
 There are a couple of rules to follow for method parameters:
 
+=== Async interface with callbacks
+
 * Last parameter must have type `Handler<AsyncResult<ServiceResponse>>`
 * Second to last parameter must have type {@link io.vertx.ext.web.api.service.ServiceRequest}
 * All parameters from first to second to last (excluded) are extracted from {@link io.vertx.ext.web.validation.RequestParameters} with specified type automatically, but they need to respect https://vertx.io/docs/vertx-service-proxy/java/#_restrictions_for_service_interface[service proxy restrictions]
+
+=== Async interface
+
+* Return type must have type `Future<ServiceResponse>`
+* Last parameter must have type {@link io.vertx.ext.web.api.service.ServiceRequest}
+* All parameters from first to last are extracted from {@link io.vertx.ext.web.validation.RequestParameters} with specified type automatically, but they need to respect https://vertx.io/docs/vertx-service-proxy/java/#_restrictions_for_service_interface[service proxy restrictions]
+
 
 A request parameter is identified only by the name of the method parameter and the special `body` method parameter name is used to extract the body of the request.
 
@@ -111,6 +120,14 @@ interface TransactionService {
   void putTransaction(JsonObject body, ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
 }
 ----
+[source,java]
+----
+@WebApiServiceGen
+interface TransactionService {
+  Future<ServiceResponse> getTransactionsList(String from, String to, ServiceRequest context);
+  Future<ServiceResponse> putTransaction(JsonObject body, ServiceRequest context);
+}
+----
 
 When you receive a request at `TransactionService#getTransactionsList` the generated service handler will automatically extract `from` and `to` parameter (if present) from {@link io.vertx.ext.web.api.service.ServiceRequest}.
 In `TransactionService#putTransaction` we use the `body` parameter name to extract the json body.
@@ -121,12 +138,20 @@ The service handler is also capable to translate `JsonObject` to Vert.x data obj
 ----
 void putTransaction(Transaction body, ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
 ----
+[source,java]
+----
+Future<ServiceResponse> putTransaction(Transaction body, ServiceRequest context);
+----
 
 You can also use {@link io.vertx.ext.web.validation.RequestParameter} to extract parameters, like:
 
 [source,java]
 ----
 void putTransaction(RequestParameter body, ServiceRequest context, Handler<AsyncResult<ServiceResponse>> resultHandler);
+----
+[source,java]
+----
+Future<ServiceResponse> putTransaction(RequestParameter body, ServiceRequest context);
 ----
 
 

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
@@ -196,7 +196,8 @@ public class OpenAPI3RouterBuilderImpl implements RouterBuilder {
   @Override
   public RouterBuilder mountServiceInterface(Class interfaceClass, String address) {
     for (Method m : interfaceClass.getMethods()) {
-      if (OpenAPI3Utils.serviceProxyMethodIsCompatibleHandler(m)) {
+      if (OpenAPI3Utils.serviceProxyMethodIsCompatibleHandler(m)
+        || OpenAPI3Utils.serviceProxyMethodIsCompatibleFuture(m)) {
         String methodName = m.getName();
         OperationImpl op = Optional
           .ofNullable(this.operations.get(methodName))

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3Utils.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3Utils.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.web.openapi.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -8,6 +9,8 @@ import io.vertx.ext.web.openapi.OpenAPIHolder;
 import io.vertx.ext.web.openapi.RouterBuilderException;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -102,6 +105,17 @@ class OpenAPI3Utils {
     if (parameters.length < 2) return false;
     if (!parameters[parameters.length - 1].getType().equals(Handler.class)) return false;
     return parameters[parameters.length - 2].getType().getName().equals("io.vertx.ext.web.api.service.ServiceRequest");
+  }
+
+  protected static boolean serviceProxyMethodIsCompatibleFuture(Method method) {
+    java.lang.reflect.Parameter[] parameters = method.getParameters();
+    if (parameters.length < 1) return false;
+    if (!parameters[parameters.length - 1].getType().getName().equals("io.vertx.ext.web.api.service.ServiceRequest")) return false;
+
+    Type returnType = method.getGenericReturnType();
+    if (!(returnType instanceof ParameterizedType)) return false;
+    if (!(((ParameterizedType) returnType).getRawType().equals(Future.class))) return false;
+    return (((ParameterizedType) returnType).getActualTypeArguments()[0]).getTypeName().equals("io.vertx.ext.web.api.service.ServiceResponse");
   }
 
   protected static JsonObject sanitizeDeliveryOptionsExtension(JsonObject jsonObject) {

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/TestFutureService.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/TestFutureService.java
@@ -1,0 +1,23 @@
+package io.vertx.ext.web.openapi.future.service;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.api.service.WebApiServiceGen;
+
+@WebApiServiceGen
+@VertxGen
+public interface TestFutureService {
+  Future<ServiceResponse> testA(ServiceRequest context);
+  Future<ServiceResponse> testB(JsonObject body, ServiceRequest context);
+  Future<ServiceResponse> testEmptyServiceResponse(ServiceRequest context);
+  Future<ServiceResponse> testUser(ServiceRequest context);
+  Future<ServiceResponse> extraPayload(ServiceRequest context);
+
+  static TestFutureService create(Vertx vertx) {
+    return new TestFutureServiceImpl(vertx);
+  }
+}

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/TestFutureServiceImpl.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/TestFutureServiceImpl.java
@@ -1,0 +1,51 @@
+package io.vertx.ext.web.openapi.future.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+
+public class TestFutureServiceImpl implements TestFutureService {
+  Vertx vertx;
+
+  public TestFutureServiceImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public Future<ServiceResponse> testA(ServiceRequest context) {
+    JsonObject body = context.getParams().getJsonObject("body");
+    return Future.succeededFuture(
+      ServiceResponse.completedWithJson(new JsonObject().put("result", body.getString("hello") + " " + body.getString("name") + "!"))
+    );
+  }
+
+  @Override
+  public Future<ServiceResponse> testB(JsonObject body, ServiceRequest context) {
+    return Future.succeededFuture(
+      ServiceResponse.completedWithJson(new JsonObject().put("result", body.getString("hello") + " " + body.getString("name") + "?"))
+    );
+  }
+
+  @Override
+  public Future<ServiceResponse> testEmptyServiceResponse(ServiceRequest context) {
+    return Future.succeededFuture(
+      new ServiceResponse()
+    );
+  }
+
+  @Override
+  public Future<ServiceResponse> testUser(ServiceRequest context) {
+    return Future.succeededFuture(
+      ServiceResponse.completedWithJson(new JsonObject().put("result", "Hello " + context.getUser().getString("username") + "!"))
+    );
+  }
+
+  @Override
+  public Future<ServiceResponse> extraPayload(ServiceRequest context) {
+    return Future.succeededFuture(
+      ServiceResponse.completedWithJson(new JsonObject().put("result", "Hello " + context.getExtra().getString("username") + "!"))
+    );
+  }
+}

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/package-info.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/future/service/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "dummy", groupPackage = "io.vertx.ext.web.openapi.future.service", useFutures = true)
+package io.vertx.ext.web.openapi.future.service;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Motivation:

We can't mount interface with Future method (#mountServiceInterface), when this is possible with #mountServicesFromExtensions
