### PR TITLE
Implement origin checks for CSWSH

### DIFF
--- a/vertx-web-graphql/src/main/generated/io/vertx/ext/web/handler/graphql/ApolloWSOptionsConverter.java
+++ b/vertx-web-graphql/src/main/generated/io/vertx/ext/web/handler/graphql/ApolloWSOptionsConverter.java
@@ -21,6 +21,11 @@ public class ApolloWSOptionsConverter {
             obj.setKeepAlive(((Number)member.getValue()).longValue());
           }
           break;
+        case "origin":
+          if (member.getValue() instanceof String) {
+            obj.setOrigin((String)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -31,5 +36,8 @@ public class ApolloWSOptionsConverter {
 
   public static void toJson(ApolloWSOptions obj, java.util.Map<String, Object> json) {
     json.put("keepAlive", obj.getKeepAlive());
+    if (obj.getOrigin() != null) {
+      json.put("origin", obj.getOrigin());
+    }
   }
 }

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSOptions.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/ApolloWSOptions.java
@@ -34,6 +34,8 @@ public class ApolloWSOptions {
 
   private long keepAlive = DEFAULT_KEEP_ALIVE;
 
+  private String origin;
+
   /**
    * Default constructor.
    */
@@ -47,6 +49,7 @@ public class ApolloWSOptions {
    */
   public ApolloWSOptions(ApolloWSOptions other) {
     keepAlive = other.keepAlive;
+    origin = other.origin;
   }
 
   /**
@@ -84,6 +87,26 @@ public class ApolloWSOptions {
    */
   public ApolloWSOptions setKeepAlive(long keepAlive) {
     this.keepAlive = keepAlive;
+    return this;
+  }
+
+  /**
+   * @return the {@code Origin} for this handler. The Origin will be used to prevent Cross-Site WebSocket Hijacking
+   * attacks.
+   */
+  public String getOrigin() {
+    return origin;
+  }
+
+  /**
+   * Set the {@code Origin} for this handler, by default it will be {@code null}.
+   *
+   * @param origin web origin for this handler or {@code null}
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ApolloWSOptions setOrigin(String origin) {
+    this.origin = origin;
     return this;
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerOptions.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerOptions.java
@@ -74,6 +74,7 @@ public class SockJSHandlerOptions {
   private final Set<String> disabledTransports = new HashSet<>();
   private boolean registerWriteHandler;
   private boolean localWriteHandler;
+  private String origin;
 
   /**
    * Copy constructor.
@@ -89,6 +90,7 @@ public class SockJSHandlerOptions {
     disabledTransports.addAll(other.disabledTransports);
     registerWriteHandler = other.registerWriteHandler;
     localWriteHandler = other.localWriteHandler;
+    origin = other.origin;
   }
 
   /**
@@ -128,6 +130,7 @@ public class SockJSHandlerOptions {
     }
     registerWriteHandler = json.getBoolean("registerWriteHandler", DEFAULT_REGISTER_WRITE_HANDLER);
     localWriteHandler = json.getBoolean("localWriteHandler", DEFAULT_LOCAL_WRITE_HANDLER);
+    origin = json.getString("origin");
   }
 
   /**
@@ -307,6 +310,26 @@ public class SockJSHandlerOptions {
    */
   public SockJSHandlerOptions setLocalWriteHandler(boolean localWriteHandler) {
     this.localWriteHandler = localWriteHandler;
+    return this;
+  }
+
+  /**
+   * @return the origin associated with this bridge
+   */
+  public String getOrigin() {
+    return origin;
+  }
+
+  /**
+   * Set the origin to be verified before a websocket upgrade happens.
+   * <p>
+   * Defaults to {@code null}.
+   *
+   * @param origin web origin
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SockJSHandlerOptions setOrigin(String origin) {
+    this.origin = origin;
     return this;
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
@@ -42,6 +42,9 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSSocket;
+import io.vertx.ext.web.impl.Origin;
+
+import static io.vertx.core.http.HttpHeaders.ORIGIN;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -194,29 +197,39 @@ class RawWebSocketTransport {
 
   RawWebSocketTransport(Vertx vertx, Router router, SockJSHandlerOptions options, Handler<SockJSSocket> sockHandler) {
 
+    final Origin origin = options.getOrigin() != null ? Origin.parse(options.getOrigin()) : null;
     String wsRE = "/websocket";
 
-    router.get(wsRE).handler(rc -> {
+    router.get(wsRE).handler(ctx -> {
+      if (origin != null) {
+        // validate the origin header to prevent Cross-Site WebSocket Hijacking (CSWSH)
+        String header = ctx.request().headers().get(ORIGIN);
+        if (header != null && !origin.sameOrigin(header)) {
+          // the client origin doesn't match the bridge origin
+          ctx.fail(403);
+          return;
+        }
+      }
       // we're about to upgrade the connection, which means an asynchronous
       // operation. We have to pause the request otherwise we will loose the
       // body of the request once the upgrade completes
-      final boolean parseEnded = rc.request().isEnded();
+      final boolean parseEnded = ctx.request().isEnded();
       if (!parseEnded) {
-        rc.request().pause();
+        ctx.request().pause();
       }
       // upgrade
-      rc.request().toWebSocket(toWebSocket -> {
+      ctx.request().toWebSocket(toWebSocket -> {
         if (toWebSocket.succeeded()) {
           // resume the parsing
           if (!parseEnded) {
-            rc.request().resume();
+            ctx.request().resume();
           }
           // handle the sockjs session as usual
-          SockJSSocket sock = new RawWSSockJSSocket(vertx, rc, options, toWebSocket.result());
+          SockJSSocket sock = new RawWSSockJSSocket(vertx, ctx, options, toWebSocket.result());
           sockHandler.handle(sock);
         } else {
           // the upgrade failed
-          rc.fail(toWebSocket.cause());
+          ctx.fail(toWebSocket.cause());
         }
       });
     });


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Verify `origin` header before performing protocol upgrades on sockjs bridge or graphql