### PR TITLE
Don't resolve resources with class loaders, user vert.x file system i…

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
@@ -9,6 +9,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -22,6 +23,7 @@ import io.vertx.json.schema.common.SchemaURNId;
 import io.vertx.json.schema.common.URIUtils;
 import io.vertx.json.schema.draft7.Draft7SchemaParser;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -37,8 +39,6 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
   private final Map<URI, JsonObject> absolutePaths;
   private final HttpClient client;
   private final FileSystem fs;
-  private final SchemaRouter router;
-  private final SchemaParser parser;
   private final Schema openapiSchema;
   private final OpenAPILoaderOptions options;
   private URI initialScope;
@@ -47,6 +47,8 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
   private final YAMLMapper yamlMapper;
   private JsonObject openapiRoot;
 
+  private final String cacheDir;
+
   public OpenAPIHolderImpl(Vertx vertx, HttpClient client, FileSystem fs, OpenAPILoaderOptions options) {
     this.vertx = vertx;
     absolutePaths = new ConcurrentHashMap<>();
@@ -54,10 +56,17 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
     this.client = client;
     this.fs = fs;
     this.options = options;
-    this.router = SchemaRouter.create(client, fs, options.toSchemaRouterOptions());
-    this.parser = Draft7SchemaParser.create(this.router);
+    SchemaRouter router = SchemaRouter.create(client, fs, options.toSchemaRouterOptions());
+    SchemaParser parser = Draft7SchemaParser.create(router);
     this.yamlMapper = new YAMLMapper();
     this.openapiSchema = parser.parseFromString(OpenAPI3Utils.openapiSchemaJson);
+
+    String cacheDir = ((VertxInternal) vertx).resolveFile("").getAbsolutePath();
+    if (!cacheDir.endsWith(File.separator)) {
+      cacheDir += File.separator;
+    }
+
+    this.cacheDir = cacheDir;
   }
 
   public Future<JsonObject> loadOpenAPI(String u) {
@@ -70,7 +79,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
         if (URIUtils.isRemoteURI(uri) || uri.isAbsolute()) {
           initialScope = uri;
         } else {
-          initialScope = getResourceAbsoluteURI(uri);
+          initialScope = getResourceAbsoluteURI(vertx, uri);
         }
         initialScopeDirectory = resolveContainingDirPath(initialScope);
       })
@@ -328,18 +337,24 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
 
   private Future<JsonObject> solveLocalRef(final URI ref) {
     String filePath = extractPath(ref);
-    return fs.readFile(filePath).compose(buf -> {
-      try {
-        return Future.succeededFuture(buf.toJsonObject());
-      } catch (DecodeException e) {
-        // Maybe it's yaml
+
+    return fs
+      // given that we are resolving using vert.x we may need to normalize paths from vert.x cache back
+      // to the CWD, this is done just by stripping the well known cache dir prefix from any path if
+      // present
+      .readFile(filePath.startsWith(cacheDir) ? filePath.substring(cacheDir.length()) : filePath)
+      .compose(buf -> {
         try {
-          return Future.succeededFuture(this.yamlToJson(buf));
-        } catch (Exception e1) {
-          return Future.failedFuture(new RuntimeException("File " + filePath + " is not a valid YAML or JSON", e1));
+          return Future.succeededFuture(buf.toJsonObject());
+        } catch (DecodeException e) {
+          // Maybe it's yaml
+          try {
+            return Future.succeededFuture(this.yamlToJson(buf));
+          } catch (Exception e1) {
+            return Future.failedFuture(new RuntimeException("File " + filePath + " is not a valid YAML or JSON", e1));
+          }
         }
-      }
-    });
+      });
   }
 
   private JsonObject yamlToJson(Buffer buf) {
@@ -357,7 +372,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
       if (ref.toString().startsWith(initialScopeDirectory))
         return ref;
       else {
-        URI fromClasspath = getResourceAbsoluteURIFromClasspath(ref);
+        URI fromClasspath = getResourceAbsoluteURI(vertx, ref);
         if (fromClasspath != null) {
           return fromClasspath;
         }
@@ -393,39 +408,33 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
     return uriToPath(absoluteURI).resolveSibling("").toString();
   }
 
-  protected static URI getResourceAbsoluteURI(URI relativeURI) {
-    // If it's relative, it could be both in filesystem and in the classpath.
-    // Try to figure this out!
-    URI fromClasspath = getResourceAbsoluteURIFromClasspath(relativeURI);
-    if (fromClasspath != null) {
-      return fromClasspath;
-    } else {
-      // Then it must be local fs!
-      return Paths.get(relativeURI.getPath()).toAbsolutePath().toUri();
+  protected static URI getResourceAbsoluteURI(Vertx vertx, URI source) {
+    String path = source.getPath();
+    File resolved = ((VertxInternal) vertx).resolveFile(path);
+    URI uri = null;
+    if (resolved != null) {
+      if (resolved.exists()) {
+        try {
+          resolved = resolved.getAbsoluteFile();
+          uri = new URI("file://" + slashify(resolved.getPath(), resolved.isDirectory()));
+        } catch (URISyntaxException e) {
+          throw new RuntimeException(e);
+        }
+      }
     }
+
+    return uri;
   }
 
-  protected static URI getResourceAbsoluteURIFromClasspath(URI u) {
-    try {
-      return getClassLoader().getResource(u.toString()).toURI();
-    } catch (NullPointerException | URISyntaxException e) {
-      return null;
-    }
-  }
-
-  private static ClassLoader getClassLoader() {
-    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    if (cl == null) {
-      cl = OpenAPIHolderImpl.class.getClassLoader();
-    }
-    // when running on substratevm (graal) the access to class loaders
-    // is very limited and might be only available from compile time
-    // known classes. (Object is always known, so we do a final attempt
-    // to get it here).
-    if (cl == null) {
-      cl = Object.class.getClassLoader();
-    }
-    return cl;
+  private static String slashify(String path, boolean isDirectory) {
+    String p = path;
+    if (File.separatorChar != '/')
+      p = p.replace(File.separatorChar, '/');
+    if (!p.startsWith("/"))
+      p = "/" + p;
+    if (!p.endsWith("/") && isDirectory)
+      p = p + "/";
+    return p;
   }
 
   public Map<URI, JsonObject> getAbsolutePaths() {

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
@@ -375,8 +375,8 @@ public class OpenAPIHolderTest {
             MyAssertions.assertThat(container)
               .extracting("paths", "/simple", "post", "requestBody", "content", "multipart/form-data", "schema", "$ref")
               .isEqualTo(resolveAbsoluteURIFromClasspath(
-                "yaml/valid/inner_refs.yaml#/components/schemas/Simple"
-              ).toString())
+                vertx,
+                "yaml/valid/inner_refs.yaml#/components/schemas/Simple").toString())
               .satisfies(ref ->
                 assertThat(parser)
                   .hasCached(URI.create((String) ref))
@@ -628,10 +628,9 @@ public class OpenAPIHolderTest {
     ).onComplete(l -> {
       testContext.verify(() -> {
         JsonPointer schemaPointer = JsonPointer.fromURI(resolveAbsoluteURIFromClasspath(
-          "specs/schemas_test_spec.yaml"
-        )).append(Arrays.asList(
-          "paths", "/test8", "post", "requestBody", "content", "application/json", "schema"
-        ));
+            vertx,
+            "specs/schemas_test_spec.yaml"))
+          .append(Arrays.asList("paths", "/test8", "post", "requestBody", "content", "application/json", "schema"));
         JsonObject resolved = (JsonObject) schemaPointer.query(l.result(),
           new JsonPointerIteratorWithLoader(loader));
 
@@ -734,11 +733,11 @@ public class OpenAPIHolderTest {
     );
   }
 
-  private URI resolveAbsoluteURIFromClasspath(String relative) {
+  private URI resolveAbsoluteURIFromClasspath(Vertx vertx, String relative) {
     URI relativeURI = URI.create(relative);
     String fragment = relativeURI.getFragment();
     return URIUtils.replaceFragment(
-      OpenAPIHolderImpl.getResourceAbsoluteURIFromClasspath(URIUtils.removeFragment(relativeURI)),
+      OpenAPIHolderImpl.getResourceAbsoluteURI(vertx, URIUtils.removeFragment(relativeURI)),
       fragment
     );
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -36,8 +36,17 @@ import java.util.regex.Pattern;
 public class Utils {
 
   public static ClassLoader getClassLoader() {
-    ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-    return tccl == null ? Utils.class.getClassLoader() : tccl;
+    // try current thread
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      // try the current class
+      cl = Utils.class.getClassLoader();
+      if (cl == null) {
+        // fall back to a well known object that should alwways exist
+        cl = Object.class.getClassLoader();
+      }
+    }
+    return cl;
   }
 
   private static final ZoneId ZONE_GMT = ZoneId.of("GMT");


### PR DESCRIPTION
…nstead

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Resolving resources with class loaders is complex and doesn't work all the times (specially with native images). This PR replaces all class loader usages with the vert.x file system which is tested to work with native images.
