### PR TITLE
Deprecate mountSubRouter on router and rely on Route (as it is used i…

### DIFF
--- a/vertx-web-openapi/src/main/java/examples/OpenAPI3Examples.java
+++ b/vertx-web-openapi/src/main/java/examples/OpenAPI3Examples.java
@@ -275,6 +275,6 @@ public class OpenAPI3Examples {
     Router global = Router.router(vertx);
 
     Router generated = routerBuilder.createRouter();
-    global.mountSubRouter("/v1", generated);
+    global.route("/v1/*").subRouter(generated);
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -360,12 +360,15 @@ public interface Router extends Handler<HttpServerRequest> {
   Router clear();
 
   /**
+   * @deprecated This method duplicates the sub router functionality from {@link Route#subRouter(Router)}.
+   *
    * Mount a sub router on this router
    *
    * @param mountPoint  the mount point (path prefix) to mount it on
    * @param subRouter  the router to mount as a sub router
    * @return a reference to this, so the API can be used fluently
    */
+  @Deprecated
   Route mountSubRouter(String mountPoint, Router subRouter);
 
   /**

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -2160,7 +2160,7 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testSubRouterNPE() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/", subRouter);
+    router.route("/*").subRouter(subRouter);
 
     testRequest(HttpMethod.GET, "foo", 404, "Not Found");
   }
@@ -2988,7 +2988,7 @@ public class RouterTest extends WebTestBase {
     swagger.route("/swagger/*")
       .handler(RoutingContext::end);
 
-    router.mountSubRouter("/q", swagger);
+    router.route("/q*").subRouter(swagger);
 
     testRequest(HttpMethod.GET, "/q/swagge", 404, "Not Found");
     testRequest(HttpMethod.GET, "/q/swagger", 200, "OK");
@@ -3041,7 +3041,7 @@ public class RouterTest extends WebTestBase {
         String parentVal = ((RoutingContextInternal)rc).parent().currentRouter().getMetadata("parent");
         rc.end(parentVal + "-" + subVal);
       });
-    router.mountSubRouter("/sub", sub);
+    router.route("/sub*").subRouter(sub);
 
     testRequest(HttpMethod.GET, "/sub/metadata", 200, "OK", "abc-123");
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -28,35 +28,28 @@ import java.util.function.Consumer;
  */
 public class SubRouterTest extends WebTestBase {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testInvalidMountPoint1() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath*", subRouter);
+    router.route("/subpath").subRouter(subRouter);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testInvalidMountPoint2() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath/*", subRouter);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidMountPoint3() throws Exception {
-    Router subRouter = Router.router(vertx);
-
-    router.mountSubRouter("subpath", subRouter);
+    router.route("/subpath/").subRouter(subRouter);
   }
 
   @Test
   public void testSimple() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath/*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
-      assertEquals("/subpath", rc.mountPoint());
+      assertEquals("/subpath/", rc.mountPoint());
       rc.response().setStatusMessage(rc.request().path()).end();
     });
 
@@ -71,7 +64,7 @@ public class SubRouterTest extends WebTestBase {
   public void testTrailingSlash() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath/", subRouter);
+    router.route("/subpath/*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
       assertEquals("/subpath/", rc.mountPoint());
@@ -89,7 +82,7 @@ public class SubRouterTest extends WebTestBase {
   public void testMultiple() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
       assertEquals("/subpath", rc.mountPoint());
@@ -119,7 +112,7 @@ public class SubRouterTest extends WebTestBase {
 
     router.route("/otherpath1").handler(rc -> rc.response().setStatusMessage(rc.request().path()).end());
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
       assertEquals("/subpath", rc.mountPoint());
@@ -154,7 +147,7 @@ public class SubRouterTest extends WebTestBase {
   public void testChain() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
       assertEquals("/subpath", rc.mountPoint());
@@ -190,7 +183,7 @@ public class SubRouterTest extends WebTestBase {
       rc.next();
     });
 
-    router.mountSubRouter("/foo", subRouter);
+    router.route("/foo*").subRouter(subRouter);
 
     subRouter.route("/bar").handler(rc -> {
       assertEquals("/foo", rc.mountPoint());
@@ -225,9 +218,9 @@ public class SubRouterTest extends WebTestBase {
     Router subRouter2 = Router.router(vertx);
     Router subRouter3 = Router.router(vertx);
 
-    router.mountSubRouter("/foo", subRouter1);
-    subRouter1.mountSubRouter("/bar", subRouter2);
-    subRouter2.mountSubRouter("/wibble", subRouter3);
+    router.route("/foo*").subRouter(subRouter1);
+    subRouter1.route("/bar*").subRouter(subRouter2);
+    subRouter2.route("/wibble*").subRouter(subRouter3);
     subRouter3.route("/eek").handler(rc -> {
       assertEquals("/foo/bar/wibble", rc.mountPoint());
       rc.response().setStatusMessage(rc.request().path()).end();
@@ -244,7 +237,7 @@ public class SubRouterTest extends WebTestBase {
   public void testEmptySubrouter() throws Exception {
     Router subRouter1 = Router.router(vertx);
 
-    router.mountSubRouter("/foo", subRouter1);
+    router.route("/foo*").subRouter(subRouter1);
 
     testRequest(HttpMethod.GET, "/foo", 404, "Not Found");
     testRequest(HttpMethod.GET, "/foo/bar", 404, "Not Found");
@@ -262,17 +255,17 @@ public class SubRouterTest extends WebTestBase {
       rc.next();
     });
 
-    router.mountSubRouter("/foo", subRouter1);
+    router.route("/foo*").subRouter(subRouter1);
     subRouter1.route("/bar/*").handler(rc -> {
       rc.put("key1", "blah1");
       rc.next();
     });
-    subRouter1.mountSubRouter("/bar", subRouter2);
+    subRouter1.route("/bar*").subRouter(subRouter2);
     subRouter2.route("/wibble/*").handler(rc -> {
       rc.put("key2", "blah2");
       rc.next();
     });
-    subRouter2.mountSubRouter("/wibble", subRouter3);
+    subRouter2.route("/wibble*").subRouter(subRouter3);
     subRouter3.route("/eek").handler(rc -> {
       assertEquals("/foo/bar/wibble", rc.mountPoint());
       rc.put("key3", "blah3");
@@ -294,7 +287,7 @@ public class SubRouterTest extends WebTestBase {
   public void testUnhandledRuntimeException() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo").handler(rc -> {
       throw new RuntimeException("Balderdash!");
@@ -307,7 +300,7 @@ public class SubRouterTest extends WebTestBase {
   public void tesHandledRuntimeException1() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo/*").handler(rc -> {
       throw new RuntimeException("Balderdash!");
@@ -326,7 +319,7 @@ public class SubRouterTest extends WebTestBase {
   public void tesHandledRuntimeException2() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo/*").handler(rc -> {
       throw new RuntimeException("Balderdash!");
@@ -345,7 +338,7 @@ public class SubRouterTest extends WebTestBase {
   public void testFailCalled1() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo/*").handler(rc -> rc.fail(557));
 
@@ -362,7 +355,7 @@ public class SubRouterTest extends WebTestBase {
   public void testFailCalled2() throws Exception {
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/subpath", subRouter);
+    router.route("/subpath*").subRouter(subRouter);
 
     subRouter.route("/foo/*").handler(rc -> rc.fail(557));
 
@@ -378,7 +371,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testSubRoutePattern() {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/foo/:abc/bar", subRouter);
+    router.route("/foo/:abc/bar*").subRouter(subRouter);
   }
 
   @Test
@@ -393,7 +386,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testRegexInSubRouter() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/api", subRouter);
+    router.route("/api*").subRouter(subRouter);
     subRouter.routeWithRegex("\\/test").handler(rc -> rc.response().setStatusMessage("sausages").end());
     testRequest(HttpMethod.GET, "/api/test", 200, "sausages");
 
@@ -402,7 +395,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testNormalized1() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/api", subRouter);
+    router.route("/api*").subRouter(subRouter);
     subRouter.route("/foo").handler(rc -> rc.response().setStatusMessage("sausages").end());
     testRequest(HttpMethod.GET, "/api/foo", 200, "sausages");
     testRequest(HttpMethod.GET, "/api/foo/", 200, "sausages");
@@ -414,7 +407,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testNormalized2() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/api/", subRouter);
+    router.route("/api/*").subRouter(subRouter);
     subRouter.route("/foo").handler(rc -> rc.response().setStatusMessage("sausages").end());
     testRequest(HttpMethod.GET, "/api/foo", 200, "sausages");
     testRequest(HttpMethod.GET, "/api/foo/", 200, "sausages");
@@ -426,7 +419,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testNormalized3() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/api", subRouter);
+    router.route("/api*").subRouter(subRouter);
     subRouter.route("/").handler(rc -> rc.response().setStatusMessage("sausages").end());
     testRequest(HttpMethod.GET, "/api/", 200, "sausages");
     testRequest(HttpMethod.GET, "/api", 200, "sausages");
@@ -437,7 +430,7 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testNormalized4() throws Exception {
     Router subRouter = Router.router(vertx);
-    router.mountSubRouter("/api/", subRouter);
+    router.route("/api/*").subRouter(subRouter);
     subRouter.route("/").handler(rc -> rc.response().setStatusMessage("sausages").end());
     testRequest(HttpMethod.GET, "/api/", 200, "sausages");
     testRequest(HttpMethod.GET, "/api", 404, "Not Found");
@@ -450,7 +443,7 @@ public class SubRouterTest extends WebTestBase {
 
     router.get("/files/:id/info").handler(ctx -> ctx.response().end());
 
-    router.mountSubRouter("/v1", router);
+    router.route("/v1*").subRouter(router);
 
     testRequest(HttpMethod.GET, "/v1/files/some-file-id/info", 200, "OK");
     testRequest(HttpMethod.GET, "/v1/files//info", 404, "Not Found");
@@ -468,7 +461,7 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().end();
     });
 
-    router.mountSubRouter("/v/:version", subRouter);
+    router.route("/v/:version*").subRouter(subRouter);
 
     testRequest(HttpMethod.GET, "/v/1/files/2/info", 200, "OK");
   }
@@ -533,7 +526,7 @@ public class SubRouterTest extends WebTestBase {
   public void testSubRouterWithRegex() {
     Router router = Router.router(vertx);
     router.getWithRegex("some-regex").handler(null);
-    router.mountSubRouter("/", router);
+    router.route("/*").subRouter(router);
   }
 
   @Test
@@ -544,7 +537,7 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().end();
     });
 
-    router.mountSubRouter("/v/", subRouter);
+    router.route("/v/*").subRouter(subRouter);
 
     testRequest(HttpMethod.GET, "/v/files/info", 200, "OK");
   }
@@ -557,7 +550,7 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().setStatusMessage("Hi").end();
     });
 
-    router.mountSubRouter("/", subRouter);
+    router.route("/*").subRouter(subRouter);
 
     testRequest(HttpMethod.GET, "/primary", 200, "Hi");
     testRequest(HttpMethod.GET, "/primary?query=1", 200, "Hi");
@@ -573,7 +566,7 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().end();
     });
 
-    router.mountSubRouter("/bank", subRouter);
+    router.route("/bank*").subRouter(subRouter);
 
     testRequest(HttpMethod.POST, "/bank/order/deposit", 200, "OK");
     testRequest(HttpMethod.GET, "/bank/order/deposit", 405, "Method Not Allowed");
@@ -583,13 +576,13 @@ public class SubRouterTest extends WebTestBase {
   @Test
   public void testMountMultiLevel() throws Exception {
     Router routerFirstLevel = Router.router(vertx);
-    router.mountSubRouter("/primary", routerFirstLevel);
+    router.route("/primary*").subRouter(routerFirstLevel);
 
     Router routerSecondLevel = Router.router(vertx);
     routerSecondLevel.get("/").handler(ctx -> {
       ctx.response().setStatusMessage("Hi").end();
     });
-    routerFirstLevel.mountSubRouter("/", routerSecondLevel);
+    routerFirstLevel.route("/*").subRouter(routerSecondLevel);
 
     // Below two scenarios will fail with 3.8.4 and higher, pass with 3.8.1 and lower.
     testRequest(HttpMethod.GET, "/primary", 200, "Hi");
@@ -618,7 +611,7 @@ public class SubRouterTest extends WebTestBase {
     Router routerSecondLevel = Router.router(vertx);
     routerSecondLevel.route("/test")
       .handler(ctx -> ctx.response().setStatusMessage("H2").end());
-    routerFirstLevel.mountSubRouter("/secondary", routerSecondLevel);
+    routerFirstLevel.route("/secondary*").subRouter(routerSecondLevel);
 
     testRequest(HttpMethod.GET, "/test", 200, "Hi");
     testRequest(HttpMethod.GET, "/secondary/test", 200, "H2");
@@ -660,9 +653,9 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().end();
     });
 
-    restRouter.mountSubRouter("/:version", subRouter);
+    restRouter.route("/:version*").subRouter(subRouter);
 
-    router.mountSubRouter("/rest", restRouter);
+    router.route("/rest*").subRouter(restRouter);
 
     // router
     // /rest -> restRouter
@@ -686,9 +679,9 @@ public class SubRouterTest extends WebTestBase {
       ctx.response().end();
     });
 
-    restRouter.mountSubRouter("/:version", subRouter);
+    restRouter.route("/:version*").subRouter(subRouter);
 
-    router.mountSubRouter("/rest", restRouter);
+    router.route("/rest*").subRouter(restRouter);
 
     // router
     // /rest -> restRouter

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -728,7 +728,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
 
     Router subRouter = Router.router(vertx);
 
-    router.mountSubRouter("/secret", subRouter);
+    router.route("/secret*").subRouter(subRouter);
 
     // create a oauth2 handler on our domain to the callback: "http://localhost:8080/secret/callback"
     OAuth2AuthHandler oauth2Handler = OAuth2AuthHandler.create(vertx, oauth2, "http://localhost:8080/secret/callback");

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerTest.java
@@ -693,7 +693,7 @@ public class StaticHandlerTest extends WebTestBase {
     router.clear();
     Router subRouter = Router.router(vertx);
     subRouter.route("/somedir/*").handler(stat);
-    router.mountSubRouter("/mymount/", subRouter);
+    router.route("/mymount/*").subRouter(subRouter);
     testRequest(HttpMethod.GET, "/mymount/somedir/otherpage.html", 200, "OK", "<html><body>Other page</body></html>");
   }
 
@@ -969,7 +969,7 @@ public class StaticHandlerTest extends WebTestBase {
 
     router.clear();
     router
-      .mountSubRouter("/test", subRouter);
+      .route("/test*").subRouter(subRouter);
 
     router
       .route()

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSErrorTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSErrorTest.java
@@ -52,7 +52,7 @@ public class SockJSErrorTest extends VertxTestBase {
     router.route("/").handler(event -> event.request().response().end("test"));
 
     Router sockJSRouter = createEventBusRouter();
-    router.mountSubRouter(WSS_PATH, sockJSRouter);
+    router.route(WSS_PATH + "*").subRouter(sockJSRouter);
 
     server.requestHandler(router);
     server.listen(PORT, context.asyncAssertSuccess());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -305,7 +305,7 @@ public class SockJSHandlerTest extends WebTestBase {
 
   private void setupSockJsServer(String serverPath, BiConsumer<SockJSSocket, Buffer> serverBufferHandler) {
     String path = serverPath;
-    router.mountSubRouter(path, SockJSHandler.create(vertx)
+    router.route(path + "*").subRouter(SockJSHandler.create(vertx)
       .socketHandler(sock -> {
         sock.handler(buffer -> serverBufferHandler.accept(sock, buffer));
         sock.exceptionHandler(this::fail);
@@ -375,9 +375,9 @@ public class SockJSHandlerTest extends WebTestBase {
     // can't rely on the response to be available to set cookies. In this test we use cookieless
     // sessions to adress the timing issues
     SessionHandler handler = SessionHandler.create(store).setCookieless(true);
-    CompletableFuture<String> sessionID = new CompletableFuture();
-    CompletableFuture<User> sessionUser = new CompletableFuture();
-    router.mountSubRouter("/webcontext", SockJSHandler.create(vertx)
+    CompletableFuture<String> sessionID = new CompletableFuture<>();
+    CompletableFuture<User> sessionUser = new CompletableFuture<>();
+    router.route("/webcontext*").subRouter(SockJSHandler.create(vertx)
       .socketHandler(sock -> {
         JsonObject principal = new JsonObject().put("key", "val");
         Session oldSession = sock.webSession();
@@ -398,7 +398,7 @@ public class SockJSHandlerTest extends WebTestBase {
         });
       }));
 
-    router.mountSubRouter("/webcontextuser", SockJSHandler.create(vertx)
+    router.route("/webcontextuser*").subRouter(SockJSHandler.create(vertx)
       .socketHandler(sock -> {
         Session session = null;
         try {
@@ -435,7 +435,7 @@ public class SockJSHandlerTest extends WebTestBase {
   @Test
   public void testCookiesRemoved() throws Exception {
     waitFor(2);
-    router.mountSubRouter("/cookiesremoved", SockJSHandler.create(vertx)
+    router.route("/cookiesremoved*").subRouter(SockJSHandler.create(vertx)
       .socketHandler(sock -> {
         MultiMap headers = sock.headers();
         String cookieHeader = headers.get("cookie");
@@ -459,7 +459,7 @@ public class SockJSHandlerTest extends WebTestBase {
 
   @Test
   public void testTimeoutCloseCode() {
-    router.mountSubRouter("/ws-timeout", SockJSHandler
+    router.route("/ws-timeout*").subRouter(SockJSHandler
       .create(vertx)
       .bridge(new SockJSBridgeOptions().setPingTimeout(1))
     );
@@ -476,7 +476,7 @@ public class SockJSHandlerTest extends WebTestBase {
 
   @Test
   public void testInvalidMessageCode() {
-    router.mountSubRouter("/ws-timeout", SockJSHandler
+    router.route("/ws-timeout*").subRouter(SockJSHandler
       .create(vertx)
       .bridge(new SockJSBridgeOptions().addInboundPermitted(new PermittedOptions().setAddress("SockJSHandlerTest.testInvalidMessageCode")))
     );

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSProtocolTest.java
@@ -68,15 +68,13 @@ public class SockJSProtocolTest {
 
     // These applications are required by the SockJS protocol and QUnit tests
 
-    router.mountSubRouter(
-      "/echo",
+    router.route("/echo*").subRouter(
       SockJSHandler.create(
         vertx,
         new SockJSHandlerOptions().setMaxBytesStreaming(4096))
         .socketHandler(sock -> sock.handler(sock::write)));
 
-    router.mountSubRouter(
-      "/close",
+    router.route("/close*").subRouter(
       SockJSHandler.create(vertx,
         new SockJSHandlerOptions().setMaxBytesStreaming(4096))
         .socketHandler(sock -> {
@@ -84,21 +82,18 @@ public class SockJSProtocolTest {
           // than the SockJS close frame "c[3000,"Go away!"]"
           vertx.setTimer(10, id -> sock.close(3000, "Go away!"));
         }));
-    router.mountSubRouter(
-      "/disabled_websocket_echo",
+    router.route("/disabled_websocket_echo*").subRouter(
       SockJSHandler.create(vertx, new SockJSHandlerOptions()
         .setMaxBytesStreaming(4096).addDisabledTransport("WEBSOCKET"))
         .socketHandler(sock -> sock.handler(sock::write)));
-    router.mountSubRouter(
-      "/ticker",
+    router.route("/ticker*").subRouter(
       SockJSHandler.create(vertx,
         new SockJSHandlerOptions().setMaxBytesStreaming(4096))
         .socketHandler(sock -> {
           long timerID = vertx.setPeriodic(1000, tid -> sock.write(buffer("tick!")));
           sock.endHandler(v -> vertx.cancelTimer(timerID));
         }));
-    router.mountSubRouter(
-      "/amplify",
+    router.route("/amplify*").subRouter(
       SockJSHandler.create(vertx,
         new SockJSHandlerOptions().setMaxBytesStreaming(4096))
         .socketHandler(sock -> sock.handler(data -> {
@@ -114,8 +109,7 @@ public class SockJSProtocolTest {
           }
           sock.write(buff);
         })));
-    router.mountSubRouter(
-      "/broadcast",
+    router.route("/broadcast*").subRouter(
       SockJSHandler.create(vertx,
         new SockJSHandlerOptions().setMaxBytesStreaming(4096).setRegisterWriteHandler(true))
         .socketHandler(new Handler<SockJSSocket>() {
@@ -139,7 +133,7 @@ public class SockJSProtocolTest {
       .setInsertJSESSIONID(true);
     SockJSHandler sockJSHandler = SockJSHandler.create(vertx, options);
     Router socketHandler = sockJSHandler.socketHandler(sock -> sock.handler(sock::write));
-    router.mountSubRouter("/cookie_needed_echo", socketHandler);
+    router.route("/cookie_needed_echo*").subRouter(socketHandler);
   }
 
   /*

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSWriteHandlerTestServer.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSWriteHandlerTestServer.java
@@ -95,7 +95,7 @@ public class SockJSWriteHandlerTestServer {
       String mountPoint = "/transport/" + transport.name()
         + "/" + (register ? "registered":"unregistered")
         + "/" + (local ? "local":"clustered");
-      router.mountSubRouter(mountPoint, sockJSHandler.socketHandler(socket -> {
+      router.route(mountPoint + "*").subRouter(sockJSHandler.socketHandler(socket -> {
         String id = socket.writeHandlerID();
         socket.write(id != null ? id:"--null--");
       }));

--- a/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/templ/TemplateTest.java
@@ -208,7 +208,7 @@ public class TemplateTest extends WebTestBase {
 
     router.clear();
 
-    router.mountSubRouter("/sub", Router.router(vertx));
+    router.route("/sub*").subRouter(Router.router(vertx));
 
     router.getWithRegex(".+\\.ftl")
       .handler(TemplateHandler.create(new TestEngine(false)));


### PR DESCRIPTION
…n implementation)

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Currently, there are 2 way of doing sub routing:

1. `Router.mountSubRouter(String, Router)`
2. `Route.subRouter(Router)`

The behavior is also inconsistent, the 1st allows any path, while the 2nd is explicit and requires that there is a wildcard `*` to mark the sub routing path.

More oddly, the implementation of the 1st, just delegates to the 2nd, by appending the missing wildcard.

This PR cleans the overall API to have a single way of doing sub routers and converts all existing examples/tests to the desired way. The old way is still preserved as-is and marked deprecated for removal.