### PR TITLE
issue-2134/ Fix CacheVariationKey affected by HttpReqImpl mutability

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKey.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKey.java
@@ -35,8 +35,8 @@ class CacheVariationsKey {
     HttpRequestImpl<?> impl = (HttpRequestImpl<?>) request;
     this.host = impl.host();
     this.port = impl.port();
-    this.path = impl.uri();
     this.queryString = queryString(impl.queryParams());
+    this.path = impl.uri();
   }
 
   @Override

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
@@ -792,7 +792,7 @@ public class CachingWebClientTest {
   }
 
   @Test
-  public void testVaryEncodingIsIgnored(TestContext context) {
+  public void testVaryEncodingDifferent(TestContext context) {
     startMockServer(context, req -> {
       req.response().headers().add("Cache-Control", "public, max-age=300");
       req.response().headers().add("Content-Encoding", "gzip");
@@ -807,7 +807,7 @@ public class CachingWebClientTest {
       req.putHeader("Accept-Encoding", "br");
     });
 
-    context.assertEquals(body1, body2);
+    context.assertNotEquals(body1, body2);
   }
 
   @Test

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
@@ -792,7 +792,7 @@ public class CachingWebClientTest {
   }
 
   @Test
-  public void testVaryEncodingDifferent(TestContext context) {
+  public void testVaryEncodingIsIgnored(TestContext context) {
     startMockServer(context, req -> {
       req.response().headers().add("Cache-Control", "public, max-age=300");
       req.response().headers().add("Content-Encoding", "gzip");
@@ -807,7 +807,7 @@ public class CachingWebClientTest {
       req.putHeader("Accept-Encoding", "br");
     });
 
-    context.assertNotEquals(body1, body2);
+    context.assertEquals(body1, body2);
   }
 
   @Test

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKeyTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKeyTest.java
@@ -1,0 +1,24 @@
+package io.vertx.ext.web.client.impl.cache;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.impl.WebClientBase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CacheVariationsKeyTest {
+
+  @Test
+  public void testCacheVariationKeyNotAffectedByHttpReqImplMutability() {
+    WebClient webClient = new WebClientBase(null, new WebClientOptions());
+    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, 8080, "server.com", "/somepath?key=value");
+    CacheVariationsKey instance1 = new CacheVariationsKey(request);
+    CacheVariationsKey instance2 = new CacheVariationsKey(request);
+    assertEquals(instance1, instance2);
+  }
+
+}


### PR DESCRIPTION
Related to https://github.com/vert-x3/vertx-web/issues/2134

It does not fix the cause of the problem but I guess that an internal team discussion is needed in order to decide how to fix it, for the time being this reordering fixes CacaheVariationKey