### PR TITLE
Fix #2096: Avoid reparsing of body

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/validation/impl/BaseValidationHandler.java
@@ -292,7 +292,7 @@ public abstract class BaseValidationHandler implements ValidationHandler {
   }
 
   private RequestParameter validateEntireBody(RoutingContext routingContext) throws ValidationException {
-    if (entireBodyValidator != null) return entireBodyValidator.isValid(routingContext.getBodyAsString());
+    if (entireBodyValidator != null) return entireBodyValidator.isValid(routingContext.body().asString());
     else return RequestParameter.create(null);
   }
 

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLHandlerImpl.java
@@ -106,7 +106,7 @@ public class GraphQLHandlerImpl implements GraphQLHandler {
         // as well as resource cleanup
         rc.fail(500, new NoStackTraceThrowable("BodyHandler is required to process POST requests"));
       } else {
-        handlePost(rc, rc.getBody());
+        handlePost(rc, rc.body().buffer());
       }
     } else {
       rc.fail(405);

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/GraphQLHandlerImpl.java
@@ -31,7 +31,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.ExecutionInputBuilderWithContext;
 import io.vertx.ext.web.handler.graphql.GraphQLHandler;
 import io.vertx.ext.web.handler.graphql.GraphQLHandlerOptions;
-import io.vertx.ext.web.impl.RoutingContextInternal;
 import org.dataloader.DataLoaderRegistry;
 
 import java.util.*;
@@ -99,7 +98,7 @@ public class GraphQLHandlerImpl implements GraphQLHandler {
     if (method == GET) {
       handleGet(rc);
     } else if (method == POST) {
-      if (!((RoutingContextInternal) rc).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
+      if (!rc.body().available()) {
         // the body handler was not set, so we cannot securely process POST bodies
         // we could just add an ad-hoc body handler but this can lead to DDoS attacks
         // and it doesn't really cover all the uploads, such as multipart, etc...

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/NoopBodyProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/NoopBodyProcessorGenerator.java
@@ -28,7 +28,7 @@ public class NoopBodyProcessorGenerator implements BodyProcessorGenerator {
 
       @Override
       public Future<RequestParameter> process(RoutingContext requestContext) {
-        return Future.succeededFuture(RequestParameter.create(requestContext.getBody()));
+        return Future.succeededFuture(RequestParameter.create(requestContext.body().buffer()));
       }
     };
   }

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/body/JsonBodyProcessorImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/body/JsonBodyProcessorImpl.java
@@ -28,7 +28,7 @@ public class JsonBodyProcessorImpl implements BodyProcessor {
   @Override
   public Future<RequestParameter> process(RoutingContext requestContext) {
     try {
-      Buffer body = requestContext.getBody();
+      Buffer body = requestContext.body().buffer();
       if (body == null) {
         throw BodyProcessorException.createParsingError(
           requestContext.request().getHeader(HttpHeaders.CONTENT_TYPE),

--- a/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/body/TextPlainBodyProcessorImpl.java
+++ b/vertx-web-validation/src/main/java/io/vertx/ext/web/validation/impl/body/TextPlainBodyProcessorImpl.java
@@ -23,7 +23,7 @@ public class TextPlainBodyProcessorImpl implements BodyProcessor {
 
   @Override
   public Future<RequestParameter> process(RoutingContext requestContext) {
-    String body = requestContext.getBodyAsString();
+    String body = requestContext.body().asString();
     if (body == null) {
       throw BodyProcessorException.createParsingError(
         requestContext.request().getHeader(HttpHeaders.CONTENT_TYPE),

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/JsonBodyProcessorImplTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/JsonBodyProcessorImplTest.java
@@ -5,6 +5,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.DecodeException;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.validation.BodyProcessorException;
 import io.vertx.ext.web.validation.MalformedValueException;
@@ -38,6 +39,7 @@ class JsonBodyProcessorImplTest {
 
   @Mock RoutingContext mockedContext;
   @Mock HttpServerRequest mockerServerRequest;
+  @Mock RequestBody mockerRequestBody;
 
   @BeforeEach
   public void setUp(Vertx vertx) {
@@ -55,7 +57,8 @@ class JsonBodyProcessorImplTest {
 
   @Test
   public void testJsonObject(VertxTestContext testContext) {
-    when(mockedContext.getBody()).thenReturn(TestSchemas.VALID_OBJECT.toBuffer());
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(TestSchemas.VALID_OBJECT.toBuffer());
 
     BodyProcessor processor = Bodies.json(TestSchemas.SAMPLE_OBJECT_SCHEMA_BUILDER).create(parser);
 
@@ -75,7 +78,8 @@ class JsonBodyProcessorImplTest {
   public void testInvalidJsonObject(VertxTestContext testContext) {
     when(mockerServerRequest.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
     when(mockedContext.request()).thenReturn(mockerServerRequest);
-    when(mockedContext.getBody()).thenReturn(TestSchemas.INVALID_OBJECT.toBuffer());
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(TestSchemas.INVALID_OBJECT.toBuffer());
 
     BodyProcessor processor = Bodies.json(TestSchemas.SAMPLE_OBJECT_SCHEMA_BUILDER).create(parser);
 
@@ -92,7 +96,8 @@ class JsonBodyProcessorImplTest {
 
   @Test
   public void testJsonArray(VertxTestContext testContext) {
-    when(mockedContext.getBody()).thenReturn(TestSchemas.VALID_ARRAY.toBuffer());
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(TestSchemas.VALID_ARRAY.toBuffer());
 
     BodyProcessor processor = Bodies.json(TestSchemas.SAMPLE_ARRAY_SCHEMA_BUILDER).create(parser);
 
@@ -112,7 +117,8 @@ class JsonBodyProcessorImplTest {
   public void testInvalidJsonArray(VertxTestContext testContext) {
     when(mockerServerRequest.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
     when(mockedContext.request()).thenReturn(mockerServerRequest);
-    when(mockedContext.getBody()).thenReturn(TestSchemas.INVALID_ARRAY.toBuffer());
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(TestSchemas.INVALID_ARRAY.toBuffer());
 
     BodyProcessor processor = Bodies.json(TestSchemas.SAMPLE_ARRAY_SCHEMA_BUILDER).create(parser);
 
@@ -131,7 +137,8 @@ class JsonBodyProcessorImplTest {
   public void testMalformedJson() {
     when(mockerServerRequest.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
     when(mockedContext.request()).thenReturn(mockerServerRequest);
-    when(mockedContext.getBody()).thenReturn(Buffer.buffer("{\"a"));
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(Buffer.buffer("{\"a"));
 
     BodyProcessor processor = Bodies.json(TestSchemas.SAMPLE_ARRAY_SCHEMA_BUILDER).create(parser);
 
@@ -143,7 +150,8 @@ class JsonBodyProcessorImplTest {
 
   @Test
   public void testNull(VertxTestContext testContext) {
-    when(mockedContext.getBody()).thenReturn(Buffer.buffer("null"));
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(Buffer.buffer("null"));
 
     BodyProcessor processor = Bodies.json(schema().withKeyword("type", "null")).create(parser);
 
@@ -159,7 +167,8 @@ class JsonBodyProcessorImplTest {
   public void testNullBody() {
     when(mockerServerRequest.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
     when(mockedContext.request()).thenReturn(mockerServerRequest);
-    when(mockedContext.getBody()).thenReturn(null);
+    when(mockedContext.body()).thenReturn(mockerRequestBody);
+    when(mockerRequestBody.buffer()).thenReturn(null);
 
     BodyProcessor processor = Bodies.json(schema().withKeyword("type", "null")).create(parser);
 

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/TextPlainBodyProcessorTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/impl/TextPlainBodyProcessorTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.web.validation.impl;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.validation.BodyProcessorException;
 import io.vertx.ext.web.validation.MalformedValueException;
@@ -36,6 +37,8 @@ public class TextPlainBodyProcessorTest {
   RoutingContext mockedContext;
   @Mock
   HttpServerRequest mockerServerRequest;
+  @Mock
+  RequestBody mockedRequestBody;
 
   @BeforeEach
   public void setUp(Vertx vertx) {
@@ -45,7 +48,8 @@ public class TextPlainBodyProcessorTest {
 
   @Test
   public void testString(VertxTestContext testContext) {
-    when(mockedContext.getBodyAsString()).thenReturn(TestSchemas.VALID_STRING);
+    when(mockedContext.body()).thenReturn(mockedRequestBody);
+    when(mockedRequestBody.asString()).thenReturn(TestSchemas.VALID_STRING);
 
     BodyProcessor processor = Bodies.textPlain(TestSchemas.SAMPLE_STRING_SCHEMA_BUILDER).create(parser);
 
@@ -65,7 +69,7 @@ public class TextPlainBodyProcessorTest {
   public void testNullBody() {
     when(mockerServerRequest.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("text/plain");
     when(mockedContext.request()).thenReturn(mockerServerRequest);
-    when(mockedContext.getBodyAsString()).thenReturn(null);
+    when(mockedContext.body()).thenReturn(mockedRequestBody);
 
     BodyProcessor processor = Bodies.textPlain(TestSchemas.SAMPLE_STRING_SCHEMA_BUILDER).create(parser);
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
@@ -124,8 +124,19 @@ public interface RequestBody {
   int length();
 
   /**
-   * Return {@code true} if a {@link io.vertx.ext.web.handler.BodyHandler} was executed before this call.
-   * @return {@code true} if body is available.
+   * A body can be empty if it is not available, or its length is {@code 0}.
+   *
+   * @return {@code true} if empty.
+   */
+  default boolean isEmpty() {
+    return length() <= 0;
+  }
+
+  /**
+   * Return {@code true} if a {@link io.vertx.ext.web.handler.BodyHandler} was executed before this call in the lifetime
+   * of the request.
+   *
+   * @return {@code true} if body was parsed during the duration of the request.
    */
   boolean available();
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
@@ -122,4 +122,10 @@ public interface RequestBody {
    * @return length in bytes.
    */
   int length();
+
+  /**
+   * Return {@code true} if a {@link io.vertx.ext.web.handler.BodyHandler} was executed before this call.
+   * @return {@code true} if body is available.
+   */
+  boolean available();
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RequestBody.java
@@ -1,0 +1,125 @@
+package io.vertx.ext.web;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@VertxGen
+public interface RequestBody {
+
+  /**
+   * @return  the entire HTTP request body as a string, assuming UTF-8 encoding if the request does not provide the
+   * content type charset attribute. If a charset is provided in the request that it shall be respected. The context
+   * must have first been routed to a {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   */
+  @Nullable String asString();
+
+  /**
+   * Get the entire HTTP request body as a string, assuming the specified encoding. The context must have first been
+   * routed to a {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   *
+   * @param encoding  the encoding, e.g. "UTF-16"
+   * @return the body
+   */
+  @Nullable String asString(String encoding);
+
+  /**
+   * Gets the current body buffer as a {@link JsonObject}. If a positive limit is provided the parsing will only happen
+   * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
+   *
+   * When the application is only handling uploads in JSON format, it is recommended to set a limit on
+   * {@link io.vertx.ext.web.handler.BodyHandler#setBodyLimit(long)} as this will avoid the upload to be parsed and
+   * loaded into the application memory.
+   *
+   * @param maxAllowedLength if the current buffer length is greater than the limit an {@link IllegalStateException} is
+   *                         thrown. This can be used to avoid DDoS attacks on very long JSON payloads that could take
+   *                         over the CPU while attempting to parse the data.
+   *
+   * @return Get the entire HTTP request body as a {@link JsonObject}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  @Nullable JsonObject asJsonObject(int maxAllowedLength);
+
+  /**
+   * Gets the current body buffer as a {@link JsonArray}. If a positive limit is provided the parsing will only happen
+   * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
+   *
+   * When the application is only handling uploads in JSON format, it is recommended to set a limit on
+   * {@link io.vertx.ext.web.handler.BodyHandler#setBodyLimit(long)} as this will avoid the upload to be parsed and
+   * loaded into the application memory.
+   *
+   * @param maxAllowedLength if the current buffer length is greater than the limit an {@link IllegalStateException} is
+   *                         thrown. This can be used to avoid DDoS attacks on very long JSON payloads that could take
+   *                         over the CPU while attempting to parse the data.
+   *
+   * @return Get the entire HTTP request body as a {@link JsonArray}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  @Nullable JsonArray asJsonArray(int maxAllowedLength);
+
+  /**
+   * @return Get the entire HTTP request body as a {@link JsonObject}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  default @Nullable JsonObject asJsonObject() {
+    return asJsonObject(-1);
+  }
+
+  /**
+   * @return Get the entire HTTP request body as a {@link JsonArray}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   */
+  default @Nullable JsonArray asJsonArray() {
+    return asJsonArray(-1);
+  }
+
+  /**
+   * @return Get the entire HTTP request body as a {@link Buffer}. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   */
+  @Nullable Buffer buffer();
+
+  /**
+   * @return Get the entire HTTP request body as a POJO. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   *
+   * <b>WARNING:</b> This feature requires jackson-databind. Or another JSON codec that implements POJO parsing
+   *
+   * @param maxAllowedLength if the current buffer length is greater than the limit an {@link IllegalStateException} is
+   *                         thrown. This can be used to avoid DDoS attacks on very long JSON payloads that could take
+   *                         over the CPU while attempting to parse the data.
+   */
+  <R> @Nullable R asPojo(Class<R> clazz, int maxAllowedLength);
+
+  /**
+   * @return Get the entire HTTP request body as a POJO. The context must have first been routed to a
+   * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
+   * <br/>
+   * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
+   *
+   * <b>WARNING:</b> This feature requires jackson-databind. Or another JSON codec that implements POJO parsing
+   */
+  default <R> @Nullable R asPojo(Class<R> clazz) {
+    return asPojo(clazz, -1);
+  }
+
+  /**
+   * Returns the total length of the body buffer. This is the length in bytes. When there is no buffer the length is
+   * {@code -1}.
+   *
+   * @return length in bytes.
+   */
+  int length();
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -264,22 +264,34 @@ public interface RoutingContext {
   Map<String, io.vertx.core.http.Cookie> cookieMap();
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * @return  the entire HTTP request body as a string, assuming UTF-8 encoding if the request does not provide the
    * content type charset attribute. If a charset is provided in the request that it shall be respected. The context
    * must have first been routed to a {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    */
-  @Nullable String getBodyAsString();
+  @Deprecated
+  default @Nullable String getBodyAsString() {
+    return body().asString();
+  }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * Get the entire HTTP request body as a string, assuming the specified encoding. The context must have first been routed to a
    * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    *
    * @param encoding  the encoding, e.g. "UTF-16"
    * @return the body
    */
-  @Nullable String getBodyAsString(String encoding);
+  @Deprecated
+  default @Nullable String getBodyAsString(String encoding) {
+    return body().asString(encoding);
+  }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * Gets the current body buffer as a {@link JsonObject}. If a positive limit is provided the parsing will only happen
    * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
    *
@@ -296,9 +308,14 @@ public interface RoutingContext {
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
-  @Nullable JsonObject getBodyAsJson(int maxAllowedLength);
+  @Deprecated
+  default @Nullable JsonObject getBodyAsJson(int maxAllowedLength) {
+    return body().asJsonObject(maxAllowedLength);
+  }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * Gets the current body buffer as a {@link JsonArray}. If a positive limit is provided the parsing will only happen
    * if the buffer length is smaller or equal to the limit. Otherwise an {@link IllegalStateException} is thrown.
    *
@@ -315,33 +332,49 @@ public interface RoutingContext {
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
-  @Nullable JsonArray getBodyAsJsonArray(int maxAllowedLength);
+  @Deprecated
+  default @Nullable JsonArray getBodyAsJsonArray(int maxAllowedLength) {
+    return body().asJsonArray(maxAllowedLength);
+  }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * @return Get the entire HTTP request body as a {@link JsonObject}. The context must have first been routed to a
    * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
+  @Deprecated
   default @Nullable JsonObject getBodyAsJson() {
-    return getBodyAsJson(-1);
+    return body().asJsonObject();
   }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * @return Get the entire HTTP request body as a {@link JsonArray}. The context must have first been routed to a
    * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    * <br/>
    * When the body is {@code null} or the {@code "null"} JSON literal then {@code null} is returned.
    */
+  @Deprecated
   default @Nullable JsonArray getBodyAsJsonArray() {
-    return getBodyAsJsonArray(-1);
+    return body().asJsonArray();
   }
 
   /**
+   * @deprecated Use {@link #body()} instead.
+   *
    * @return Get the entire HTTP request body as a {@link Buffer}. The context must have first been routed to a
    * {@link io.vertx.ext.web.handler.BodyHandler} for this to be populated.
    */
-  @Nullable Buffer getBody();
+  @Deprecated
+  default @Nullable Buffer getBody() {
+    return body().buffer();
+  }
+
+  RequestBody body();
 
   /**
    * @return a set of fileuploads (if any) for the request. The context must have first been routed to a
@@ -492,17 +525,21 @@ public interface RoutingContext {
   boolean failed();
 
   /**
+   * @deprecated This method is internal. Users that really need to use it should refer to {@link io.vertx.ext.web.impl.RoutingContextInternal#setBody(Buffer)}
    * Set the body. Used by the {@link io.vertx.ext.web.handler.BodyHandler}. You will not normally call this method.
    *
    * @param body  the body
    */
+  @Deprecated
   void setBody(Buffer body);
 
   /**
+   * @deprecated This method is internal. Users that really need to use it should refer to {@link io.vertx.ext.web.impl.RoutingContextInternal#setSession(Session)}
    * Set the session. Used by the {@link io.vertx.ext.web.handler.SessionHandler}. You will not normally call this method.
    *
    * @param session  the session
    */
+  @Deprecated
   void setSession(Session session);
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -318,7 +318,7 @@ public class BodyHandlerImpl implements BodyHandler {
       if (mergeFormAttributes && req.isExpectMultipart()) {
         req.params().addAll(req.formAttributes());
       }
-      context.setBody(body);
+      ((RoutingContextInternal) context).setBody(body);
       // release body as it may take lots of memory
       body = null;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
@@ -27,7 +27,6 @@ import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.CSRFHandler;
 import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.impl.Origin;
-import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -190,7 +189,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
     String header = ctx.request().getHeader(headerName);
     if (header == null) {
       // fallback to form attributes
-      if (((RoutingContextInternal) ctx).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
+      if (ctx.body().available()) {
         header = ctx.request().getFormAttribute(headerName);
       } else {
         ctx.fail(new IllegalStateException("BodyHandler is required to process POST requests"));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
@@ -30,7 +30,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.FormLoginHandler;
 import io.vertx.ext.web.handler.HttpException;
-import io.vertx.ext.web.impl.RoutingContextInternal;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -81,7 +80,7 @@ public class FormLoginHandlerImpl extends AuthenticationHandlerImpl<Authenticati
     if (req.method() != HttpMethod.POST) {
       handler.handle(Future.failedFuture(BAD_METHOD)); // Must be a POST
     } else {
-      if (!((RoutingContextInternal) context).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
+      if (!context.body().available()) {
         handler.handle(Future.failedFuture("BodyHandler is required to process POST requests"));
       } else {
         MultiMap params = req.formAttributes();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -30,6 +30,7 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.impl.RoutingContextInternal;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.ext.web.sstore.impl.SessionInternal;
 
@@ -305,7 +306,7 @@ public class SessionHandlerImpl implements SessionHandler {
         if (res.succeeded()) {
           Session session = res.result();
           if (session != null) {
-            context.setSession(session);
+            ((RoutingContextInternal) context).setSession(session);
             // attempt to load the user from the session
             UserHolder holder = session.get(SESSION_USER_HOLDER_KEY);
             if (holder != null) {
@@ -340,7 +341,7 @@ public class SessionHandlerImpl implements SessionHandler {
 
   public Session newSession(RoutingContext context) {
     Session session = sessionStore.createSession(sessionTimeout, minLength);
-    context.setSession(session);
+    ((RoutingContextInternal) context).setSession(session);
     if (!cookieless) {
       context.response().removeCookie(sessionCookieName, false);
     }
@@ -445,7 +446,7 @@ public class SessionHandlerImpl implements SessionHandler {
 
   private void createNewSession(RoutingContext context) {
     Session session = sessionStore.createSession(sessionTimeout, minLength);
-    context.setSession(session);
+    ((RoutingContextInternal) context).setSession(session);
     if (!cookieless) {
       context.response().removeCookie(sessionCookieName, false);
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthnHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthnHandlerImpl.java
@@ -137,7 +137,7 @@ public class WebAuthnHandlerImpl extends AuthenticationHandlerImpl<WebAuthn> imp
       .handler(ctx -> {
         try {
           // might throw runtime exception if there's no json or is bad formed
-          final JsonObject webauthnRegister = ctx.getBodyAsJson();
+          final JsonObject webauthnRegister = ctx.body().asJsonObject();
           final Session session = ctx.session();
 
           // the register object should match a Webauthn user.
@@ -186,7 +186,7 @@ public class WebAuthnHandlerImpl extends AuthenticationHandlerImpl<WebAuthn> imp
       .handler(ctx -> {
         try {
           // might throw runtime exception if there's no json or is bad formed
-          final JsonObject webauthnLogin = ctx.getBodyAsJson();
+          final JsonObject webauthnLogin = ctx.body().asJsonObject();
           final Session session = ctx.session();
 
           if (webauthnLogin == null || !containsRequiredString(webauthnLogin, "name")) {
@@ -235,7 +235,7 @@ public class WebAuthnHandlerImpl extends AuthenticationHandlerImpl<WebAuthn> imp
       .handler(ctx -> {
         try {
           // might throw runtime exception if there's no json or is bad formed
-          final JsonObject webauthnResp = ctx.getBodyAsJson();
+          final JsonObject webauthnResp = ctx.body().asJsonObject();
           // input validation
           if (
             webauthnResp == null ||

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/BaseTransport.java
@@ -153,7 +153,7 @@ class BaseTransport {
     }
   }
 
-  static void setCORS(RoutingContext rc) {
+  static void setCORSIfNeeded(RoutingContext rc) {
     if (!((RoutingContextInternal) rc).seenHandler(RoutingContextInternal.CORS_HANDLER)) {
       HttpServerRequest req = rc.request();
       String origin = req.getHeader(ORIGIN);
@@ -191,7 +191,7 @@ class BaseTransport {
         // Java ints are signed, so we need to use a long and add the offset so
         // the result is not negative
         json.put("entropy", offset + prng.nextInt());
-        setCORS(rc);
+        setCORSIfNeeded(rc);
         rc.response().end(json.encode());
       }
     };
@@ -214,7 +214,7 @@ class BaseTransport {
         .putHeader(EXPIRES, expires)
         .putHeader(ACCESS_CONTROL_ALLOW_METHODS, methods)
         .putHeader(ACCESS_CONTROL_MAX_AGE, String.valueOf(oneYearSeconds));
-      setCORS(rc);
+      setCORSIfNeeded(rc);
       setJSESSIONID(options, rc);
       rc.response().setStatusCode(204);
       rc.response().end();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSHandlerImpl.java
@@ -186,7 +186,7 @@ public class SockJSHandlerImpl implements SockJSHandler {
       public void handle(RoutingContext rc) {
         rc.response().headers().set("Content-Type", "application/javascript; charset=UTF-8");
 
-        BaseTransport.setCORS(rc);
+        BaseTransport.setCORSIfNeeded(rc);
         rc.response().setChunked(true);
 
         Buffer h = buffer(2);

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RequestBodyImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RequestBodyImpl.java
@@ -17,6 +17,7 @@ package io.vertx.ext.web.impl;
 
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -139,5 +140,10 @@ public class RequestBodyImpl implements RequestBody {
     } else {
       return body.length();
     }
+  }
+
+  @Override
+  public boolean available() {
+    return ((RoutingContextInternal) ctx).seenHandler(RoutingContextInternal.BODY_HANDLER);
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RequestBodyImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RequestBodyImpl.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.impl;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.MIMEHeader;
+import io.vertx.ext.web.ParsedHeaderValues;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Implementation of the Cacheable Request Body
+ *
+ * @author Paulo Lopes
+ */
+public class RequestBodyImpl implements RequestBody {
+
+  private final RoutingContext ctx;
+
+  private Buffer body;
+
+  // caches
+  private String string;
+  private JsonObject jsonObject;
+  private JsonArray jsonArray;
+
+  public RequestBodyImpl(RoutingContext ctx) {
+    this.ctx = ctx;
+  }
+
+  public void setBuffer(Buffer body) {
+    this.body = body;
+    // reset caches
+    string = null;
+    jsonObject = null;
+    jsonArray = null;
+  }
+
+  @Override
+  public @Nullable String asString() {
+    if (body == null) {
+      return null;
+    } else {
+      if (string == null) {
+        ParsedHeaderValues parsedHeaders = ctx.parsedHeaders();
+        if (parsedHeaders != null) {
+          MIMEHeader contentType = parsedHeaders.contentType();
+          if (contentType != null) {
+            String charset = contentType.parameter("charset");
+            if (charset != null) {
+              string = body.toString(charset);
+              return string;
+            }
+          }
+        }
+        string = body.toString();
+      }
+      return string;
+    }
+  }
+
+  @Override
+  public @Nullable String asString(String encoding) {
+    if (body == null) {
+      return null;
+    } else {
+      return body.toString(encoding);
+    }
+  }
+
+  @Override
+  public @Nullable JsonObject asJsonObject(int maxAllowedLength) {
+    if (body == null) {
+      return null;
+    } else {
+      if (jsonObject == null) {
+        if (maxAllowedLength >= 0 && body.length() > maxAllowedLength) {
+          throw new IllegalStateException("RoutingContext body size exceeds the allowed limit");
+        }
+        jsonObject = (JsonObject) Json.decodeValue(body);
+      }
+      return jsonObject;
+    }
+  }
+
+  @Override
+  public @Nullable JsonArray asJsonArray(int maxAllowedLength) {
+    if (body == null) {
+      return null;
+    } else {
+      if (jsonArray == null) {
+        if (maxAllowedLength >= 0 && body.length() > maxAllowedLength) {
+          throw new IllegalStateException("RoutingContext body size exceeds the allowed limit");
+        }
+        jsonArray = (JsonArray) Json.decodeValue(body);
+      }
+      return jsonArray;
+    }
+  }
+
+  @Override
+  public <R> @Nullable R asPojo(Class<R> clazz, int maxAllowedLength) {
+    if (body == null) {
+      return null;
+    } else {
+      if (maxAllowedLength >= 0 && body.length() > maxAllowedLength) {
+        throw new IllegalStateException("RoutingContext body size exceeds the allowed limit");
+      }
+      return Json.decodeValue(body, clazz);
+    }
+  }
+
+  @Override
+  public @Nullable Buffer buffer() {
+    return body;
+  }
+
+  @Override
+  public int length() {
+    if (body == null) {
+      return -1;
+    } else {
+      return body.length();
+    }
+  }
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -10,8 +10,6 @@ import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 
@@ -41,17 +39,17 @@ public class RoutingContextDecorator implements RoutingContextInternal {
 
   @Override
   public RoutingContextInternal visitHandler(int id) {
-    return ((RoutingContextInternal) decoratedContext).visitHandler(id);
+    return decoratedContext.visitHandler(id);
   }
 
   @Override
   public boolean seenHandler(int id) {
-    return ((RoutingContextInternal) decoratedContext).seenHandler(id);
+    return decoratedContext.seenHandler(id);
   }
 
   @Override
   public RoutingContextInternal setMatchFailure(int matchFailure) {
-    return ((RoutingContextInternal) decoratedContext).setMatchFailure(matchFailure);
+    return decoratedContext.setMatchFailure(matchFailure);
   }
 
   @Override
@@ -157,28 +155,8 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
-  public Buffer getBody() {
-    return decoratedContext.getBody();
-  }
-
-  @Override
-  public JsonObject getBodyAsJson(int maxAllowedLength) {
-    return decoratedContext.getBodyAsJson(maxAllowedLength);
-  }
-
-  @Override
-  public JsonArray getBodyAsJsonArray(int maxAllowedLength) {
-    return decoratedContext.getBodyAsJsonArray(maxAllowedLength);
-  }
-
-  @Override
-  public String getBodyAsString() {
-    return decoratedContext.getBodyAsString();
-  }
-
-  @Override
-  public String getBodyAsString(String encoding) {
-    return decoratedContext.getBodyAsString(encoding);
+  public RequestBody body() {
+    return decoratedContext.body();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
@@ -17,8 +17,10 @@ package io.vertx.ext.web.impl;
 
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 
 /**
  * Internal methods that are not expected or prime to be in the public API
@@ -69,4 +71,17 @@ public interface RoutingContextInternal extends RoutingContext {
   @CacheReturn
   @Nullable RoutingContextInternal parent();
 
+  /**
+   * Set the body. Used by the {@link io.vertx.ext.web.handler.BodyHandler}.
+   *
+   * @param body  the body
+   */
+  void setBody(Buffer body);
+
+  /**
+   * Set the session. Used by the {@link io.vertx.ext.web.handler.SessionHandler}.
+   *
+   * @param session  the session
+   */
+  void setSession(Session session);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -26,8 +26,6 @@ import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 
@@ -72,12 +70,12 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
 
   @Override
   public synchronized RoutingContextInternal visitHandler(int id) {
-    return ((RoutingContextInternal) inner).visitHandler(id);
+    return inner.visitHandler(id);
   }
 
   @Override
   public boolean seenHandler(int id) {
-    return ((RoutingContextInternal) inner).seenHandler(id);
+    return inner.seenHandler(id);
   }
 
   @Override
@@ -263,28 +261,8 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public String getBodyAsString() {
-    return inner.getBodyAsString();
-  }
-
-  @Override
-  public String getBodyAsString(String encoding) {
-    return inner.getBodyAsString(encoding);
-  }
-
-  @Override
-  public JsonObject getBodyAsJson(int maxAllowedLength) {
-    return inner.getBodyAsJson(maxAllowedLength);
-  }
-
-  @Override
-  public JsonArray getBodyAsJsonArray(int maxAllowedLength) {
-    return inner.getBodyAsJsonArray(maxAllowedLength);
-  }
-
-  @Override
-  public Buffer getBody() {
-    return inner.getBody();
+  public RequestBody body() {
+    return inner.body();
   }
 
   @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -3060,7 +3060,7 @@ public class RouterTest extends WebTestBase {
 
     router.route(HttpMethod.GET, "/fail")
       .handler(BodyHandler.create())
-      .handler(ctx -> ctx.response().setStatusCode(200).end(ctx.getBodyAsString()));
+      .handler(ctx -> ctx.response().setStatusCode(200).end(ctx.body().asString()));
 
     testRequest(
       HttpMethod.GET,

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
@@ -61,7 +61,7 @@ public class BodyHandlerTest extends WebTestBase {
   @Test
   public void testGETWithoutBody() throws Exception {
     router.route().handler(rc -> {
-      assertNull(rc.getBody());
+      assertNull(rc.body().buffer());
       rc.response().end();
     });
     testRequest(HttpMethod.GET, "/", 200, "OK");
@@ -70,7 +70,7 @@ public class BodyHandlerTest extends WebTestBase {
   @Test
   public void testHEADWithoutBody() throws Exception {
     router.route().handler(rc -> {
-      assertNull(rc.getBody());
+      assertNull(rc.body().buffer());
       rc.response().end();
     });
     testRequest(HttpMethod.HEAD, "/", 200, "OK");
@@ -80,7 +80,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyBuffer() throws Exception {
     Buffer buff = TestUtils.randomBuffer(1000);
     router.route().handler(rc -> {
-      assertEquals(buff, rc.getBody());
+      assertEquals(buff, rc.body().buffer());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -93,7 +93,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyString() throws Exception {
     String str = "sausages";
     router.route().handler(rc -> {
-      assertEquals(str, rc.getBodyAsString());
+      assertEquals(str, rc.body().asString());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -106,8 +106,8 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyStringWithEncoding() throws Exception {
     String str = "\u00FF";
     router.route().handler(rc -> {
-      assertEquals(1, rc.getBody().length());
-      String decoded = rc.getBodyAsString();
+      assertEquals(1, rc.body().length());
+      String decoded = rc.body().asString();
       assertEquals(str, decoded);
       rc.response().end();
     });
@@ -124,7 +124,7 @@ public class BodyHandlerTest extends WebTestBase {
     String str = TestUtils.randomUnicodeString(100);
     String enc = "UTF-16";
     router.route().handler(rc -> {
-      assertEquals(str, rc.getBodyAsString(enc));
+      assertEquals(str, rc.body().asString(enc));
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -137,7 +137,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyJson() throws Exception {
     JsonObject json = new JsonObject().put("foo", "bar").put("blah", 123);
     router.route().handler(rc -> {
-      assertEquals(json, rc.getBodyAsJson());
+      assertEquals(json, rc.body().asJsonObject());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -150,7 +150,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyJsonWithNegativeContentLength() throws Exception {
     JsonObject json = new JsonObject().put("foo", "bar").put("blah", 123);
     router.route().handler(rc -> {
-      assertEquals(json, rc.getBodyAsJson());
+      assertEquals(json, rc.body().asJsonObject());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -164,7 +164,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyJsonWithEmptyContentLength() throws Exception {
     JsonObject json = new JsonObject().put("foo", "bar").put("blah", 123);
     router.route().handler(rc -> {
-      assertEquals(json, rc.getBodyAsJson());
+      assertEquals(json, rc.body().asJsonObject());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -178,7 +178,7 @@ public class BodyHandlerTest extends WebTestBase {
   public void testBodyJsonWithHugeContentLength() throws Exception {
     JsonObject json = new JsonObject().put("foo", "bar").put("blah", 123);
     router.route().handler(rc -> {
-      assertEquals(json, rc.getBodyAsJson());
+      assertEquals(json, rc.body().asJsonObject());
       rc.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -261,7 +261,7 @@ public class BodyHandlerTest extends WebTestBase {
       Buffer uploaded = vertx.fileSystem().readFileBlocking(uploadedFileName);
       assertEquals(fileData, uploaded);
       // the data is upload as HTML form, so the body should be empty
-      Buffer rawBody = rc.getBody();
+      Buffer rawBody = rc.body().buffer();
       assertNull(rawBody);
       rc.response().end();
     });
@@ -563,7 +563,7 @@ public class BodyHandlerTest extends WebTestBase {
     router.route().handler(BodyHandler.create()
       .setUploadsDirectory(uploadsDirectory));
     router.route().handler(ctx -> {
-      assertNull(ctx.getBody());
+      assertNull(ctx.body().buffer());
       assertEquals(1, ctx.fileUploads().size());
       ctx.response().end();
     });
@@ -788,7 +788,7 @@ public class BodyHandlerTest extends WebTestBase {
     Buffer buffer = Buffer.buffer("000000000000000000000000000000000000000000000000");
     router.route().handler(rc -> {
       try {
-        rc.getBodyAsJson(10);
+        rc.body().asJsonObject(10);
         // should not reach here!
         rc.fail(500);
       } catch (IllegalStateException e) {
@@ -809,7 +809,7 @@ public class BodyHandlerTest extends WebTestBase {
     Buffer buffer = Buffer.buffer("{\"k\":1111}");
     router.route().handler(rc -> {
       try {
-        rc.getBodyAsJson(10);
+        rc.body().asJsonObject(10);
         rc.end();
       } catch (IllegalStateException e) {
         // should not reach here!
@@ -845,7 +845,7 @@ public class BodyHandlerTest extends WebTestBase {
       Buffer uploaded = vertx.fileSystem().readFileBlocking(uploadedFileName);
       assertEquals(fileData, uploaded);
       // the data is upload as HTML form, so the body should be empty
-      Buffer rawBody = rc.getBody();
+      Buffer rawBody = rc.body().buffer();
       assertNull(rawBody);
       rc.response().end();
     });

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -34,6 +34,7 @@ import io.vertx.ext.web.Session;
 import io.vertx.ext.web.WebTestBase;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.impl.RoutingContextInternal;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
@@ -387,7 +388,7 @@ public class SockJSHandlerTest extends WebTestBase {
           assertFalse(result.failed());
           assertNotSame(session, oldSession);
           assertEquals(session, sock.webSession());
-          sock.routingContext().setSession(session);
+          ((RoutingContextInternal) sock.routingContext()).setSession(session);
           assertEquals(sock.webSession(), sock.routingContext().session());
           assertEquals(sock.webUser(), sock.routingContext().user());
           assertEquals(sock.webUser(), user);
@@ -406,7 +407,7 @@ public class SockJSHandlerTest extends WebTestBase {
         } catch (InterruptedException | ExecutionException e) {
           fail();
         }
-        sock.routingContext().setSession(session);
+        ((RoutingContextInternal) sock.routingContext()).setSession(session);
         try {
           assertEquals(sessionID.get(), store.get(sessionID.get()).result().id());
           assertEquals(sessionUser.get(), sock.webUser());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSWriteHandlerTestServer.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSWriteHandlerTestServer.java
@@ -65,7 +65,7 @@ public class SockJSWriteHandlerTestServer {
 
       router.post("/message").handler(BodyHandler.create()).handler(rc -> {
         EventBus eventBus = vertx.eventBus();
-        JsonObject body = rc.getBodyAsJson();
+        JsonObject body = rc.body().asJsonObject();
         if (rc.queryParams().contains("relay")) {
           eventBus.send("relay", body);
         } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/RoutingContextImplTest.java
@@ -30,7 +30,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_empty_array_as_json_array_yields_empty_json_array() throws Exception {
     router.route().handler(event -> {
-      assertEquals(new JsonArray(), event.getBodyAsJsonArray());
+      assertEquals(new JsonArray(), event.body().asJsonArray());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -42,8 +42,8 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_empty_yields_null_json_types() throws Exception {
     router.route().handler(event -> {
-      assertNull(event.getBodyAsJsonArray());
-      assertNull(event.getBodyAsJson());
+      assertNull(event.body().asJsonArray());
+      assertNull(event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -60,7 +60,7 @@ public class RoutingContextImplTest extends WebTestBase {
           new JsonObject(Collections.singletonMap("foo", "bar"))
         )
       );
-      assertEquals(array, event.getBodyAsJsonArray());
+      assertEquals(array, event.body().asJsonArray());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -72,7 +72,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_null_literal_array_as_json_array_yields_null_json_array() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJsonArray());
+      assertEquals(null, event.body().asJsonArray());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -84,7 +84,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_non_array_as_json_array_fails_json_array() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJsonArray());
+      assertEquals(null, event.body().asJsonArray());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -96,7 +96,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_invalid_array_as_json_array_fails_json_array() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJsonArray());
+      assertEquals(null, event.body().asJsonArray());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -108,7 +108,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_empty_object_as_json_yields_empty_json_object() throws Exception {
     router.route().handler(event -> {
-      assertEquals(new JsonObject(), event.getBodyAsJson());
+      assertEquals(new JsonObject(), event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -120,7 +120,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_object_as_json_yields_json_object() throws Exception {
     router.route().handler(event -> {
-      assertEquals(new JsonObject(Collections.singletonMap("foo", "bar")), event.getBodyAsJson());
+      assertEquals(new JsonObject(Collections.singletonMap("foo", "bar")), event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -132,7 +132,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_null_literal_object_as_json_yields_empty_json_object() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJson());
+      assertEquals(null, event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -144,7 +144,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_invalid_json_object_as_json_fails_json_object() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJson());
+      assertEquals(null, event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -156,7 +156,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_non_json_object_as_json_fails_json_object() throws Exception {
     router.route().handler(event -> {
-      assertEquals(null, event.getBodyAsJson());
+      assertEquals(null, event.body().asJsonObject());
       event.response().end();
     });
     testRequest(HttpMethod.POST, "/", req -> {
@@ -168,7 +168,7 @@ public class RoutingContextImplTest extends WebTestBase {
   @Test
   public void test_remove_data() throws Exception {
     router.route().handler(event -> {
-      String foo = event.getBodyAsJson().encode();
+      String foo = event.body().asJsonObject().encode();
       event.put("foo", foo);
       String removedFoo = event.remove("foo");
       assertEquals(removedFoo, foo);

--- a/vertx-web/src/test/java/io/vertx/ext/web/it/FIDO2TCK.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/it/FIDO2TCK.java
@@ -14,6 +14,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.handler.WebAuthnHandler;
+import io.vertx.ext.web.impl.RoutingContextInternal;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -172,14 +173,14 @@ public class FIDO2TCK {
 
         app.post("/attestation/options")
           .handler(ctx -> {
-            JsonObject json = ctx.getBodyAsJson();
+            JsonObject json = ctx.body().asJsonObject();
             // vert.x doesn't work with "username" but "name"
             if (json.containsKey("username")) {
               String username = json.getString("username");
               json.remove("username");
               json.put("name", username);
               // patch the request
-              ctx.setBody(json.toBuffer());
+              ((RoutingContextInternal) ctx).setBody(json.toBuffer());
             }
 
             // register, we need to listen to the request and change the config
@@ -208,14 +209,14 @@ public class FIDO2TCK {
 
         app.post("/assertion/options")
           .handler(ctx -> {
-            JsonObject json = ctx.getBodyAsJson();
+            JsonObject json = ctx.body().asJsonObject();
             // vert.x doesn't work with "username" but "name"
             if (json.containsKey("username")) {
               String username = json.getString("username");
               json.remove("username");
               json.put("name", username);
               // patch the request
-              ctx.setBody(json.toBuffer());
+              ((RoutingContextInternal) ctx).setBody(json.toBuffer());
             }
 
             config.setUserVerification(UserVerification.of(json.getString("userVerification", "discouraged")));


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #2096 

Currently the body of a request is not cached, so if several handlers request a decoded view of the body, parsing will happen multiple times.