### PR TITLE
StaticHandler root access change (replaces #2099)

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/FileSystemAccess.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021, 2022 The Eclipse foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.handler;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Enumaration of FileSystem access permissions, used in
+ * 
+ * @see "StaticHandler"
+ * 
+ * @author <a href="https://wissel.net">Stephan Wissel</a>
+ */
+@VertxGen
+public enum FileSystemAccess {
+
+    /**
+     * Access to the full file system, starting at "/",
+     * Limited by the operating systems permission for
+     * the user running the app. Use with care to avoid
+     * indecent exposure
+     */
+    ROOT,
+
+    /**
+     * Access to files relative to the application's working
+     * directory including the Java class path.
+     * This is the recommended default option
+     */
+    RELATIVE
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/StaticHandler.java
@@ -16,6 +16,9 @@
 
 package io.vertx.ext.web.handler;
 
+import java.util.List;
+import java.util.Set;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
@@ -23,9 +26,6 @@ import io.vertx.ext.web.Http2PushMapping;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.common.WebEnvironment;
 import io.vertx.ext.web.handler.impl.StaticHandlerImpl;
-
-import java.util.List;
-import java.util.Set;
 
 /**
  * A handler for serving static resources from the file system or classpath.
@@ -106,7 +106,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   boolean DEFAULT_RANGE_SUPPORT = true;
 
   /**
-   * Default of whether access to the root of the file system should be allowed or just allow from the current working
+   * Default of whether access to the root of the file system should be allowed or
+   * just allow from the current working
    * directory.
    */
   boolean DEFAULT_ROOT_FILESYSTEM_ACCESS = false;
@@ -122,7 +123,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create() {
-    return new StaticHandlerImpl();
+    return create(FileSystemAccess.RELATIVE, null);
   }
 
   /**
@@ -132,7 +133,19 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return the handler
    */
   static StaticHandler create(String root) {
-    return create().setWebRoot(root);
+    return create(FileSystemAccess.RELATIVE, root);
+  }
+
+  /**
+   * Create a handler, specifying web-root
+   * and access option: absolute path or relative
+   * 
+   * @param handlerVisibility CWD or file system root
+   * @param root              the web-root
+   * @return the handler
+   */
+  static StaticHandler create(FileSystemAccess handlerVisibility, String root) {
+    return new StaticHandlerImpl(handlerVisibility, root);
   }
 
   /**
@@ -142,6 +155,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @Deprecated
   StaticHandler setAllowRootFileSystemAccess(boolean allowRootFileSystemAccess);
 
   /**
@@ -151,6 +165,7 @@ public interface StaticHandler extends Handler<RoutingContext> {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
+  @Deprecated
   StaticHandler setWebRoot(String webRoot);
 
   /**
@@ -235,8 +250,10 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setHttp2PushMapping(List<Http2PushMapping> http2PushMappings);
 
   /**
-   * Skip compression if the media type of the file to send is in the provided {@code mediaTypes} set.
-   * {@code Content-Encoding} header set to {@code identity} for the types present in the {@code mediaTypes} set
+   * Skip compression if the media type of the file to send is in the provided
+   * {@code mediaTypes} set.
+   * {@code Content-Encoding} header set to {@code identity} for the types present
+   * in the {@code mediaTypes} set
    *
    * @param mediaTypes the set of mime types that are already compressed
    * @return a reference to this, so the API can be used fluently
@@ -245,8 +262,10 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler skipCompressionForMediaTypes(Set<String> mediaTypes);
 
   /**
-   * Skip compression if the suffix of the file to send is in the provided {@code fileSuffixes} set.
-   * {@code Content-Encoding} header set to {@code identity} for the suffixes present in the {@code fileSuffixes} set
+   * Skip compression if the suffix of the file to send is in the provided
+   * {@code fileSuffixes} set.
+   * {@code Content-Encoding} header set to {@code identity} for the suffixes
+   * present in the {@code fileSuffixes} set
    *
    * @param fileSuffixes the set of file suffixes that are already compressed
    * @return a reference to this, so the API can be used fluently
@@ -291,7 +310,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setDirectoryTemplate(String directoryTemplate);
 
   /**
-   * Set whether range requests (resumable downloads; media streaming) should be enabled.
+   * Set whether range requests (resumable downloads; media streaming) should be
+   * enabled.
    *
    * @param enableRangeSupport true to enable range support
    * @return a reference to this, so the API can be used fluently
@@ -309,7 +329,8 @@ public interface StaticHandler extends Handler<RoutingContext> {
   StaticHandler setSendVaryHeader(boolean varyHeader);
 
   /**
-   * Set the default content encoding for text related files. This allows overriding the system settings default value.
+   * Set the default content encoding for text related files. This allows
+   * overriding the system settings default value.
    *
    * @param contentEncoding the desired content encoding e.g.: "UTF-8"
    * @return a reference to this, so the API can be used fluently

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -16,10 +16,37 @@
 
 package io.vertx.ext.web.handler.impl;
 
-import io.vertx.core.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_MODIFIED;
+import static io.netty.handler.codec.http.HttpResponseStatus.PARTIAL_CONTENT;
+import static io.netty.handler.codec.http.HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.file.FileProps;
 import io.vertx.core.file.FileSystem;
-import io.vertx.core.http.*;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.http.impl.MimeMapping;
 import io.vertx.core.impl.logging.Logger;
@@ -29,19 +56,11 @@ import io.vertx.core.net.impl.URIDecoder;
 import io.vertx.ext.web.Http2PushMapping;
 import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.FileSystemAccess;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.impl.LRUCache;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.impl.Utils;
-
-import java.io.File;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
 
 /**
  * Static web server
@@ -49,11 +68,13 @@ import static io.netty.handler.codec.http.HttpResponseStatus.*;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
+ * @author <a href="https://wissel.net">Stephan Wissel</a>
  */
 public class StaticHandlerImpl implements StaticHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(StaticHandlerImpl.class);
 
+  // TODO change to private final after setWebRoot has been removed
   private String webRoot = DEFAULT_WEB_ROOT;
   private long maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS; // One day
   private boolean directoryListing = DEFAULT_DIRECTORY_LISTING;
@@ -64,6 +85,7 @@ public class StaticHandlerImpl implements StaticHandler {
   private String indexPage = DEFAULT_INDEX_PAGE;
   private List<Http2PushMapping> http2PushMappings;
   private boolean rangeSupport = DEFAULT_RANGE_SUPPORT;
+  // TODO change to private final after setAllowRootAccess has been removed
   private boolean allowRootFileSystemAccess = DEFAULT_ROOT_FILESYSTEM_ACCESS;
   private boolean sendVaryHeader = DEFAULT_SEND_VARY_HEADER;
   private String defaultContentEncoding = Charset.defaultCharset().name();
@@ -74,17 +96,50 @@ public class StaticHandlerImpl implements StaticHandler {
   private final FSTune tune = new FSTune();
   private final FSPropsCache cache = new FSPropsCache();
 
+  /**
+   * Constructor called by static factory method
+   * 
+   * @param visibility          path specified by root is RELATIVE or ROOT
+   * @param staticRootDirectory path on host with static file location
+   */
+  public StaticHandlerImpl(FileSystemAccess visibility, String staticRootDirectory) {
+
+    switch (visibility) {
+      case ROOT:
+        this.allowRootFileSystemAccess = true;
+        break;
+      case RELATIVE:
+        this.allowRootFileSystemAccess = false;
+        break;
+      default:
+        throw new IllegalStateException("Unsupported visibility: " + visibility);
+    }
+
+    this.setRoot(staticRootDirectory != null ? staticRootDirectory : DEFAULT_WEB_ROOT);
+  }
+
+  /**
+   * Default constructor with DEFAULT_WEB_ROOT and
+   * relative file access only
+   */
+  public StaticHandlerImpl() {
+
+    this.allowRootFileSystemAccess = false;
+    this.setRoot(DEFAULT_WEB_ROOT);
+  }
+
   private String directoryTemplate(FileSystem fileSystem) {
     if (directoryTemplate == null) {
       directoryTemplate = fileSystem
-        .readFileBlocking(directoryTemplateResource)
-        .toString(StandardCharsets.UTF_8);
+          .readFileBlocking(directoryTemplateResource)
+          .toString(StandardCharsets.UTF_8);
     }
     return directoryTemplate;
   }
 
   /**
-   * Create all required header so content can be cache by Caching servers or Browsers
+   * Create all required header so content can be cache by Caching servers or
+   * Browsers
    *
    * @param request base HttpServerRequest
    * @param props   file properties
@@ -112,7 +167,8 @@ public class StaticHandlerImpl implements StaticHandler {
   public void handle(RoutingContext context) {
     HttpServerRequest request = context.request();
     if (request.method() != HttpMethod.GET && request.method() != HttpMethod.HEAD) {
-      if (LOG.isTraceEnabled()) LOG.trace("Not GET or HEAD so ignoring request");
+      if (LOG.isTraceEnabled())
+        LOG.trace("Not GET or HEAD so ignoring request");
       context.next();
     } else {
       // decode URL path
@@ -130,11 +186,12 @@ public class StaticHandlerImpl implements StaticHandler {
       FileSystem fs = context.vertx().fileSystem();
 
       sendStatic(
-        context,
-        fs,
-        path,
-        // only root is known for sure to be a directory. all other directories must be identified as such.
-        !directoryListing && "/".equals(path));
+          context,
+          fs,
+          path,
+          // only root is known for sure to be a directory. all other directories must be
+          // identified as such.
+          !directoryListing && "/".equals(path));
     }
   }
 
@@ -176,8 +233,8 @@ public class StaticHandlerImpl implements StaticHandler {
 
         if (Utils.fresh(context, lastModified)) {
           context.response()
-            .setStatusCode(NOT_MODIFIED.code())
-            .end();
+              .setStatusCode(NOT_MODIFIED.code())
+              .end();
           return;
         }
       }
@@ -203,60 +260,60 @@ public class StaticHandlerImpl implements StaticHandler {
 
     // verify if the file exists
     fileSystem
-      .exists(localFile, exists -> {
-        if (exists.failed()) {
-          context.fail(exists.cause());
-          return;
-        }
-
-        // file does not exist, continue...
-        if (!exists.result()) {
-          if (cache.enabled()) {
-            cache.put(path, null);
+        .exists(localFile, exists -> {
+          if (exists.failed()) {
+            context.fail(exists.cause());
+            return;
           }
-          context.next();
-          return;
-        }
 
-        // Need to read the props from the filesystem
-        getFileProps(fileSystem, localFile, res -> {
-          if (res.succeeded()) {
-            FileProps fprops = res.result();
-            if (fprops == null) {
-              // File does not exist
-              if (dirty) {
-                cache.remove(path);
-              }
-              context.next();
-            } else if (fprops.isDirectory()) {
-              if (index) {
-                // file does not exist (well it exists but it's a directory), continue...
-                if (cache.enabled()) {
-                  cache.put(path, null);
-                }
-                context.next();
-              } else {
+          // file does not exist, continue...
+          if (!exists.result()) {
+            if (cache.enabled()) {
+              cache.put(path, null);
+            }
+            context.next();
+            return;
+          }
+
+          // Need to read the props from the filesystem
+          getFileProps(fileSystem, localFile, res -> {
+            if (res.succeeded()) {
+              FileProps fprops = res.result();
+              if (fprops == null) {
+                // File does not exist
                 if (dirty) {
                   cache.remove(path);
                 }
-                sendDirectory(context, fileSystem, path, localFile);
+                context.next();
+              } else if (fprops.isDirectory()) {
+                if (index) {
+                  // file does not exist (well it exists but it's a directory), continue...
+                  if (cache.enabled()) {
+                    cache.put(path, null);
+                  }
+                  context.next();
+                } else {
+                  if (dirty) {
+                    cache.remove(path);
+                  }
+                  sendDirectory(context, fileSystem, path, localFile);
+                }
+              } else {
+                if (cache.enabled()) {
+                  cache.put(path, fprops);
+
+                  if (Utils.fresh(context, Utils.secondsFactor(fprops.lastModifiedTime()))) {
+                    context.response().setStatusCode(NOT_MODIFIED.code()).end();
+                    return;
+                  }
+                }
+                sendFile(context, fileSystem, localFile, fprops);
               }
             } else {
-              if (cache.enabled()) {
-                cache.put(path, fprops);
-
-                if (Utils.fresh(context, Utils.secondsFactor(fprops.lastModifiedTime()))) {
-                  context.response().setStatusCode(NOT_MODIFIED.code()).end();
-                  return;
-                }
-              }
-              sendFile(context, fileSystem, localFile, fprops);
+              context.fail(res.cause());
             }
-          } else {
-            context.fail(res.cause());
-          }
+          });
         });
-      });
   }
 
   /**
@@ -267,9 +324,9 @@ public class StaticHandlerImpl implements StaticHandler {
     // the user is requesting a directory (ends with /)
     if (!path.endsWith("/")) {
       context.response()
-        .putHeader(HttpHeaders.LOCATION, path + "/")
-        .setStatusCode(301)
-        .end();
+          .putHeader(HttpHeaders.LOCATION, path + "/")
+          .setStatusCode(301)
+          .end();
       return;
     }
 
@@ -431,7 +488,7 @@ public class StaticHandlerImpl implements StaticHandler {
           }
 
         } else if (http2PushMappings != null) {
-          //Link preload when file push is not supported
+          // Link preload when file push is not supported
           List<String> links = new ArrayList<>();
           for (Http2PushMapping dependency : http2PushMappings) {
             final String dep = webRoot + "/" + dependency.getFilePath();
@@ -441,7 +498,7 @@ public class StaticHandlerImpl implements StaticHandler {
                 // push
                 writeCacheHeaders(request, filePropsAsyncResult.result());
                 links.add("<" + dependency.getFilePath() + ">; rel=preload; as="
-                  + dependency.getExtensionTarget() + (dependency.isNoPush() ? "; nopush" : ""));
+                    + dependency.getExtensionTarget() + (dependency.isNoPush() ? "; nopush" : ""));
               }
             });
           }
@@ -457,13 +514,21 @@ public class StaticHandlerImpl implements StaticHandler {
     }
   }
 
+  /**
+   * @deprecated - Use the parameters in constructor
+   */
   @Override
+  @Deprecated
   public StaticHandler setAllowRootFileSystemAccess(boolean allowRootFileSystemAccess) {
     this.allowRootFileSystemAccess = allowRootFileSystemAccess;
     return this;
   }
 
+  /**
+   * @deprecated - Use the parameters in constructor
+   */
   @Override
+  @Deprecated
   public StaticHandler setWebRoot(String webRoot) {
     setRoot(webRoot);
     return this;
@@ -613,10 +678,9 @@ public class StaticHandlerImpl implements StaticHandler {
   }
 
   private static final Collection<MIMEHeader> DIRECTORY_LISTING_ACCEPT = Arrays.asList(
-    new ParsableMIMEValue("text/html").forceParse(),
-    new ParsableMIMEValue("text/plain").forceParse(),
-    new ParsableMIMEValue("application/json").forceParse()
-  );
+      new ParsableMIMEValue("text/html").forceParse(),
+      new ParsableMIMEValue("text/plain").forceParse(),
+      new ParsableMIMEValue("application/json").forceParse());
 
   private void sendDirectoryListing(FileSystem fileSystem, String dir, RoutingContext context) {
     final HttpServerResponse response = context.response();
@@ -632,7 +696,7 @@ public class StaticHandlerImpl implements StaticHandler {
 
         if (accepts != null) {
           MIMEHeader header = context.parsedHeaders()
-            .findBestUserAcceptedIn(context.parsedHeaders().accept(), DIRECTORY_LISTING_ACCEPT);
+              .findBestUserAcceptedIn(context.parsedHeaders().accept(), DIRECTORY_LISTING_ACCEPT);
 
           if (header != null) {
             accept = header.component() + "/" + header.subComponent();
@@ -681,11 +745,11 @@ public class StaticHandlerImpl implements StaticHandler {
             String parent = "<a href=\"" + normalizedDir.substring(0, slashPos + 1) + "\">..</a>";
 
             response
-              .putHeader(HttpHeaders.CONTENT_TYPE, "text/html")
-              .end(
-                directoryTemplate(fileSystem).replace("{directory}", normalizedDir)
-                  .replace("{parent}", parent)
-                  .replace("{files}", files.toString()));
+                .putHeader(HttpHeaders.CONTENT_TYPE, "text/html")
+                .end(
+                    directoryTemplate(fileSystem).replace("{directory}", normalizedDir)
+                        .replace("{parent}", parent)
+                        .replace("{files}", files.toString()));
             break;
           case "application/json":
             JsonArray json = new JsonArray();
@@ -699,8 +763,8 @@ public class StaticHandlerImpl implements StaticHandler {
               json.add(file);
             }
             response
-              .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-              .end(json.encode());
+                .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .end(json.encode());
             break;
           default:
             StringBuilder buffer = new StringBuilder();
@@ -716,8 +780,8 @@ public class StaticHandlerImpl implements StaticHandler {
             }
 
             response
-              .putHeader(HttpHeaders.CONTENT_TYPE, "text/plain")
-              .end(buffer.toString());
+                .putHeader(HttpHeaders.CONTENT_TYPE, "text/plain")
+                .end(buffer.toString());
         }
       }
     });
@@ -753,7 +817,8 @@ public class StaticHandlerImpl implements StaticHandler {
   }
 
   private static class FSTune {
-    // These members are all related to auto tuning of synchronous vs asynchronous file system access
+    // These members are all related to auto tuning of synchronous vs asynchronous
+    // file system access
     private static final int NUM_SERVES_TUNING_FS_ACCESS = 1000;
 
     // these variables are read often and should always represent the
@@ -798,7 +863,9 @@ public class StaticHandlerImpl implements StaticHandler {
         if (avg > maxAvgServeTimeNanoSeconds) {
           useAsyncFS = true;
           if (LOG.isInfoEnabled()) {
-            LOG.info("Switching to async file system access in static file server as fs access is slow! (Average access time of " + avg + " ns)");
+            LOG.info(
+                "Switching to async file system access in static file server as fs access is slow! (Average access time of "
+                    + avg + " ns)");
           }
           enabled = false;
         }


### PR DESCRIPTION
Replaces PR #2099

- added scope RELATIVE or ROOT in constructor
- flagged obsolete properties as deprecated

Motivation:

When creating a static handler with an absolute source path outside the working directory, the code is currently confusing:

```java
StaticHandler.create()
      .setAllowRootFileSystemAccess(true)
      .setWebRoot("/somedir");
```

after the change the same code will be:

```java
StaticHandler.create(FileSystemAccess.RELATIVE, "/somedir");
```

(P.S. all formatting changes were inflicted by VSCode Quarkus tooling - happy to reconfigure, if guidance can be provided)