### PR TITLE
Fix #2136: sub router must skip matched path when evaluating next sub…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -346,12 +346,14 @@ public class RouterImpl implements Router {
     }
     // regex
     if (ctx.matchRest != -1) {
+      // if we're on a sub router already we need to skip the matched path
+      int skip = ctx.mountPoint != null ? ctx.mountPoint.length() : 0;
       if (ctx.matchNormalized) {
-        return ctx.normalizedPath().substring(0, ctx.matchRest);
+        return ctx.normalizedPath().substring(skip, skip + ctx.matchRest);
       } else {
         String path = ctx.request().path();
         if (path != null) {
-          return path.substring(0, ctx.matchRest);
+          return path.substring(skip, skip + ctx.matchRest);
         }
         return null;
       }

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -647,5 +647,55 @@ public class SubRouterTest extends WebTestBase {
     router.route("/level1/*").handler(level2);
     testRequest(HttpMethod.GET, "/level1/level2/level3", 200, "ok");
   }
+
+  @Test
+  public void testHierarchicalWithParams() throws Exception {
+
+    Router restRouter = Router.router(vertx);
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/files").handler(ctx -> {
+      // version is extracted from the root router
+      assertEquals("1", ctx.pathParam("version"));
+      ctx.response().end();
+    });
+
+    restRouter.mountSubRouter("/:version", subRouter);
+
+    router.mountSubRouter("/rest", restRouter);
+
+    // router
+    // /rest -> restRouter
+    //      /:version -> subRouter
+    //                    /files -> OK
+
+    testRequest(HttpMethod.GET, "/rest/1/files", 200, "OK");
+  }
+
+  @Test
+  public void testHierarchicalWithParamsInAllRouters() throws Exception {
+
+    Router restRouter = Router.router(vertx);
+    Router subRouter = Router.router(vertx);
+
+    subRouter.get("/files/:id").handler(ctx -> {
+      // version is extracted from the root router
+      assertEquals("1", ctx.pathParam("version"));
+      // id is extracted from this router
+      assertEquals("2", ctx.pathParam("id"));
+      ctx.response().end();
+    });
+
+    restRouter.mountSubRouter("/:version", subRouter);
+
+    router.mountSubRouter("/rest", restRouter);
+
+    // router
+    // /rest -> restRouter
+    //      /:version -> subRouter
+    //                    /files/:id -> OK
+
+    testRequest(HttpMethod.GET, "/rest/1/files/2", 200, "OK");
+  }
 }
 


### PR DESCRIPTION
…routers

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

When matching sub routers in certain circumstances the matched segment wasn't skipped resulting always in a no match.