### PR TITLE
Laxing the vary header according to: https://fetch.spec.whatwg.org/#c…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -174,7 +174,7 @@ public class CorsHandlerImpl implements CorsHandler {
     if (origin == null) {
       // https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
       // If CORS protocol requirements are more complicated than setting `Access-Control-Allow-Origin` to *
-      // `Vary` is to be used.
+      // or a static origin, `Vary` is to be used.
       if (!starOrigin() && !staticOrigin()) {
         Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
       }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -164,7 +164,10 @@ public class CorsHandlerImpl implements CorsHandler {
     HttpServerResponse response = context.response();
     String origin = context.request().headers().get(ORIGIN);
     if (origin == null) {
-      Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
+      // allowed origin: *
+      if (allowedOrigin == null && allowedOrigins == null) {
+        Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
+      }
       // Not a CORS request - we don't set any headers and just call the next handler
       context.next();
     } else if (isValidOrigin(origin)) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -67,6 +67,14 @@ public class CorsHandlerImpl implements CorsHandler {
     allowedOrigins = null;
   }
 
+  private boolean starOrigin() {
+    return allowedOrigin == null && allowedOrigins == null;
+  }
+
+  private boolean staticOrigin() {
+    return allowedOrigin == null && allowedOrigins != null && allowedOrigins.size() == 1;
+  }
+
   @Override
   public CorsHandler addOrigin(String origin) {
     if (allowedOrigin != null) {
@@ -164,8 +172,10 @@ public class CorsHandlerImpl implements CorsHandler {
     HttpServerResponse response = context.response();
     String origin = context.request().headers().get(ORIGIN);
     if (origin == null) {
-      // allowed origin: *
-      if (allowedOrigin == null && allowedOrigins == null) {
+      // https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
+      // If CORS protocol requirements are more complicated than setting `Access-Control-Allow-Origin` to *
+      // `Vary` is to be used.
+      if (!starOrigin() && !staticOrigin()) {
         Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
       }
       // Not a CORS request - we don't set any headers and just call the next handler
@@ -229,8 +239,8 @@ public class CorsHandlerImpl implements CorsHandler {
 
   private boolean isValidOrigin(String origin) {
 
-    // Null means accept all origins
-    if (allowedOrigin == null && allowedOrigins == null) {
+    // * means accept all origins
+    if (starOrigin()) {
       return Origin.isValid(origin);
     }
 
@@ -250,10 +260,9 @@ public class CorsHandlerImpl implements CorsHandler {
   }
 
   private String getAllowedOrigin(String origin) {
-    if(allowedOrigin == null && allowedOrigins == null) {
+    if(starOrigin()) {
       return "*";
     }
-
     return origin;
   }
 }


### PR DESCRIPTION
…ors-protocol-and-http-caches

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Discussing the issue: https://github.com/vert-x3/vertx-web/issues/2115

@MarcelWaldvogel If I understand this correctly, and reading further:

1. https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
2. https://bugs.chromium.org/p/chromium/issues/detail?id=855713#c4

To improve the caching, hits **YET** ensuring that the CORS resources don't leak to non-CORS requests, we should only send the `VARY` if the handler is not configured with a wildcard. (We could improve the if statement to also consider a single static origin).

Can you describe an example from your side where things are not optimal and if this change would suffice? 