### PR TITLE
[web-api-service]Missinformation method interface signature error

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyModel.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyModel.java
@@ -25,7 +25,7 @@ import java.util.Set;
  */
 public class WebApiProxyModel extends ProxyModel {
 
-  private static final String SIGNATURE_CONSTRAINT_ERROR = "Method must respect signature Future<io.vertx.ext.web.api.ServiceResponse> foo(extractedParams..., io.vertx.ext.web.api.ServiceRequest request) or foo(extractedParams..., io.vertx.ext.web.api.ServiceRequest request, Handler<AsyncResult<io.vertx.ext.web.api.ServiceResponse>> handler)";
+  private static final String SIGNATURE_CONSTRAINT_ERROR = "Method must respect signature Future<io.vertx.ext.web.api.service.ServiceResponse> foo(extractedParams..., io.vertx.ext.web.api.service.ServiceRequest request) or foo(extractedParams..., io.vertx.ext.web.api.service.ServiceRequest request, Handler<AsyncResult<io.vertx.ext.web.api.service.ServiceResponse>> handler)";
 
   public WebApiProxyModel(ProcessingEnvironment env, TypeMirrorFactory typeFactory, TypeElement modelElt) {
     super(env, typeFactory, modelElt);


### PR DESCRIPTION
Message information error is wrong, with bad package for ServiceResponse & ServiceRequest
Refer to **io.vertx.ext.web.api** but it's now **io.vertx.ext.web.api.service**

https://github.com/vert-x3/vertx-web/blob/18e059787ae0c7156e9a5ac6924d9a6502188d31/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/generator/model/WebApiProxyModel.java#L28

Fix #2040