### PR TITLE
Updated Java-GraphQL to Version 17.3

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -33,7 +33,7 @@
     Update these properties in the vertx-lang-* modules too
      -->
     <graphql.java.major.version>17</graphql.java.major.version>
-    <graphql.java.version>${graphql.java.major.version}.2</graphql.java.version>
+    <graphql.java.version>${graphql.java.major.version}.3</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
Im not sure if they will release some more 17.X version before vertx 4.2 release.
But it seems that they wont