### PR TITLE
feat: Introduce an optional OAuth2WebClient behavior where only a fir…

### DIFF
--- a/vertx-web-client/src/main/generated/io/vertx/ext/web/client/OAuth2WebClientOptionsConverter.java
+++ b/vertx-web-client/src/main/generated/io/vertx/ext/web/client/OAuth2WebClientOptionsConverter.java
@@ -20,6 +20,11 @@ public class OAuth2WebClientOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, OAuth2WebClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "failFast":
+          if (member.getValue() instanceof Boolean) {
+            obj.setFailFast((Boolean)member.getValue());
+          }
+          break;
         case "leeway":
           if (member.getValue() instanceof Number) {
             obj.setLeeway(((Number)member.getValue()).intValue());
@@ -39,6 +44,7 @@ public class OAuth2WebClientOptionsConverter {
   }
 
   public static void toJson(OAuth2WebClientOptions obj, java.util.Map<String, Object> json) {
+    json.put("failFast", obj.getFailFast());
     json.put("leeway", obj.getLeeway());
     json.put("renewTokenOnForbidden", obj.isRenewTokenOnForbidden());
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/OAuth2WebClientOptions.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/OAuth2WebClientOptions.java
@@ -35,8 +35,14 @@ public class OAuth2WebClientOptions {
    */
   public static final int DEFAULT_LEEWAY = 0;
 
+  /**
+   * The default fail fast of requests they happen while refreshing/loading token.
+   */
+  public static final boolean DEFAULT_FAIL_FAST = true;
+
   private boolean renewTokenOnForbidden = DEFAULT_RENEW_TOKEN_ON_FORBIDDEN;
   private int leeway = DEFAULT_LEEWAY;
+  private boolean failFast = DEFAULT_FAIL_FAST;
 
   public OAuth2WebClientOptions() {
   }
@@ -109,6 +115,27 @@ public class OAuth2WebClientOptions {
    */
   public OAuth2WebClientOptions setLeeway(int leeway) {
     this.leeway = leeway;
+    return this;
+  }
+
+  /**
+   * Should all requests that happen while this object is refreshing/loading token fail as soon as possible, or queue
+   * the incoming requests until the in flight operation completes.
+   *
+   * @return default value is {@link #DEFAULT_FAIL_FAST}
+   */
+  public boolean getFailFast() {
+    return failFast;
+  }
+
+  /**
+   * Set if all requests that happen while this object is refreshing/loading token should fail as soon as possible.
+   *
+   * @param failFast requests while refreshing/loading token
+   * @return fluent self
+   */
+  public OAuth2WebClientOptions setFailFast(boolean failFast) {
+    this.failFast = failFast;
     return this;
   }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/Oauth2WebClientAware.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/Oauth2WebClientAware.java
@@ -38,7 +38,7 @@ public class Oauth2WebClientAware extends WebClientBase implements OAuth2WebClie
     }
     this.option = options;
 
-    addInterceptor(new OAuth2AwareInterceptor(this));
+    addInterceptor(new OAuth2AwareInterceptor(this, options.getFailFast()));
   }
 
   @Override


### PR DESCRIPTION
…st authentication request will reach the server. Default disabled (fail fast subsequent requests)

Signed-off-by: Michel Werren <michel.werren@gmail.com>

Motivation:

Introducing of an optional queuing like mechanism while an authentication request is pending. So it's possible to avoid request hammering in that situation, as if the IdP has a rate limit, this could end in a death lock like result.
