### PR TITLE
Hold request parsing, until really required

### DIFF
--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderTest.java
@@ -36,7 +36,7 @@ import static io.vertx.ext.web.openapi.asserts.MyAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(VertxExtension.class)
-@Timeout(value = 1, timeUnit = TimeUnit.SECONDS)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 public class OpenAPIHolderTest {
 
   private HttpServer schemaServer;

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -133,7 +133,9 @@ Here's the 10000 foot view:
 A {@link io.vertx.ext.web.Router} is one of the core concepts of Vert.x-Web. It's an object which maintains zero or more
 {@link io.vertx.ext.web.Route Routes}.
 
-A router takes an HTTP request and finds the first matching route for that request, and passes the request to that route.
+A router will pause the incoming {@link io.vertx.core.http.HttpServerRequest}, to ensure that the request body or any
+protocol upgrades are not lost. Second, it will find the first matching route for that request, and passes the request
+to that route.
 
 The route can have a _handler_ associated with it, which then receives the request. You then _do something_ with the
 request, and then, either end it or pass it to the next matching handler.
@@ -862,20 +864,12 @@ file uploads.
 
 You should make sure a body handler is on a matching route for any requests that require this functionality.
 
-The usage of this handler requires that it is installed as soon as possible in the router since it needs
-to install handlers to consume the HTTP request body and this must be done before executing any async call.
+The usage of this handler requires that it is installed as soon as possible. The handler will resume the
+{@link io.vertx.core.http.HttpServerRequest} processing, since it installs handlers to consume the HTTP request body.
 
 [source,$lang]
 ----
 {@link examples.WebExamples#example27}
-----
-
-If an async call is required before, the `HttpServerRequest` should be paused and then resumed so that the request
-events are not delivered until the body handler is ready to process them.
-
-[source,$lang]
-----
-{@link examples.WebExamples#example27_1}
 ----
 
 NOTE: Uploads can be a source of DDoS attacks, in order to reduce the attack surface, it is recommended to

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -690,32 +690,6 @@ public class WebExamples {
 
   }
 
-  public void example27_1(Router router) {
-
-    router.route().handler(ctx -> {
-
-      HttpServerRequest request = ctx.request();
-
-      // Pause the request
-      request.pause();
-
-      someAsyncCall(result -> {
-
-        // Resume the request
-        request.resume();
-
-        // And continue processing
-        ctx.next();
-      });
-    });
-
-    // This body handler will be called for all routes
-    router.route().handler(BodyHandler.create());
-  }
-
-  private void someAsyncCall(Handler<Void> handler) {
-  }
-
   public void example28(Router router) {
 
     router.route().handler(BodyHandler.create());

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
@@ -18,8 +18,6 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.auth.User;
@@ -57,14 +55,6 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
     if (user == null) {
       ctx.fail(FORBIDDEN_CODE, FORBIDDEN_EXCEPTION);
     } else {
-      // before starting any potential async operation here
-      // pause parsing the request body. The reason is that
-      // we don't want to loose the body or protocol upgrades
-      // for async operations
-      final boolean parseEnded = ctx.request().isEnded();
-      if (!parseEnded) {
-        ctx.request().pause();
-      }
       try {
         // create the authorization context
         final AuthorizationContext authorizationContext = AuthorizationContext.create(user);
@@ -72,10 +62,9 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
           variableHandler.accept(ctx, authorizationContext);
         }
         // check or fetch authorizations
-        checkOrFetchAuthorizations(ctx, parseEnded, authorizationContext, authorizationProviders.iterator());
+        checkOrFetchAuthorizations(ctx, authorizationContext, authorizationProviders.iterator());
       } catch (RuntimeException e) {
         // resume as the error handler may allow this request to become valid again
-        resume(ctx.request(), parseEnded);
         ctx.fail(e);
       }
     }
@@ -95,10 +84,8 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
    * @param authorizationContext the current authorization context
    * @param providers the providers iterator
    */
-  private void checkOrFetchAuthorizations(RoutingContext ctx, boolean parseEnded, AuthorizationContext authorizationContext, Iterator<AuthorizationProvider> providers) {
+  private void checkOrFetchAuthorizations(RoutingContext ctx, AuthorizationContext authorizationContext, Iterator<AuthorizationProvider> providers) {
     if (authorization.match(authorizationContext)) {
-      // resume the processing of the request
-      resume(ctx.request(), parseEnded);
       ctx.next();
       return;
     }
@@ -106,8 +93,6 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
     final User user = ctx.user();
 
     if (user == null || !providers.hasNext()) {
-      // resume as the error handler may allow this request to become valid again
-      resume(ctx.request(), parseEnded);
       ctx.fail(FORBIDDEN_CODE, FORBIDDEN_EXCEPTION);
       return;
     }
@@ -124,15 +109,13 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
             LOG.warn("An error occurred getting authorization - providerId: " + provider.getId(), authorizationResult.cause());
             // note that we don't 'record' the fact that we tried to fetch the authorization provider. therefore, it will be re-fetched later-on
           }
-          checkOrFetchAuthorizations(ctx, parseEnded, authorizationContext, providers);
+          checkOrFetchAuthorizations(ctx, authorizationContext, providers);
         });
         // get out right now as the callback will decide what to do next
         return;
       }
     } while (providers.hasNext());
     // reached the end of the iterator
-    // resume as the error handler may allow this request to become valid again, yet mark the request as forbidden
-    resume(ctx.request(), parseEnded);
     ctx.fail(FORBIDDEN_CODE, FORBIDDEN_EXCEPTION);
   }
 
@@ -141,11 +124,5 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
     Objects.requireNonNull(authorizationProvider);
     this.authorizationProviders.add(authorizationProvider);
     return this;
-  }
-
-  private void resume(HttpServerRequest request, final boolean parseEnded) {
-    if (!parseEnded && !request.headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true)) {
-      request.resume();
-    }
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -80,11 +80,13 @@ public class BodyHandlerImpl implements BodyHandler {
     }
     // we need to keep state since we can be called again on reroute
     if (!((RoutingContextInternal) context).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
+      ((RoutingContextInternal) context).visitHandler(RoutingContextInternal.BODY_HANDLER);
+      request.resume();
+
       long contentLength = isPreallocateBodyBuffer ? parseContentLengthHeader(request) : -1;
       BHandler handler = new BHandler(context, contentLength);
       request.handler(handler);
       request.endHandler(v -> handler.end());
-      ((RoutingContextInternal) context).visitHandler(RoutingContextInternal.BODY_HANDLER);
     } else {
       // on reroute we need to re-merge the form params if that was desired
       if (mergeFormAttributes && request.isExpectMultipart()) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -73,17 +73,28 @@ public class BodyHandlerImpl implements BodyHandler {
 
   @Override
   public void handle(RoutingContext context) {
-    HttpServerRequest request = context.request();
-    if (request.headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true)) {
-      context.next();
-      return;
-    }
+    final HttpServerRequest request = context.request();
+
     // we need to keep state since we can be called again on reroute
     if (!((RoutingContextInternal) context).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
       ((RoutingContextInternal) context).visitHandler(RoutingContextInternal.BODY_HANDLER);
+
+      // Check if a request has a request body.
+      // A request with a body __must__ either have `transfer-encoding`
+      // or `content-length` headers set.
+      // http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+      final long parsedContentLength = parseContentLengthHeader(request);
+
+      if (!request.headers().contains(HttpHeaders.TRANSFER_ENCODING) && parsedContentLength == -1) {
+        // there is no "body", so we can skip this handler
+        context.next();
+        return;
+      }
+
+      // resume the request (if paused)
       request.resume();
 
-      long contentLength = isPreallocateBodyBuffer ? parseContentLengthHeader(request) : -1;
+      long contentLength = isPreallocateBodyBuffer ? parsedContentLength : -1;
       BHandler handler = new BHandler(context, contentLength);
       request.handler(handler);
       request.endHandler(v -> handler.end());

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -91,13 +91,12 @@ public class BodyHandlerImpl implements BodyHandler {
         return;
       }
 
-      // resume the request (if paused)
-      request.resume();
-
-      long contentLength = isPreallocateBodyBuffer ? parsedContentLength : -1;
-      BHandler handler = new BHandler(context, contentLength);
-      request.handler(handler);
-      request.endHandler(v -> handler.end());
+      final BHandler handler = new BHandler(context, isPreallocateBodyBuffer ? parsedContentLength : -1);
+      request
+        // resume the request (if paused)
+        .resume()
+        .handler(handler)
+        .endHandler(handler::end);
     } else {
       // on reroute we need to re-merge the form params if that was desired
       if (mergeFormAttributes && request.isExpectMultipart()) {
@@ -293,7 +292,7 @@ public class BodyHandlerImpl implements BodyHandler {
       }
     }
 
-    void end() {
+    void end(Void v) {
       // this marks the end of body parsing, calling doEnd should
       // only be possible from this moment onwards
       ended = true;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -23,7 +23,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.CookieSameSite;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -301,19 +300,8 @@ public class SessionHandlerImpl implements SessionHandler {
     // Look for existing session id
     String sessionID = getSessionId(context);
     if (sessionID != null && sessionID.length() > minLength) {
-      // before starting any potential async operation here
-      // pause parsing the request body. The reason is that
-      // we don't want to lose the body or protocol upgrades
-      // for async operations
-      final boolean parseEnded = request.isEnded();
-      if (!parseEnded) {
-        request.pause();
-      }
       // we passed the OWASP min length requirements
       getSession(context.vertx(), sessionID, res -> {
-        if (!parseEnded && !request.headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true)) {
-          request.resume();
-        }
         if (res.succeeded()) {
           Session session = res.result();
           if (session != null) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -75,22 +75,11 @@ class WebSocketTransport extends BaseTransport {
           ctx.fail(403, new IllegalStateException("Invalid Origin"));
           return;
         }
-        // we're about to upgrade the connection, which means an asynchronous
-        // operation. We have to pause the request otherwise we will loose the
-        // body of the request once the upgrade completes
-        final boolean parseEnded = req.isEnded();
-        if (!parseEnded) {
-          req.pause();
-        }
         // upgrade
         req.toWebSocket(toWebSocket -> {
           if (toWebSocket.succeeded()) {
             if (LOG.isTraceEnabled()) {
               LOG.trace("WS, handler");
-            }
-            // resume the parsing
-            if (!parseEnded) {
-              req.resume();
             }
             // handle the sockjs session as usual
             SockJSSession session = new SockJSSession(vertx, sessions, ctx, options, sockHandler);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
@@ -40,6 +40,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
@@ -119,8 +120,11 @@ class XhrTransport extends BaseTransport {
 
   private void handleSend(RoutingContext rc, SockJSSession session) {
     if (!((RoutingContextInternal) rc).seenHandler(RoutingContextInternal.BODY_HANDLER)) {
-      LOG.error("No BodyHandler was executed on the route. Please add a BodyHandler before the SockJS handler.");
-      rc.fail(500);
+      // the body handler was not set, so we cannot securely process POST bodies
+      // we could just add an ad-hoc body handler but this can lead to DDoS attacks
+      // and it doesn't really cover all the uploads, such as multipart, etc...
+      // as well as resource cleanup
+      rc.fail(500, new NoStackTraceThrowable("BodyHandler is required to process POST requests"));
       return;
     }
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/XhrTransport.java
@@ -126,6 +126,7 @@ class XhrTransport extends BaseTransport {
           + "(see the docs).");
       rc.fail(500);
     } else {
+      rc.request().resume();
       rc.request().bodyHandler(buff -> handleSendMessage(rc, session, buff));
     }
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -64,6 +64,11 @@ public class RouterImpl implements Router {
     if (LOG.isTraceEnabled()) {
       LOG.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
     }
+
+    // will pause the request, this means the body is not parsed yet
+    // or protocol upgrades will be on-hold.
+    request.pause();
+
     new RoutingContextImpl(null, this, request, state.getRoutes()).next();
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -1121,11 +1121,7 @@ public class EventbusBridgeTest extends WebTestBase {
     router.route("/eventbus/*").handler(rc -> {
       // we need to be logged in
       if (rc.user() == null) {
-        UsernamePasswordCredentials authInfo = new UsernamePasswordCredentials("tim", "delicious:sausages");
-        HttpServerRequest request = rc.request();
-        request.pause();
-        authProvider.authenticate(authInfo, res -> {
-          request.resume();
+        authProvider.authenticate(new UsernamePasswordCredentials("tim", "delicious:sausages"), res -> {
           if (res.succeeded()) {
             rc.setUser(res.result());
             rc.next();

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionContextTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSSessionContextTest.java
@@ -19,6 +19,7 @@ package io.vertx.ext.web.handler.sockjs;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.handler.BodyHandler;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -32,6 +33,8 @@ public class SockJSSessionContextTest extends SockJSTestBase {
   public void setUp() throws Exception {
     numServers = 2;
     super.setUp();
+    // add a body handler to the setup
+    preSockJSHandlerSetup = router -> router.route().handler(BodyHandler.create());
   }
 
   @Test

--- a/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/sstore/ClusteredSessionHandlerTest.java
@@ -182,11 +182,9 @@ public class ClusteredSessionHandlerTest extends SessionHandlerTestBase {
     router.route().handler(SessionHandler.create(store).setSessionCookieName(sessionCookieName).setMinLength(0));
     router.route().handler(rc ->
       rc.request()
-        .pause()
         .toWebSocket()
         .onFailure(this::fail)
         .onSuccess(serverWebSocket -> {
-          rc.request().resume();
           serverWebSocket.textMessageHandler(msg -> {
             assertEquals("foo", msg);
             testComplete();


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Trying to simplify the internal state and avoid over engineer the parsing of the request body when protocol upgrades are needed.