### PR TITLE
Web Client URI Template

### DIFF
--- a/vertx-web-client/pom.xml
+++ b/vertx-web-client/pom.xml
@@ -21,6 +21,12 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-uri-template</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-web-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -516,6 +516,45 @@ a {@link io.vertx.ext.web.client.WebClientSession}.
 {@link examples.CachingWebClientExamples#createWithSession(io.vertx.core.Vertx)}
 ----
 
+== URI templates
+
+URI templates provide an alternative to string URIs to perform requests.
+
+You can parse a Java string to a `UriTemplate`
+
+[source,$lang]
+----
+public static final UriTemplate REQUEST_URI = UriTemplate.of("/some-uri?{param}");
+----
+
+then use it to create a request
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplate1}
+----
+
+set the template variable
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplate2}
+----
+
+and finally send the request as usual
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplate3}
+----
+
+or fluently
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplateFluent}
+----
+
 == Using HTTPS
 
 Vert.x Web Client can be configured to use HTTPS in exactly the same way as the Vert.x {@link io.vertx.core.http.HttpClient}.

--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -584,6 +584,20 @@ this behavior to fail instead:
 {@link examples.WebClientExamples#testConfigureTemplateExpansion}
 ----
 
+=== Template parameter values
+
+Template parameters accept `String`, `List<String>` and `Map<String, String` values.
+
+The expansion of each kind depends on the expansion style (denoted by the `?` prefix) , here is an example of the _query_ parameter that is exploded
+(denoted by the `*` suffix) and expanded using form-style query expansion:
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplateMapExpansion}
+----
+
+Form-style query expansion expands the variable `{?query*}` as `?color=red&width=30&height=50` per definition.
+
 == Using HTTPS
 
 Vert.x Web Client can be configured to use HTTPS in exactly the same way as the Vert.x {@link io.vertx.core.http.HttpClient}.

--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -518,13 +518,15 @@ a {@link io.vertx.ext.web.client.WebClientSession}.
 
 == URI templates
 
-URI templates provide an alternative to string URIs to perform requests.
+URI templates provide an alternative to HTTP request string URIs based on the https://datatracker.ietf.org/doc/html/rfc6570[URI Template RFC 6570].
 
-You can parse a Java string to a `UriTemplate`
+You can create a `HttpRequest` with a `UriTemplate` URI instead of a Java string URI,
+
+first parse the template string to a `UriTemplate`
 
 [source,$lang]
 ----
-public static final UriTemplate REQUEST_URI = UriTemplate.of("/some-uri?{param}");
+UriTemplate REQUEST_URI = UriTemplate.of("/some-uri?{param}");
 ----
 
 then use it to create a request
@@ -534,7 +536,7 @@ then use it to create a request
 {@link examples.WebClientExamples#testUriTemplate1}
 ----
 
-set the template variable
+set the template parameter
 
 [source,$lang]
 ----
@@ -553,6 +555,33 @@ or fluently
 [source,$lang]
 ----
 {@link examples.WebClientExamples#testUriTemplateFluent}
+----
+
+=== URI templates expansion
+
+Before sending the request, Vert.x WebClient expands the template to a string with the request template parameters.
+
+String expansion takes care of encoding the parameters for you,
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testUriTemplateEncoding}
+----
+
+The default expansion syntax is known as _simple string expansion_, there are other expansion syntax available
+
+- _path segment expansion_ (`{/varname}`)
+- _form-style query expansion_ (`{?varname}`)
+- etc...
+
+You can refer to the Vert.x URI Template documentation (add link when available) for a complete overview of the various expansion styles.
+
+As mandated by the RFC, template expansion will replace missing template parameters by empty strings. You can change
+this behavior to fail instead:
+
+[source,$lang]
+----
+{@link examples.WebClientExamples#testConfigureTemplateExpansion}
 ----
 
 == Using HTTPS

--- a/vertx-web-client/src/main/generated/io/vertx/ext/web/client/WebClientOptionsConverter.java
+++ b/vertx-web-client/src/main/generated/io/vertx/ext/web/client/WebClientOptionsConverter.java
@@ -25,6 +25,11 @@ public class WebClientOptionsConverter {
             obj.setFollowRedirects((Boolean)member.getValue());
           }
           break;
+        case "templateExpandOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setTemplateExpandOptions(new io.vertx.uritemplate.ExpandOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
         case "userAgent":
           if (member.getValue() instanceof String) {
             obj.setUserAgent((String)member.getValue());
@@ -45,6 +50,9 @@ public class WebClientOptionsConverter {
 
   public static void toJson(WebClientOptions obj, java.util.Map<String, Object> json) {
     json.put("followRedirects", obj.isFollowRedirects());
+    if (obj.getTemplateExpandOptions() != null) {
+      json.put("templateExpandOptions", obj.getTemplateExpandOptions().toJson());
+    }
     if (obj.getUserAgent() != null) {
       json.put("userAgent", obj.getUserAgent());
     }

--- a/vertx-web-client/src/main/java/examples/WebClientExamples.java
+++ b/vertx-web-client/src/main/java/examples/WebClientExamples.java
@@ -39,6 +39,7 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
+import io.vertx.uritemplate.UriTemplate;
 
 import java.util.function.Function;
 
@@ -598,6 +599,32 @@ public class WebClientExamples {
         // Obtain response
         System.out.println("Received response with status code" + res.statusCode());
       })
+      .onFailure(err ->
+        System.out.println("Something went wrong " + err.getMessage()));
+  }
+
+  public void testUriTemplate1(WebClient client, UriTemplate REQUEST_URI) {
+    HttpRequest<Buffer> request = client.get(8080, "myserver.mycompany.com", REQUEST_URI);
+  }
+
+  public void testUriTemplate2(HttpRequest<Buffer> request) {
+    request.setTemplateParam("param", "param_value");
+  }
+
+  public void testUriTemplate3(HttpRequest<Buffer> request) {
+    request.send()
+      .onSuccess(res ->
+        System.out.println("Received response with status code" + res.statusCode()))
+      .onFailure(err ->
+        System.out.println("Something went wrong " + err.getMessage()));
+  }
+
+  public void testUriTemplateFluent(WebClient client, UriTemplate REQUEST_URI) {
+    client.get(8080, "myserver.mycompany.com", REQUEST_URI)
+      .setTemplateParam("param", "param_value")
+      .send()
+      .onSuccess(res ->
+        System.out.println("Received response with status code" + res.statusCode()))
       .onFailure(err ->
         System.out.println("Something went wrong " + err.getMessage()));
   }

--- a/vertx-web-client/src/main/java/examples/WebClientExamples.java
+++ b/vertx-web-client/src/main/java/examples/WebClientExamples.java
@@ -16,6 +16,7 @@
 
 package examples;
 
+import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -43,6 +44,8 @@ import io.vertx.uritemplate.ExpandOptions;
 import io.vertx.uritemplate.UriTemplate;
 import io.vertx.uritemplate.Variables;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -634,11 +637,15 @@ public class WebClientExamples {
   private void assertEquals(String a, String b) {
   }
 
-  public void testUriTemplateEncoding(HttpRequest<Buffer> request) {
+  public void testUriTemplateEncoding(WebClient client, String amount) {
     String euroSymbol = "\u20AC";
-    Variables params = Variables.variables().set("currency", euroSymbol);
-    UriTemplate template = UriTemplate.of("{currency}");
-    assertEquals("%E2%82%AC", template.expandToString(params));
+    UriTemplate template = UriTemplate.of("/convert?{amount}&{currency}");
+
+    // Request uri: /convert?amount=1234&currency=%E2%82%AC
+    Future<HttpResponse<Buffer>> fut = client.get(template)
+      .setTemplateParam("amount", amount)
+      .setTemplateParam("currency", euroSymbol)
+      .send();
   }
 
   public void testConfigureTemplateExpansion(Vertx vertx) {
@@ -648,6 +655,18 @@ public class WebClientExamples {
     );
   }
 
+  public void testUriTemplateMapExpansion(WebClient client) {
+    Map<String, String> query = new HashMap<>();
+    query.put("color", "red");
+    query.put("width", "30");
+    query.put("height", "50");
+    UriTemplate template = UriTemplate.of("/{?query*}");
+
+    // Request uri: /?color=red&width=30&height=50
+    Future<HttpResponse<Buffer>> fut = client.getAbs(template)
+      .setTemplateParam("query", query)
+      .send();
+  }
 
   public void testOverrideRequestSSL(WebClient client) {
 

--- a/vertx-web-client/src/main/java/examples/WebClientExamples.java
+++ b/vertx-web-client/src/main/java/examples/WebClientExamples.java
@@ -39,7 +39,9 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
+import io.vertx.uritemplate.ExpandOptions;
 import io.vertx.uritemplate.UriTemplate;
+import io.vertx.uritemplate.Variables;
 
 import java.util.function.Function;
 
@@ -628,6 +630,24 @@ public class WebClientExamples {
       .onFailure(err ->
         System.out.println("Something went wrong " + err.getMessage()));
   }
+
+  private void assertEquals(String a, String b) {
+  }
+
+  public void testUriTemplateEncoding(HttpRequest<Buffer> request) {
+    String euroSymbol = "\u20AC";
+    Variables params = Variables.variables().set("currency", euroSymbol);
+    UriTemplate template = UriTemplate.of("{currency}");
+    assertEquals("%E2%82%AC", template.expandToString(params));
+  }
+
+  public void testConfigureTemplateExpansion(Vertx vertx) {
+    WebClient webClient = WebClient.create(vertx, new WebClientOptions()
+      .setTemplateExpandOptions(new ExpandOptions()
+        .setAllowVariableMiss(false))
+    );
+  }
+
 
   public void testOverrideRequestSSL(WebClient client) {
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -32,6 +32,7 @@ import io.vertx.ext.web.multipart.MultipartForm;
 import io.vertx.uritemplate.Variables;
 import io.vertx.uritemplate.UriTemplate;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -275,6 +276,16 @@ public interface HttpRequest<T> {
    */
   @Fluent
   HttpRequest<T> setTemplateParam(String paramName, String paramValue);
+
+  /**
+   * Set a request URI template list parameter to the request, expanded when the request URI is a {@link UriTemplate}.
+   *
+   * @param paramName  the param name
+   * @param paramValue the param value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> setTemplateParam(String paramName, List<String> paramValue);
 
   /**
    * Set a request URI template map parameter to the request, expanded when the request URI is a {@link UriTemplate}.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -29,7 +29,10 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
+import io.vertx.uritemplate.Variables;
+import io.vertx.uritemplate.UriTemplate;
 
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -264,6 +267,26 @@ public interface HttpRequest<T> {
   HttpRequest<T> setQueryParam(String paramName, String paramValue);
 
   /**
+   * Set a request URI template string parameter to the request, expanded when the request URI is a {@link UriTemplate}.
+   *
+   * @param paramName  the param name
+   * @param paramValue the param value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> setTemplateParam(String paramName, String paramValue);
+
+  /**
+   * Set a request URI template map parameter to the request, expanded when the request URI is a {@link UriTemplate}.
+   *
+   * @param paramName  the param name
+   * @param paramValue the param value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> setTemplateParam(String paramName, Map<String, String> paramValue);
+
+  /**
    * Set wether or not to follow the directs for the request.
    *
    * @param value true if redirections should be followed
@@ -314,6 +337,13 @@ public interface HttpRequest<T> {
    * @return the current query parameters
    */
   MultiMap queryParams();
+
+  /**
+   * Return the current request URI template parameters.
+   *
+   * @return the current request URI template parameters
+   */
+  Variables templateParams();
 
   /**
    * Copy this request

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.impl.WebClientBase;
+import io.vertx.uritemplate.UriTemplate;
 
 /**
  * An asynchronous HTTP / HTTP/2 client called {@code WebClient}.
@@ -98,10 +99,24 @@ public interface WebClient {
    * @param method  the HTTP method
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> request(HttpMethod method, int port, String host, String requestURI);
+  default HttpRequest<Buffer> request(HttpMethod method, int port, String host, String requestURI) {
+    return request(method, null, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP request to send to the server at the specified host and port.
+   * @param method  the HTTP method
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> request(HttpMethod method, int port, String host, UriTemplate requestURI) {
+    return request(method, null, port, host, requestURI);
+  }
 
   /**
    * Like {@link #request(HttpMethod, int, String, String)} using the {@code serverAddress} parameter to connect to the
@@ -114,13 +129,36 @@ public interface WebClient {
   HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, int port, String host, String requestURI);
 
   /**
+   * Like {@link #request(HttpMethod, int, String, UriTemplate)} using the {@code serverAddress} parameter to connect to the
+   * server instead of the {@code port} and {@code host} parameters.
+   * <p>
+   * The request host header will still be created from the {@code port} and {@code host} parameters.
+   * <p>
+   * Use {@link SocketAddress#domainSocketAddress(String)} to connect to a unix domain socket server.
+   */
+  HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, int port, String host, UriTemplate requestURI);
+
+  /**
    * Create an HTTP request to send to the server at the specified host and default port.
    * @param method  the HTTP method
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> request(HttpMethod method, String host, String requestURI);
+  default HttpRequest<Buffer> request(HttpMethod method, String host, String requestURI) {
+    return request(method, null, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP request to send to the server at the specified host and default port.
+   * @param method  the HTTP method
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> request(HttpMethod method, String host, UriTemplate requestURI) {
+    return request(method, null, host, requestURI);
+  }
 
   /**
    * Like {@link #request(HttpMethod, String, String)} using the {@code serverAddress} parameter to connect to the
@@ -133,12 +171,34 @@ public interface WebClient {
   HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String host, String requestURI);
 
   /**
+   * Like {@link #request(HttpMethod, String, UriTemplate)} using the {@code serverAddress} parameter to connect to the
+   * server instead of the default port and {@code host} parameter.
+   * <p>
+   * The request host header will still be created from the default port and {@code host} parameter.
+   * <p>
+   * Use {@link SocketAddress#domainSocketAddress(String)} to connect to a unix domain socket server.
+   */
+  HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String host, UriTemplate requestURI);
+
+  /**
    * Create an HTTP request to send to the server at the default host and port.
    * @param method  the HTTP method
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> request(HttpMethod method, String requestURI);
+  default HttpRequest<Buffer> request(HttpMethod method, String requestURI) {
+    return request(method, (SocketAddress) null, requestURI);
+  }
+
+  /**
+   * Create an HTTP request to send to the server at the default host and port.
+   * @param method  the HTTP method
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> request(HttpMethod method, UriTemplate requestURI) {
+    return request(method, (SocketAddress) null, requestURI);
+  }
 
   /**
    * Like {@link #request(HttpMethod, String)} using the {@code serverAddress} parameter to connect to the
@@ -151,12 +211,24 @@ public interface WebClient {
   HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String requestURI);
 
   /**
+   * Like {@link #request(HttpMethod, UriTemplate)} using the {@code serverAddress} parameter to connect to the
+   * server instead of the default port and default host.
+   * <p>
+   * The request host header will still be created from the default port and default host.
+   * <p>
+   * Use {@link SocketAddress#domainSocketAddress(String)} to connect to a unix domain socket server.
+   */
+  HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, UriTemplate requestURI);
+
+  /**
    * Create an HTTP request to send to the server at the specified host and port.
    * @param method  the HTTP method
    * @param options  the request options
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> request(HttpMethod method, RequestOptions options);
+  default HttpRequest<Buffer> request(HttpMethod method, RequestOptions options) {
+    return request(method, null, options);
+  }
 
   /**
    * Like {@link #request(HttpMethod, RequestOptions)} using the {@code serverAddress} parameter to connect to the
@@ -171,10 +243,22 @@ public interface WebClient {
   /**
    * Create an HTTP request to send to the server using an absolute URI
    * @param method  the HTTP method
-   * @param absoluteURI  the absolute URI
+   * @param absoluteURI the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> requestAbs(HttpMethod method, String absoluteURI);
+  default HttpRequest<Buffer> requestAbs(HttpMethod method, String absoluteURI) {
+    return requestAbs(method, null, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP request to send to the server using an absolute URI
+   * @param method  the HTTP method
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> requestAbs(HttpMethod method, UriTemplate absoluteURI) {
+    return requestAbs(method, null, absoluteURI);
+  }
 
   /**
    * Like {@link #requestAbs(HttpMethod, String)} using the {@code serverAddress} parameter to connect to the
@@ -187,28 +271,74 @@ public interface WebClient {
   HttpRequest<Buffer> requestAbs(HttpMethod method, SocketAddress serverAddress, String absoluteURI);
 
   /**
-   * Create an HTTP GET request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
-   * @return  an HTTP client request object
+   * Like {@link #requestAbs(HttpMethod, UriTemplate)} using the {@code serverAddress} parameter to connect to the
+   * server instead of the {@code absoluteURI} parameter.
+   * <p>
+   * The request host header will still be created from the {@code absoluteURI} parameter.
+   * <p>
+   * Use {@link SocketAddress#domainSocketAddress(String)} to connect to a unix domain socket server.
    */
-  HttpRequest<Buffer> get(String requestURI);
+  HttpRequest<Buffer> requestAbs(HttpMethod method, SocketAddress serverAddress, UriTemplate absoluteURI);
+
+  /**
+   * Create an HTTP GET request to send to the server at the default host and port.
+   * @param requestURI the request URI
+   * @return an HTTP client request object
+   */
+  default HttpRequest<Buffer> get(String requestURI) {
+    return request(HttpMethod.GET, requestURI);
+  }
+
+  /**
+   * Create an HTTP GET request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return an HTTP client request object
+   */
+  default HttpRequest<Buffer> get(UriTemplate requestURI) {
+    return request(HttpMethod.GET, requestURI);
+  }
 
   /**
    * Create an HTTP GET request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> get(int port, String host, String requestURI);
+  default HttpRequest<Buffer> get(int port, String host, String requestURI) {
+    return request(HttpMethod.GET, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP GET request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> get(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.GET, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP GET request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> get(String host, String requestURI);
+  default HttpRequest<Buffer> get(String host, String requestURI) {
+    return request(HttpMethod.GET, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP GET request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> get(String host, UriTemplate requestURI) {
+    return request(HttpMethod.GET, host, requestURI);
+  }
 
   /**
    * Create an HTTP GET request to send to the server using an absolute URI, specifying a response handler to receive
@@ -216,31 +346,79 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> getAbs(String absoluteURI);
+  default HttpRequest<Buffer> getAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.GET, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP GET request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> getAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.GET, absoluteURI);
+  }
 
   /**
    * Create an HTTP POST request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> post(String requestURI);
+  default HttpRequest<Buffer> post(String requestURI) {
+    return request(HttpMethod.POST, requestURI);
+  }
+
+  /**
+   * Create an HTTP POST request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> post(UriTemplate requestURI) {
+    return request(HttpMethod.POST, requestURI);
+  }
 
   /**
    * Create an HTTP POST request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> post(int port, String host, String requestURI);
+  default HttpRequest<Buffer> post(int port, String host, String requestURI) {
+    return request(HttpMethod.POST, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP POST request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> post(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.POST, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP POST request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> post(String host, String requestURI);
+  default HttpRequest<Buffer> post(String host, String requestURI) {
+    return request(HttpMethod.POST, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP POST request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> post(String host, UriTemplate requestURI) {
+    return request(HttpMethod.POST, host, requestURI);
+  }
 
   /**
    * Create an HTTP POST request to send to the server using an absolute URI, specifying a response handler to receive
@@ -248,31 +426,79 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> postAbs(String absoluteURI);
+  default HttpRequest<Buffer> postAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.POST, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP POST request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absoluate URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> postAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.POST, absoluteURI);
+  }
 
   /**
    * Create an HTTP PUT request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> put(String requestURI);
+  default HttpRequest<Buffer> put(String requestURI) {
+    return request(HttpMethod.PUT, requestURI);
+  }
+
+  /**
+   * Create an HTTP PUT request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> put(UriTemplate requestURI) {
+    return request(HttpMethod.PUT, requestURI);
+  }
 
   /**
    * Create an HTTP PUT request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> put(int port, String host, String requestURI);
+  default HttpRequest<Buffer> put(int port, String host, String requestURI) {
+    return request(HttpMethod.PUT, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP PUT request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> put(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.PUT, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP PUT request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> put(String host, String requestURI);
+  default HttpRequest<Buffer> put(String host, String requestURI) {
+    return request(HttpMethod.PUT, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP PUT request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> put(String host, UriTemplate requestURI) {
+    return request(HttpMethod.PUT, host, requestURI);
+  }
 
   /**
    * Create an HTTP PUT request to send to the server using an absolute URI, specifying a response handler to receive
@@ -280,31 +506,79 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> putAbs(String absoluteURI);
+  default HttpRequest<Buffer> putAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.PUT, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP PUT request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> putAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.PUT, absoluteURI);
+  }
 
   /**
    * Create an HTTP DELETE request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> delete(String requestURI);
+  default HttpRequest<Buffer> delete(String requestURI) {
+    return request(HttpMethod.DELETE, requestURI);
+  }
+
+  /**
+   * Create an HTTP DELETE request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> delete(UriTemplate requestURI) {
+    return request(HttpMethod.DELETE, requestURI);
+  }
 
   /**
    * Create an HTTP DELETE request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> delete(int port, String host, String requestURI);
+  default HttpRequest<Buffer> delete(int port, String host, String requestURI) {
+    return request(HttpMethod.DELETE, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP DELETE request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> delete(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.DELETE, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP DELETE request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> delete(String host, String requestURI);
+  default HttpRequest<Buffer> delete(String host, String requestURI) {
+    return request(HttpMethod.DELETE, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP DELETE request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> delete(String host, UriTemplate requestURI) {
+    return request(HttpMethod.DELETE, host, requestURI);
+  }
 
   /**
    * Create an HTTP DELETE request to send to the server using an absolute URI, specifying a response handler to receive
@@ -312,31 +586,79 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> deleteAbs(String absoluteURI);
+  default HttpRequest<Buffer> deleteAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.DELETE, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP DELETE request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> deleteAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.DELETE, absoluteURI);
+  }
 
   /**
    * Create an HTTP PATCH request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> patch(String requestURI);
+  default HttpRequest<Buffer> patch(String requestURI) {
+    return request(HttpMethod.PATCH, requestURI);
+  }
+
+  /**
+   * Create an HTTP PATCH request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> patch(UriTemplate requestURI) {
+    return request(HttpMethod.PATCH, requestURI);
+  }
 
   /**
    * Create an HTTP PATCH request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> patch(int port, String host, String requestURI);
+  default HttpRequest<Buffer> patch(int port, String host, String requestURI) {
+    return request(HttpMethod.PATCH, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP PATCH request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> patch(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.PATCH, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP PATCH request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> patch(String host, String requestURI);
+  default HttpRequest<Buffer> patch(String host, String requestURI) {
+    return request(HttpMethod.PATCH, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP PATCH request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> patch(String host, UriTemplate requestURI) {
+    return request(HttpMethod.PATCH, host, requestURI);
+  }
 
   /**
    * Create an HTTP PATCH request to send to the server using an absolute URI, specifying a response handler to receive
@@ -344,31 +666,79 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> patchAbs(String absoluteURI);
+  default HttpRequest<Buffer> patchAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.PATCH, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP PATCH request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> patchAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.PATCH, absoluteURI);
+  }
 
   /**
    * Create an HTTP HEAD request to send to the server at the default host and port.
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> head(String requestURI);
+  default HttpRequest<Buffer> head(String requestURI) {
+    return request(HttpMethod.HEAD, requestURI);
+  }
+
+  /**
+   * Create an HTTP HEAD request to send to the server at the default host and port.
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> head(UriTemplate requestURI) {
+    return request(HttpMethod.HEAD, requestURI);
+  }
 
   /**
    * Create an HTTP HEAD request to send to the server at the specified host and port.
    * @param port  the port
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> head(int port, String host, String requestURI);
+  default HttpRequest<Buffer> head(int port, String host, String requestURI) {
+    return request(HttpMethod.HEAD, port, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP HEAD request to send to the server at the specified host and port.
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> head(int port, String host, UriTemplate requestURI) {
+    return request(HttpMethod.HEAD, port, host, requestURI);
+  }
 
   /**
    * Create an HTTP HEAD request to send to the server at the specified host and default port.
    * @param host  the host
-   * @param requestURI  the relative URI
+   * @param requestURI the request URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> head(String host, String requestURI);
+  default HttpRequest<Buffer> head(String host, String requestURI) {
+    return request(HttpMethod.HEAD, host, requestURI);
+  }
+
+  /**
+   * Create an HTTP HEAD request to send to the server at the specified host and default port.
+   * @param host  the host
+   * @param requestURI the request URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> head(String host, UriTemplate requestURI) {
+    return request(HttpMethod.HEAD, host, requestURI);
+  }
 
   /**
    * Create an HTTP HEAD request to send to the server using an absolute URI, specifying a response handler to receive
@@ -376,7 +746,19 @@ public interface WebClient {
    * @param absoluteURI  the absolute URI
    * @return  an HTTP client request object
    */
-  HttpRequest<Buffer> headAbs(String absoluteURI);
+  default HttpRequest<Buffer> headAbs(String absoluteURI) {
+    return requestAbs(HttpMethod.HEAD, absoluteURI);
+  }
+
+  /**
+   * Create an HTTP HEAD request to send to the server using an absolute URI, specifying a response handler to receive
+   * the response
+   * @param absoluteURI the absolute URI as a {@link UriTemplate}
+   * @return  an HTTP client request object
+   */
+  default HttpRequest<Buffer> headAbs(UriTemplate absoluteURI) {
+    return requestAbs(HttpMethod.HEAD, absoluteURI);
+  }
 
   /**
    * Close the client. Closing will close down any pooled connections.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
@@ -25,6 +25,7 @@ import io.vertx.core.impl.launcher.commands.VersionCommand;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.uritemplate.ExpandOptions;
 
 import java.util.List;
 import java.util.Set;
@@ -51,9 +52,12 @@ public class WebClientOptions extends HttpClientOptions {
    */
   public static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
 
+  public static final ExpandOptions DEFAULT_EXPAND_OPTIONS = null;
+
   private boolean userAgentEnabled = DEFAULT_USER_AGENT_ENABLED;
   private String userAgent = DEFAULT_USER_AGENT;
   private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+  private ExpandOptions templateExpandOptions = DEFAULT_EXPAND_OPTIONS;
 
   public WebClientOptions() {
   }
@@ -91,6 +95,7 @@ public class WebClientOptions extends HttpClientOptions {
     this.userAgentEnabled = other.userAgentEnabled;
     this.userAgent = other.userAgent;
     this.followRedirects = other.followRedirects;
+    this.templateExpandOptions = other.templateExpandOptions != null ? new ExpandOptions(other.templateExpandOptions) : null;
   }
 
   /**
@@ -155,6 +160,15 @@ public class WebClientOptions extends HttpClientOptions {
    */
   public WebClientOptions setFollowRedirects(boolean followRedirects) {
     this.followRedirects = followRedirects;
+    return this;
+  }
+
+  public ExpandOptions getTemplateExpandOptions() {
+    return templateExpandOptions;
+  }
+
+  public WebClientOptions setTemplateExpandOptions(ExpandOptions templateExpandOptions) {
+    this.templateExpandOptions = templateExpandOptions;
     return this;
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientUri.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/ClientUri.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2022 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.client.impl;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+class ClientUri {
+  final String protocol;
+  final Boolean ssl;
+  final int port;
+  final String host;
+  final String uri;
+
+  private ClientUri(String protocol, boolean ssl, int port, String host, String uri) {
+    this.protocol = protocol;
+    this.ssl = ssl;
+    this.port = port;
+    this.host = host;
+    this.uri = uri;
+  }
+
+  static ClientUri parse(String suri) throws URISyntaxException, MalformedURLException {
+    URL url = new URL(suri);
+    boolean ssl = false;
+    int port = url.getPort();
+    String protocol = url.getProtocol();
+    if ("ftp".equals(protocol)) {
+      if (port == -1) {
+        port = 21;
+      }
+    } else {
+      char chend = protocol.charAt(protocol.length() - 1);
+      if (chend == 'p') {
+        if (port == -1) {
+          port = 80;
+        }
+      } else if (chend == 's'){
+        ssl = true;
+        if (port == -1) {
+          port = 443;
+        }
+      }
+    }
+    String file = url.getFile();
+    String host = url.getHost();
+    return new ClientUri(protocol, ssl, port, host, file);
+  }
+}

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -181,7 +181,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     Boolean ssl;
     String uri;
     if (absoluteUri != null) {
-      uri = absoluteUri.expandToString(templateParams());
+      uri = absoluteUri.expandToString(templateParams(), client.options.getTemplateExpandOptions());
       ClientUri curi = ClientUri.parse(uri);
       uri = curi.uri;
       host = curi.host;
@@ -195,7 +195,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
       if (this.uri instanceof String) {
         uri = (String) this.uri;
       } else {
-        uri = ((UriTemplate) this.uri).expandToString(templateParams());
+        uri = ((UriTemplate) this.uri).expandToString(templateParams(), client.options.getTemplateExpandOptions());
       }
       protocol = null;
     }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -324,6 +324,12 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   @Override
+  public HttpRequest<T> setTemplateParam(String paramName, List<String> paramValue) {
+    templateParams().set(paramName, paramValue);
+    return this;
+  }
+
+  @Override
   public HttpRequest<T> setTemplateParam(String paramName, Map<String, String> paramValue) {
     templateParams().set(paramName, paramValue);
     return this;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
@@ -44,7 +44,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
 
   private void createRequest(HttpContext<?> context) {
 
-    HttpRequestImpl<?> request = (HttpRequestImpl<?>) context.request();
+    RequestOptions request = context.requestOptions();
 
     RequestOptions requestOptions = context.requestOptions();
     MultiMap headers = requestOptions.getHeaders();
@@ -54,12 +54,12 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     }
     headers.addAll(parentClient.headers());
 
-    String domain = request.virtualHost();
+    String domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
     if (domain == null) {
-      domain = request.host();
+      domain = requestOptions.getHost();
     }
 
-    Iterable<Cookie> cookies = parentClient.cookieStore().get(request.ssl, domain, request.uri);
+    Iterable<Cookie> cookies = parentClient.cookieStore().get(request.isSsl(), domain, request.getURI());
     String encodedCookies = ClientCookieEncoder.STRICT.encode(cookies);
     if (encodedCookies != null) {
       headers.add(HttpHeaders.COOKIE, encodedCookies);
@@ -78,11 +78,11 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
       return;
     }
 
-    HttpRequestImpl<?> originalRequest = (HttpRequestImpl<?>) context.request();
+    RequestOptions originalRequest = context.requestOptions();
     CookieStore cookieStore = parentClient.cookieStore();
     String domain = URI.create(context.clientResponse().request().absoluteURI()).getHost();
-    if (domain.equals(originalRequest.host()) && originalRequest.virtualHost != null) {
-      domain = originalRequest.virtualHost;
+    if (domain.equals(originalRequest.getHost()) && ((HttpRequestImpl<?>)context.request()).virtualHost != null) {
+      domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
     }
     final String finalDomain = domain;
     cookieHeaders.forEach(header -> {
@@ -102,17 +102,17 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     // Now the context contains the redirect request in clientRequest() and the original request in request()
     RequestOptions redirectRequest = context.requestOptions();
 
-    HttpRequestImpl<?> originalRequest = (HttpRequestImpl<?>) context.request();
+    RequestOptions originalRequest = context.requestOptions();
     String redirectHost = redirectRequest.getHost();
     String domain;
-    if (redirectHost.equals(originalRequest.host()) && originalRequest.virtualHost != null) {
-      domain = originalRequest.virtualHost;
+    if (redirectHost.equals(originalRequest.getHost()) && ((HttpRequestImpl<?>)context.request()).virtualHost != null) {
+      domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
     } else {
       domain = redirectHost;
     }
 
     String path = parsePath(redirectRequest.getURI());
-    Iterable<Cookie> cookies = parentClient.cookieStore().get(originalRequest.ssl, domain, path);
+    Iterable<Cookie> cookies = parentClient.cookieStore().get(originalRequest.isSsl(), domain, path);
     String encodedCookies = ClientCookieEncoder.STRICT.encode(cookies);
     if (encodedCookies != null) {
       redirectRequest.putHeader(HttpHeaders.COOKIE, encodedCookies);
@@ -152,7 +152,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
       return;
     }
 
-    HttpRequestImpl<?> request = (HttpRequestImpl<?>) context.request();
+    RequestOptions request = context.requestOptions();
     CookieStore cookieStore = parentClient.cookieStore();
     cookieHeaders.forEach(header -> {
       Cookie cookie = ClientCookieDecoder.STRICT.decode(header);
@@ -160,7 +160,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
         if (cookie.domain() == null) {
           // Set the domain if missing, because we need to send cookies
           // only to the domains we received them from.
-          cookie.setDomain(request.virtualHost != null ? request.virtualHost : request.host());
+          cookie.setDomain(((HttpRequestImpl<?>)context.request()).virtualHost != null ? ((HttpRequestImpl<?>)context.request()).virtualHost : request.getHost());
         }
         cookieStore.put(cookie);
       }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.uritemplate.ExpandOptions;
 import io.vertx.uritemplate.UriTemplate;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.impl.predicate.PredicateInterceptor;
@@ -46,8 +47,14 @@ public class WebClientBase implements WebClientInternal {
   final List<Handler<HttpContext<?>>> interceptors;
 
   public WebClientBase(HttpClient client, WebClientOptions options) {
+
+    options = new WebClientOptions(options);
+    if (options.getTemplateExpandOptions() == null) {
+      options.setTemplateExpandOptions(new ExpandOptions());
+    }
+
     this.client = client;
-    this.options = new WebClientOptions(options);
+    this.options = options;
     this.interceptors = new CopyOnWriteArrayList<>();
 
     // Add base interceptor

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -26,12 +26,13 @@ import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.uritemplate.UriTemplate;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.impl.predicate.PredicateInterceptor;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -60,201 +61,64 @@ public class WebClientBase implements WebClientInternal {
   }
 
   @Override
-  public HttpRequest<Buffer> get(int port, String host, String requestURI) {
-    return request(HttpMethod.GET, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> get(String requestURI) {
-    return request(HttpMethod.GET, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> get(String host, String requestURI) {
-    return request(HttpMethod.GET, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> getAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.GET, absoluteURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> post(String requestURI) {
-    return request(HttpMethod.POST, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> post(String host, String requestURI) {
-    return request(HttpMethod.POST, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> post(int port, String host, String requestURI) {
-    return request(HttpMethod.POST, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> put(String requestURI) {
-    return request(HttpMethod.PUT, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> put(String host, String requestURI) {
-    return request(HttpMethod.PUT, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> put(int port, String host, String requestURI) {
-    return request(HttpMethod.PUT, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> delete(String host, String requestURI) {
-    return request(HttpMethod.DELETE, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> delete(String requestURI) {
-    return request(HttpMethod.DELETE, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> delete(int port, String host, String requestURI) {
-    return request(HttpMethod.DELETE, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> patch(String requestURI) {
-    return request(HttpMethod.PATCH, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> patch(String host, String requestURI) {
-    return request(HttpMethod.PATCH, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> patch(int port, String host, String requestURI) {
-    return request(HttpMethod.PATCH, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> head(String requestURI) {
-    return request(HttpMethod.HEAD, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> head(String host, String requestURI) {
-    return request(HttpMethod.HEAD, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> head(int port, String host, String requestURI) {
-    return request(HttpMethod.HEAD, port, host, requestURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> postAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.POST, absoluteURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> putAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.PUT, absoluteURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> deleteAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.DELETE, absoluteURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> patchAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.PATCH, absoluteURI);
-  }
-
-  @Override
-  public HttpRequest<Buffer> headAbs(String absoluteURI) {
-    return requestAbs(HttpMethod.HEAD, absoluteURI);
-  }
-
-  public HttpRequest<Buffer> request(HttpMethod method, String requestURI) {
-    return request(method, (SocketAddress) null, requestURI);
-  }
-
-  @Override
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String requestURI) {
-    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), options.getDefaultPort(), options.getDefaultHost(),
-      requestURI, BodyCodecImpl.BUFFER, options);
+    return request(method, serverAddress, options.getDefaultPort(), options.getDefaultHost(), requestURI);
   }
 
   @Override
-  public HttpRequest<Buffer> request(HttpMethod method, RequestOptions requestOptions) {
-    return request(method, null, requestOptions);
+  public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, UriTemplate requestURI) {
+    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), options.getDefaultPort(), options.getDefaultHost(),
+      requestURI, BodyCodecImpl.BUFFER, options, null);
   }
 
   @Override
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, RequestOptions requestOptions) {
-      HttpRequestImpl<Buffer> request = new HttpRequestImpl<>(this, method, serverAddress, requestOptions.isSsl(), requestOptions.getPort(),
-      requestOptions.getHost(), requestOptions.getURI(), BodyCodecImpl.BUFFER, options, requestOptions.getProxyOptions());
-      return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
-  }
-
-  public HttpRequest<Buffer> request(HttpMethod method, String host, String requestURI) {
-    return request(method, null, host, requestURI);
+    Integer port = requestOptions.getPort();
+    if (port == null) {
+      port = options.getDefaultPort();
+    }
+    String host = requestOptions.getHost();
+    if (host == null) {
+      host = options.getDefaultHost();
+    }
+    HttpRequestImpl<Buffer> request = request(method, serverAddress, port, host, requestOptions.getURI());
+    return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
   }
 
   @Override
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String host, String requestURI) {
-    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), options.getDefaultPort(), host, requestURI, BodyCodecImpl.BUFFER, options);
-  }
-
-  public HttpRequest<Buffer> request(HttpMethod method, int port, String host, String requestURI) {
-    return request(method, null, port, host, requestURI);
+    return request(method, serverAddress, options.getDefaultPort(), host, requestURI);
   }
 
   @Override
-  public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, int port, String host, String requestURI) {
-    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), port, host, requestURI, BodyCodecImpl.BUFFER, options);
+  public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, String host, UriTemplate requestURI) {
+    return request(method, serverAddress, options.getDefaultPort(), host, requestURI);
   }
 
   @Override
-  public HttpRequest<Buffer> requestAbs(HttpMethod method, String surl) {
-    return requestAbs(method, null, surl);
+  public HttpRequestImpl<Buffer> request(HttpMethod method, SocketAddress serverAddress, int port, String host, String requestURI) {
+    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), port, host, requestURI, BodyCodecImpl.BUFFER, options, null);
+  }
+
+  @Override
+  public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, int port, String host, UriTemplate requestURI) {
+    return new HttpRequestImpl<>(this, method, serverAddress, options.isSsl(), port, host, requestURI, BodyCodecImpl.BUFFER, options, null);
   }
 
   @Override
   public HttpRequest<Buffer> requestAbs(HttpMethod method, SocketAddress serverAddress, String surl) {
-    // Note - parsing a URL this way is slower than specifying host, port and relativeURI
-    URL url;
+    ClientUri curi;
     try {
-      url = new URL(surl);
-    } catch (MalformedURLException e) {
-      throw new VertxException("Invalid url: " + surl, e);
+      curi = ClientUri.parse(surl);
+    } catch (URISyntaxException | MalformedURLException e) {
+      throw new VertxException(e);
     }
-    boolean ssl = false;
-    int port = url.getPort();
-    String protocol = url.getProtocol();
-    if ("ftp".equals(protocol)) {
-      if (port == -1) {
-        port = 21;
-      }
-    } else {
-      char chend = protocol.charAt(protocol.length() - 1);
-      if (chend == 'p') {
-        if (port == -1) {
-          port = 80;
-        }
-      } else if (chend == 's'){
-        ssl = true;
-        if (port == -1) {
-          port = 443;
-        }
-      }
-    }
-    return new HttpRequestImpl<>(this, method, serverAddress, protocol, ssl, port, url.getHost(), url.getFile(),
-            BodyCodecImpl.BUFFER, options, null);
+    return new HttpRequestImpl<>(this, method, serverAddress, curi.ssl, curi.port, curi.host, curi.uri, BodyCodecImpl.BUFFER, options, null);
+  }
+
+  @Override
+  public HttpRequest<Buffer> requestAbs(HttpMethod method, SocketAddress serverAddress, UriTemplate absoluteURI) {
+    return new HttpRequestImpl<>(this, method, serverAddress, absoluteURI,  BodyCodecImpl.BUFFER, options, null);
   }
 
   @Override
@@ -270,7 +134,7 @@ public class WebClientBase implements WebClientInternal {
   @Override
   public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
     HttpClientImpl client = (HttpClientImpl) this.client;
-    return new HttpContext<>(client, interceptors, handler);
+    return new HttpContext<>(client, options, interceptors, handler);
   }
 
   @Override

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheKey.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheKey.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.ext.web.client.impl.cache;
 
+import io.vertx.core.http.RequestOptions;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.spi.CacheStore;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,7 @@ public class CacheKey extends CacheVariationsKey {
 
   private final String variations;
 
-  public CacheKey(HttpRequest<?> request, Vary vary) {
+  public CacheKey(RequestOptions request, Vary vary) {
     super(request);
     this.variations = vary.toString();
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/Vary.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/Vary.java
@@ -17,7 +17,7 @@ package io.vertx.ext.web.client.impl.cache;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.core.http.RequestOptions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,7 +40,7 @@ public class Vary {
     this.variations = parseHeaders(responseHeaders);
   }
 
-  public boolean matchesRequest(HttpRequest<?> request) {
+  public boolean matchesRequest(RequestOptions request) {
     return variations.stream().allMatch(variation -> variationMatches(variation, request));
   }
 
@@ -55,7 +55,7 @@ public class Vary {
     return parts.stream().sorted().collect(Collectors.joining(","));
   }
 
-  private boolean variationMatches(CharSequence variation, HttpRequest<?> request) {
+  private boolean variationMatches(CharSequence variation, RequestOptions request) {
     if (HttpHeaders.USER_AGENT.equals(variation)) {
       return isUserAgentMatch(request);
     } else if (HttpHeaders.CONTENT_ENCODING.equals(variation)) {
@@ -67,15 +67,15 @@ public class Vary {
     }
   }
 
-  private boolean isUserAgentMatch(HttpRequest<?> request) {
+  private boolean isUserAgentMatch(RequestOptions request) {
     UserAgent original = UserAgent.parse(requestHeaders);
-    UserAgent current = UserAgent.parse(request.headers());
+    UserAgent current = UserAgent.parse(request.getHeaders());
 
     return original.equals(current);
   }
 
-  private boolean isEncodingMatch(HttpRequest<?> request) {
-    Set<String> req = normalizeValues(request.headers().getAll(HttpHeaders.ACCEPT_ENCODING));
+  private boolean isEncodingMatch(RequestOptions request) {
+    Set<String> req = normalizeValues(request.getHeaders().getAll(HttpHeaders.ACCEPT_ENCODING));
     Set<String> res = normalizeValues(responseHeaders.getAll(HttpHeaders.CONTENT_ENCODING));
 
     // If the request is asking for any form of encoding the response mentioned, assume a match
@@ -86,8 +86,8 @@ public class Vary {
     return !intersection.isEmpty();
   }
 
-  private boolean isExactMatch(CharSequence variation, HttpRequest<?> request) {
-    Set<String> a = normalizeValues(request.headers().getAll(variation));
+  private boolean isExactMatch(CharSequence variation, RequestOptions request) {
+    Set<String> a = normalizeValues(request.getHeaders().getAll(variation));
     Set<String> b = normalizeValues(requestHeaders.getAll(variation));
 
     return a.equals(b);

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
@@ -1,11 +1,14 @@
 package io.vertx.ext.web.client;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.uritemplate.ExpandOptions;
 import io.vertx.uritemplate.UriTemplate;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -76,5 +79,21 @@ public class UriTemplateTest extends WebClientTestBase {
       assertEquals("red", req.getParam("color"));
       assertEquals(EURO_SYMBOL, req.getParam("currency"));
     });
+  }
+
+  @Test
+  public void testIncomplete() throws Exception {
+    UriTemplate template = UriTemplate.of("/{missing}");
+    WebClient webClient = WebClient.create(vertx, new WebClientOptions()
+      .setDefaultPort(8080)
+      .setDefaultHost("localhost")
+      .setTemplateExpandOptions(new ExpandOptions()
+        .setAllowVariableMiss(false)));
+    HttpRequest<Buffer> request = webClient.get(template);
+    request.send(onFailure(err -> {
+      assertEquals(NoSuchElementException.class, err.getClass());
+      testComplete();
+    }));
+    await();
   }
 }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
@@ -1,0 +1,80 @@
+package io.vertx.ext.web.client;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.uritemplate.UriTemplate;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class UriTemplateTest extends WebClientTestBase {
+
+  private static final String EURO_SYMBOL = "\u20AC";
+
+  @Test
+  public void testUriTemplate() throws Exception {
+    UriTemplate template = UriTemplate.of("/test{?name}{&currency}");
+    testRequest(client ->
+        client.get(template)
+          .setTemplateParam("name", "Julien")
+          .setTemplateParam("currency", "\u20AC"),
+      req -> {
+        assertEquals("name=Julien&currency=%E2%82%AC", req.query());
+        assertEquals("Julien", req.params().get("name"));
+        assertEquals(EURO_SYMBOL, req.params().get("currency"));
+      });
+  }
+
+  @Test
+  public void testQueryParam() throws Exception {
+    UriTemplate template = UriTemplate.of("/{?name}{&currency}");
+    testRequest(client ->
+        client.get(template)
+          .setTemplateParam("name", "Julien")
+          .setTemplateParam("currency", EURO_SYMBOL)
+          .setQueryParam("city", "Marseille"),
+      req -> {
+        assertEquals("name=Julien&currency=%E2%82%AC&city=Marseille", req.query());
+        assertEquals("Julien", req.params().get("name"));
+        assertEquals(EURO_SYMBOL, req.params().get("currency"));
+        assertEquals("Marseille", req.params().get("city"));
+      });
+  }
+
+  @Test
+  public void testAbsoluteURI() throws Exception {
+    UriTemplate template = UriTemplate.of("http://{host}:{port}/{?name}{&currency}");
+    testRequest(client ->
+        client.requestAbs(HttpMethod.GET, template)
+          .setTemplateParam("host", "localhost")
+          .setTemplateParam("port", "8080")
+          .setTemplateParam("name", "Julien")
+          .setTemplateParam("currency", EURO_SYMBOL)
+          .setQueryParam("city", "Marseille"),
+      req -> {
+        assertEquals("name=Julien&currency=%E2%82%AC&city=Marseille", req.query());
+        assertEquals("Julien", req.params().get("name"));
+        assertEquals(EURO_SYMBOL, req.params().get("currency"));
+        assertEquals("Marseille", req.params().get("city"));
+      });
+  }
+
+  @Test
+  public void testTemplateExpansion() throws Exception {
+    Map<String, String> query = new HashMap<>();
+    query.put("color", "red");
+    query.put("currency", EURO_SYMBOL);
+    testRequest(client -> client.request(HttpMethod.GET, UriTemplate.of("/{action}?username={username}{&query*}"))
+      .setTemplateParam("action", "info")
+      .setTemplateParam("username", "vietj")
+      .setTemplateParam("query", query), req -> {
+      assertEquals("/info", req.path());
+      assertEquals("vietj", req.getParam("username"));
+      assertEquals("red", req.getParam("color"));
+      assertEquals(EURO_SYMBOL, req.getParam("currency"));
+    });
+  }
+}

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
@@ -21,14 +21,24 @@ import io.vertx.core.Handler;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.core.file.AsyncFile;
+import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpTestBase;
 import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.TestUtils;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -55,6 +65,66 @@ public class WebClientTestBase extends HttpTestBase {
     webClient = WebClient.wrap(client);
     server.close();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST));
+  }
+
+  protected void testRequest(Function<WebClient, HttpRequest<Buffer>> reqFactory, Consumer<HttpServerRequest> reqChecker) throws Exception {
+    waitFor(4);
+    server.requestHandler(req -> {
+      try {
+        reqChecker.accept(req);
+        complete();
+      } finally {
+        req.response().end();
+      }
+    });
+    startServer();
+    HttpRequest<Buffer> builder = reqFactory.apply(webClient);
+    builder.send(onSuccess(resp -> complete()));
+    builder.send(onSuccess(resp -> complete()));
+    await();
+  }
+
+  protected void testRequestWithBody(HttpMethod method, boolean chunked) throws Exception {
+    String expected = TestUtils.randomAlphaString(1024 * 1024);
+    File f = File.createTempFile("vertx", ".data");
+    f.deleteOnExit();
+    Files.write(f.toPath(), expected.getBytes(StandardCharsets.UTF_8));
+    waitFor(2);
+    server.requestHandler(req -> req.bodyHandler(buff -> {
+      assertEquals(method, req.method());
+      assertEquals(Buffer.buffer(expected), buff);
+      complete();
+      req.response().end();
+    }));
+    startServer();
+    vertx.runOnContext(v -> {
+      AsyncFile asyncFile = vertx.fileSystem().openBlocking(f.getAbsolutePath(), new OpenOptions());
+
+      HttpRequest<Buffer> builder = null;
+
+      switch (method.name()) {
+        case "POST":
+          builder = webClient.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+          break;
+        case "PUT":
+          builder = webClient.put(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+          break;
+        case "PATCH":
+          builder = webClient.patch(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+          break;
+        default:
+          fail("Invalid HTTP method");
+      }
+
+      if (!chunked) {
+        builder = builder.putHeader("Content-Length", "" + expected.length());
+      }
+      builder.sendStream(asyncFile, onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        complete();
+      }));
+    });
+    await();
   }
 
   protected void testResponseBody(String body, Handler<AsyncResult<HttpResponse<Buffer>>> checker) throws Exception {


### PR DESCRIPTION
Allow to create Web Client `HttpRequest` using a compiled URI Template based on [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) and parameterise it

```java
UriTemplate requestUri = UriTemplate.of("/some-uri?{param}");
Future<HttpResponse<Buffer>> response = client.get(8080, "myserver.mycompany.com", requestUri)
  .setTemplateParam("param", "param_value")
  .send();
```
