### PR TITLE
Fix #2020: Move back error log

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -183,8 +183,6 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   }
 
   private void handleInHandlerRuntimeFailure(RouterImpl router, boolean failed, Throwable t) {
-    LOG.error("Unhandled exception in router", t);
-
     if (!failed) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Failing the routing");
@@ -200,6 +198,8 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   }
 
   protected void unhandledFailure(int statusCode, Throwable failure, RouterImpl router) {
+    LOG.error("Unhandled exception in router", failure);
+
     int code = statusCode != -1 ?
       statusCode :
       (failure instanceof HttpException) ?


### PR DESCRIPTION
Motivation:

In c7df49750b5d3465019cdb8547e297044a938b39, the error log was moved to the wrong function. This leads to error logs even when there is a failureHandler in place doing the error handling.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
