### PR TITLE
Fix #1751: OpenAPI RouterBuilder path matching order

### DIFF
--- a/vertx-web-openapi/src/test/resources/specs/path_matching_order.yaml
+++ b/vertx-web-openapi/src/test/resources/specs/path_matching_order.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  description: 'Test API'
+  version: 1.0.0
+paths:
+  /shops/{shopId}/pets/{petId}:
+    post:
+      operationId: addPetToShop
+      parameters:
+        - name: shopId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        required: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+  /shops/{shopId}/pets/_search:
+    post:
+      operationId: searchPetsInShop
+      parameters:
+        - name: shopId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          required: false
+          schema:
+            type: string
+            default: ""
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+  /pets/{petId}:
+    post:
+      operationId: addPet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        required: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+  /pets/_search:
+    post:
+      operationId: searchPets
+      parameters:
+        - name: query
+          in: query
+          description: the text query
+          required: false
+          schema:
+            type: string
+            default: ""
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
Motivation:

This PR aims at fixing path matching order issues in the OpenAPI RouterBuilder: #1751 
Let this PR be the continuation of https://github.com/vert-x3/vertx-web/pull/1787 that seem to have lost traction.

As mentioned by @slinkydeveloper in https://github.com/vert-x3/vertx-web/pull/1787#discussion_r555932885 I also think the problem can only be fixed by pre-ordering the operations: this is what I've done.

I added a unit test demonstrating the behavior. Commenting out the `.sorted()` in `OpenAPI3RouterBuilderImpl` makes the unit test fail:
```java
    List<ResolvedOpenAPI3Path> resolvedPaths = operations
      .values()
      .stream()
      .map(it -> new ResolvedOpenAPI3Path(it, openapi))
      .sorted()
      .collect(Collectors.toList());
```

