### PR TITLE
StaticHandler root access change

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Eclipse foundation
+ * Copyright 2021, 2022 The Eclipse foundation
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,8 @@
  */
 package io.vertx.ext.web.handler;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
  * Enumaration of FileSystem access permissions, used in
  * 
@@ -22,6 +24,7 @@ package io.vertx.ext.web.handler;
  * 
  * @author <a href="https://wissel.net">Stephan Wissel</a>
  */
+@VertxGen
 public enum FileSystemAccess {
 
     /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Eclipse foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.handler;
+
+/**
+ * Enumaration of FileSystem access permissions, used in
+ * 
+ * @see "StaticHandler"
+ * 
+ * @author <a href="https://wissel.net">Stephan Wissel</a>
+ */
+public enum FileSystemAccess {
+
+    /**
+     * Access to the full file system, starting at "/",
+     * Limited by the operating systems permission for
+     * the user running the app. Use with care to avoid
+     * indecent exposure
+     */
+    ROOT,
+
+    /**
+     * Access to files relative to the application's working
+     * directory including the Java class path.
+     * This is the recommended default option
+     */
+    RELATIVE
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -40,15 +40,15 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * Where can the static directory be located
    * relative to the working directory or anywhere on disk
    */
-  public enum HandlerPathOptions {
+  public enum StaticHandlerVisibility {
     /**
      * Absolute path, a.k.a. Root access
      */
-    ANY_PATH,
+    ROOT,
     /**
-     * Only relative to working directory / classpath
+     * Only relative to current working directory (CWD) / classpath
      */
-    RELATIVE_TO_WORKING_DIR
+    CWD
   }
 
   /**
@@ -139,7 +139,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create() {
-    return create(null, HandlerPathOptions.RELATIVE_TO_WORKING_DIR);
+    return create(null, StaticHandlerVisibility.CWD);
   }
 
   /**
@@ -149,18 +149,19 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create(String root) {
-    return create(root, HandlerPathOptions.RELATIVE_TO_WORKING_DIR);
+    return create(root, StaticHandlerVisibility.CWD);
   }
 
   /**
    * Create a handler, specifying web-root
    * and access option: absolute path or relative
    *
-   * @param root the web-root
+   * @param root              the web-root
+   * @param handlerVisibility CWD or file system root
    * @return the handler
    */
-  static StaticHandler create(String root, HandlerPathOptions pathOptions) {
-    return new StaticHandlerImpl(root, pathOptions);
+  static StaticHandler create(String root, StaticHandlerVisibility handlerVisibility) {
+    return new StaticHandlerImpl(root, handlerVisibility);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -37,21 +37,6 @@ import io.vertx.ext.web.handler.impl.StaticHandlerImpl;
 public interface StaticHandler extends Handler<RoutingContext> {
 
   /**
-   * Where can the static directory be located
-   * relative to the working directory or anywhere on disk
-   */
-  public enum StaticHandlerVisibility {
-    /**
-     * Absolute path, a.k.a. Root access
-     */
-    ROOT,
-    /**
-     * Only relative to current working directory (CWD) / classpath
-     */
-    CWD
-  }
-
-  /**
    * Default value of the web-root, where files are served from
    */
   String DEFAULT_WEB_ROOT = "webroot";
@@ -139,7 +124,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create() {
-    return create(null, StaticHandlerVisibility.CWD);
+    return create(FileSystemAccess.RELATIVE, null);
   }
 
   /**
@@ -149,19 +134,19 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create(String root) {
-    return create(root, StaticHandlerVisibility.CWD);
+    return create(FileSystemAccess.RELATIVE, root);
   }
 
   /**
    * Create a handler, specifying web-root
    * and access option: absolute path or relative
-   *
-   * @param root              the web-root
+   * 
    * @param handlerVisibility CWD or file system root
+   * @param root              the web-root
    * @return the handler
    */
-  static StaticHandler create(String root, StaticHandlerVisibility handlerVisibility) {
-    return new StaticHandlerImpl(root, handlerVisibility);
+  static StaticHandler create(FileSystemAccess handlerVisibility, String root) {
+    return new StaticHandlerImpl(handlerVisibility, root);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -16,6 +16,9 @@
 
 package io.vertx.ext.web.handler;
 
+import java.util.List;
+import java.util.Set;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
@@ -24,16 +27,29 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.common.WebEnvironment;
 import io.vertx.ext.web.handler.impl.StaticHandlerImpl;
 
-import java.util.List;
-import java.util.Set;
-
 /**
  * A handler for serving static resources from the file system or classpath.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="https://wissel.net">Stephan Wissel</a>
  */
 @VertxGen
 public interface StaticHandler extends Handler<RoutingContext> {
+
+  /**
+   * Where can the static directory be located
+   * relative to the working directory or anywhere on disk
+   */
+  public enum HandlerPathOptions {
+    /**
+     * Absolute path, a.k.a. Root access
+     */
+    ANY_PATH,
+    /**
+     * Only relative to working directory / classpath
+     */
+    RELATIVE_TO_WORKING_DIR
+  }
 
   /**
    * Default value of the web-root, where files are served from
@@ -106,7 +122,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   boolean DEFAULT_RANGE_SUPPORT = true;
 
   /**
-   * Default of whether access to the root of the file system should be allowed or just allow from the current working
+   * Default of whether access to the root of the file system should be allowed or
+   * just allow from the current working
    * directory.
    */
   boolean DEFAULT_ROOT_FILESYSTEM_ACCESS = false;
@@ -122,7 +139,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create() {
-    return new StaticHandlerImpl();
+    return create(null, HandlerPathOptions.RELATIVE_TO_WORKING_DIR);
   }
 
   /**
@@ -132,25 +149,41 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create(String root) {
-    return create().setWebRoot(root);
+    return create(root, HandlerPathOptions.RELATIVE_TO_WORKING_DIR);
+  }
+
+  /**
+   * Create a handler, specifying web-root
+   * and access option: absolute path or relative
+   *
+   * @param root the web-root
+   * @return the handler
+   */
+  static StaticHandler create(String root, HandlerPathOptions pathOptions) {
+    return new StaticHandlerImpl(root, pathOptions);
   }
 
   /**
    * Enable/Disable access to the root of the filesystem
-   *
+   * 
+   * @deprecated root file system access is set when constructed
+   * 
    * @param allowRootFileSystemAccess whether root access is allowed
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @Deprecated
   StaticHandler setAllowRootFileSystemAccess(boolean allowRootFileSystemAccess);
 
   /**
    * Set the web root
-   *
+   * 
+   * @deprecated webroot is set on creation only
    * @param webRoot the web root
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @Deprecated
   StaticHandler setWebRoot(String webRoot);
 
   /**
@@ -235,8 +268,10 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setHttp2PushMapping(List<Http2PushMapping> http2PushMappings);
 
   /**
-   * Skip compression if the media type of the file to send is in the provided {@code mediaTypes} set.
-   * {@code Content-Encoding} header set to {@code identity} for the types present in the {@code mediaTypes} set
+   * Skip compression if the media type of the file to send is in the provided
+   * {@code mediaTypes} set.
+   * {@code Content-Encoding} header set to {@code identity} for the types present
+   * in the {@code mediaTypes} set
    *
    * @param mediaTypes the set of mime types that are already compressed
    * @return a reference to this, so the API can be used fluently
@@ -245,8 +280,10 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler skipCompressionForMediaTypes(Set<String> mediaTypes);
 
   /**
-   * Skip compression if the suffix of the file to send is in the provided {@code fileSuffixes} set.
-   * {@code Content-Encoding} header set to {@code identity} for the suffixes present in the {@code fileSuffixes} set
+   * Skip compression if the suffix of the file to send is in the provided
+   * {@code fileSuffixes} set.
+   * {@code Content-Encoding} header set to {@code identity} for the suffixes
+   * present in the {@code fileSuffixes} set
    *
    * @param fileSuffixes the set of file suffixes that are already compressed
    * @return a reference to this, so the API can be used fluently
@@ -291,7 +328,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setDirectoryTemplate(String directoryTemplate);
 
   /**
-   * Set whether range requests (resumable downloads; media streaming) should be enabled.
+   * Set whether range requests (resumable downloads; media streaming) should be
+   * enabled.
    *
    * @param enableRangeSupport true to enable range support
    * @return a reference to this, so the API can be used fluently
@@ -309,7 +347,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setSendVaryHeader(boolean varyHeader);
 
   /**
-   * Set the default content encoding for text related files. This allows overriding the system settings default value.
+   * Set the default content encoding for text related files. This allows
+   * overriding the system settings default value.
    *
    * @param contentEncoding the desired content encoding e.g.: "UTF-8"
    * @return a reference to this, so the API can be used fluently

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -56,6 +56,7 @@ import io.vertx.core.net.impl.URIDecoder;
 import io.vertx.ext.web.Http2PushMapping;
 import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.FileSystemAccess;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.impl.LRUCache;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
@@ -95,12 +96,22 @@ public class StaticHandlerImpl implements StaticHandler {
   private final FSTune tune = new FSTune();
   private final FSPropsCache cache = new FSPropsCache();
 
-  public StaticHandlerImpl(String root, StaticHandlerVisibility visibility) {
+  /**
+   * Constructor called by static factory method
+   * 
+   * @param visibility          path specified by root is RELATIVE or ROOT
+   * @param staticRootDirectory path on host with static file location
+   */
+  public StaticHandlerImpl(FileSystemAccess visibility, String staticRootDirectory) {
 
-    this.allowRootFileSystemAccess = StaticHandlerVisibility.ROOT.equals(visibility);
-    this.setRoot(root != null ? root : DEFAULT_WEB_ROOT);
+    this.allowRootFileSystemAccess = FileSystemAccess.ROOT.equals(visibility);
+    this.setRoot(staticRootDirectory != null ? staticRootDirectory : DEFAULT_WEB_ROOT);
   }
 
+  /**
+   * Default constructor with DEFAULT_WEB_ROOT and
+   * relative file access only
+   */
   public StaticHandlerImpl() {
 
     this.allowRootFileSystemAccess = false;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -73,6 +73,7 @@ public class StaticHandlerImpl implements StaticHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(StaticHandlerImpl.class);
 
+  // TODO change to private final after setWebRoot has been removed
   private String webRoot = DEFAULT_WEB_ROOT;
   private long maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS; // One day
   private boolean directoryListing = DEFAULT_DIRECTORY_LISTING;
@@ -97,10 +98,13 @@ public class StaticHandlerImpl implements StaticHandler {
   public StaticHandlerImpl(String root, HandlerPathOptions options) {
 
     this.allowRootFileSystemAccess = HandlerPathOptions.ANY_PATH.equals(options);
+    this.setRoot(root != null ? root : DEFAULT_WEB_ROOT);
+  }
 
-    if (root != null) {
-      this.setRoot(root);
-    }
+  public StaticHandlerImpl() {
+
+    this.allowRootFileSystemAccess = false;
+    this.setRoot(DEFAULT_WEB_ROOT);
   }
 
   private String directoryTemplate(FileSystem fileSystem) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -95,9 +95,9 @@ public class StaticHandlerImpl implements StaticHandler {
   private final FSTune tune = new FSTune();
   private final FSPropsCache cache = new FSPropsCache();
 
-  public StaticHandlerImpl(String root, HandlerPathOptions options) {
+  public StaticHandlerImpl(String root, StaticHandlerVisibility visibility) {
 
-    this.allowRootFileSystemAccess = HandlerPathOptions.ANY_PATH.equals(options);
+    this.allowRootFileSystemAccess = StaticHandlerVisibility.ROOT.equals(visibility);
     this.setRoot(root != null ? root : DEFAULT_WEB_ROOT);
   }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -104,7 +104,17 @@ public class StaticHandlerImpl implements StaticHandler {
    */
   public StaticHandlerImpl(FileSystemAccess visibility, String staticRootDirectory) {
 
-    this.allowRootFileSystemAccess = FileSystemAccess.ROOT.equals(visibility);
+    switch (visibility) {
+      case ROOT:
+        this.allowRootFileSystemAccess = true;
+        break;
+      case RELATIVE:
+        this.allowRootFileSystemAccess = false;
+        break;
+      default:
+        throw new IllegalStateException("Unsupported visibility: " + visibility);
+    }
+
     this.setRoot(staticRootDirectory != null ? staticRootDirectory : DEFAULT_WEB_ROOT);
   }
 


### PR DESCRIPTION
Motivation:

When creating a static handler with an absolute source path outside the working directory, the code is currently confusing:

```java
StaticHandler.create()
      .setAllowRootFileSystemAccess(true)
      .setWebRoot("/somedir");
```
after the change the same code will be:

```java
StaticHandler.create("/somedir", StaticHandlerVisibility.ROOT);
```

(P.S. all formatting changes were inflicted by VSCode Quarkus tooling - happy to reconfigure, if guidance can be provided)