### PR TITLE
Vary to ignore content encoding

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/Vary.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/Vary.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:craigday3@gmail.com">Craig Day</a>
+ * @author <a href="mailto:jllachf@gmail.com">Jordi Llach</a>
  */
 public class Vary {
 
@@ -58,10 +59,8 @@ public class Vary {
   private boolean variationMatches(CharSequence variation, RequestOptions request) {
     if (HttpHeaders.USER_AGENT.equals(variation)) {
       return isUserAgentMatch(request);
-    } else if (HttpHeaders.CONTENT_ENCODING.equals(variation)) {
-      return isEncodingMatch(request);
     } else if (HttpHeaders.ACCEPT_ENCODING.equals(variation)) {
-      return isEncodingMatch(request);
+      return true;
     } else {
       return isExactMatch(variation, request);
     }
@@ -72,18 +71,6 @@ public class Vary {
     UserAgent current = UserAgent.parse(request.getHeaders());
 
     return original.equals(current);
-  }
-
-  private boolean isEncodingMatch(RequestOptions request) {
-    Set<String> req = normalizeValues(request.getHeaders().getAll(HttpHeaders.ACCEPT_ENCODING));
-    Set<String> res = normalizeValues(responseHeaders.getAll(HttpHeaders.CONTENT_ENCODING));
-
-    // If the request is asking for any form of encoding the response mentioned, assume a match
-    // For example, `Accept-Encoding: gzip,deflate` should match `Content-Encoding: gzip`
-    Set<String> intersection = new HashSet<>(req);
-    intersection.retainAll(res);
-
-    return !intersection.isEmpty();
   }
 
   private boolean isExactMatch(CharSequence variation, RequestOptions request) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
@@ -792,7 +792,7 @@ public class CachingWebClientTest {
   }
 
   @Test
-  public void testVaryEncodingDifferent(TestContext context) {
+  public void testVaryEncodingTransformedToIdentityAlwaysSoWeIgnoreIt(TestContext context) {
     startMockServer(context, req -> {
       req.response().headers().add("Cache-Control", "public, max-age=300");
       req.response().headers().add("Content-Encoding", "gzip");
@@ -807,7 +807,7 @@ public class CachingWebClientTest {
       req.putHeader("Accept-Encoding", "br");
     });
 
-    context.assertNotEquals(body1, body2);
+    context.assertEquals(body1, body2);
   }
 
   @Test

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
@@ -772,26 +772,6 @@ public class CachingWebClientTest {
   // Cache-Control: public; Vary: Content-Encoding
 
   @Test
-  public void testVaryEncodingOverlap(TestContext context) {
-    startMockServer(context, req -> {
-      req.response().headers().add("Cache-Control", "public, max-age=300");
-      req.response().headers().add("Content-Encoding", "gzip");
-      req.response().headers().add("Vary", "Accept-Encoding");
-    });
-
-    String body1 = executeGetBlocking(context, varyClient, req -> {
-      req.putHeader("Accept-Encoding", "gzip,deflate,sdch");
-    });
-
-    String body2 = executeGetBlocking(context, varyClient, req -> {
-      req.putHeader("Accept-Encoding", "gzip,deflate");
-    });
-
-    // Both accept gzip, so cache should be used
-    context.assertEquals(body1, body2);
-  }
-
-  @Test
   public void testVaryEncodingTransformedToIdentityAlwaysSoWeIgnoreIt(TestContext context) {
     startMockServer(context, req -> {
       req.response().headers().add("Cache-Control", "public, max-age=300");

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/VaryTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/VaryTest.java
@@ -1,0 +1,75 @@
+package io.vertx.ext.web.client.impl.cache;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * As Netty is always decompressing the response and removing Content-Encoding header, we ignore this kind of variation.
+ * @author <a href="mailto:jllachf@gmail.com">Jordi Llach</a>
+ */
+public class VaryTest {
+
+  private static final String ACCEPT_ENCODING = "Accept-Encoding";
+  private static final String CONTENT_ENCODING = "Content-Encoding";
+  private static final String VARY = "Vary";
+  private static final String USER_AGENT = "User-Agent";
+
+  @Test
+  public void testVaryPerUserAgent() {
+    MultiMap requestHeaders = new HeadersMultiMap()
+      .add(USER_AGENT, "Concrete Mobile User Agent");
+    MultiMap responseHeaders = new HeadersMultiMap()
+      .add(VARY, USER_AGENT)
+      .add(USER_AGENT, "Mobile");
+    Vary instance = new Vary(requestHeaders, responseHeaders);
+
+    RequestOptions requestMatches = new RequestOptions().addHeader(USER_AGENT, "Another Mobile User Agent");
+    RequestOptions requestDoesNotMatch = buildEmptyRequestOptions(); // Desktop by default
+    assertTrue("User Agent Vary should match", instance.matchesRequest(requestMatches));
+    assertFalse("User Agent Vary should not match", instance.matchesRequest(requestDoesNotMatch));
+  }
+
+  @Test
+  public void testVaryPerAcceptEncodingIsIgnored() {
+    MultiMap requestHeaders = new HeadersMultiMap()
+      .add(ACCEPT_ENCODING, "gzip");
+    MultiMap responseHeaders = new HeadersMultiMap()
+      .add(VARY, ACCEPT_ENCODING)
+      .add(CONTENT_ENCODING, "gzip");
+    Vary instance = new Vary(requestHeaders, responseHeaders);
+
+    RequestOptions requestMatches = new RequestOptions().addHeader(ACCEPT_ENCODING, "gzip");
+    RequestOptions requestMatchesToo = new RequestOptions().addHeader(ACCEPT_ENCODING, "deflate");
+    RequestOptions requestMatchesTooo = buildEmptyRequestOptions();
+    assertTrue("Encoding matches", instance.matchesRequest(requestMatches));
+    assertTrue("Encoding deflate does not match but it is ok", instance.matchesRequest(requestMatchesToo));
+    assertTrue("No encoding specified is also ok", instance.matchesRequest(requestMatchesTooo));
+  }
+
+  @Test
+  public void testVaryForOtherCasesRequestMustMatch() {
+    MultiMap requestHeaders = new HeadersMultiMap()
+      .add("X-Vertx", "jordi");
+    MultiMap responseHeaders = new HeadersMultiMap()
+      .add("Vary", "X-Vertx")
+      .add("X-Vertx", "jordi");
+    Vary instance = new Vary(requestHeaders, responseHeaders);
+
+    RequestOptions requestMatches = new RequestOptions().addHeader("X-Vertx", "jordi");
+    RequestOptions requestFails = new RequestOptions().addHeader("X-Vertx", "llach");
+    RequestOptions requestFailsToo = buildEmptyRequestOptions();
+    assertTrue("Vary per custom header matches", instance.matchesRequest(requestMatches));
+    assertFalse("Vary per custom header does not match", instance.matchesRequest(requestFails));
+    assertFalse("Vary per custom header not present", instance.matchesRequest(requestFailsToo));
+  }
+
+  private RequestOptions buildEmptyRequestOptions() {
+    return new RequestOptions().setHeaders(new HeadersMultiMap());
+  }
+
+}


### PR DESCRIPTION
Related to https://github.com/vert-x3/vertx-web/issues/2135

BTW @vietj while using RequestOptions in the test I realised that headers field is not initialised. 
Until now, as we were using HttpReqImpl, the 'headers' field was initialised always, headers = HttpHeaders.headers();  or the like ... so I'd suggest to do the same in RequestOptions, what do you think ?