### PR TITLE
fixed #2153

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/MultipartFormBodyProcessorGenerator.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/MultipartFormBodyProcessorGenerator.java
@@ -35,9 +35,14 @@ public class MultipartFormBodyProcessorGenerator implements BodyProcessorGenerat
     ValueParser<List<String>> additionalPropertiesValueParser =
       ValueParserInferenceUtils.infeerAdditionalPropertiesFormValueParserForObjectSchema(schemas.getFakeSchema());
 
+    // Get the required properties
+    JsonObject requiredFields = schemas.getFakeSchema().getJsonObject("required", new JsonObject());
+
     for (Entry<String, Object> pe : schemas.getFakeSchema().getJsonObject("properties", new JsonObject())) {
       JsonObject propSchema = (JsonObject) pe.getValue();
       String encoding = (String) JsonPointer.create().append("encoding").append(pe.getKey()).append("contentType").queryJson(mediaTypeObject);
+
+      boolean required = requiredFields.getValue(pe.getKey()) != null;
 
       if (encoding == null) {
         if (OpenAPI3Utils.isSchemaObjectOrCombinators(propSchema) ||
@@ -47,14 +52,14 @@ public class MultipartFormBodyProcessorGenerator implements BodyProcessorGenerat
         } else if ("string".equals(propSchema.getString("type")) &&
           ("binary".equals(propSchema.getString("format")) || "base64".equals(propSchema.getString("format")))) {
           context.addPredicate(
-            RequestPredicate.multipartFileUploadExists(pe.getKey(), Pattern.quote("application/octet-stream"))
+            RequestPredicate.multipartFileUploadExists(pe.getKey(), Pattern.quote("application/octet-stream"), required)
           );
           propertiesValueParsers.remove(pe.getKey());
           searchPropAndRemoveInSchema(schemas.getNormalizedSchema(), pe.getKey());
         }
       } else {
         context.addPredicate(
-          RequestPredicate.multipartFileUploadExists(pe.getKey(), OpenAPI3Utils.resolveContentTypeRegex(encoding))
+          RequestPredicate.multipartFileUploadExists(pe.getKey(), OpenAPI3Utils.resolveContentTypeRegex(encoding), required)
         );
         propertiesValueParsers.remove(pe.getKey());
         searchPropAndRemoveInSchema(schemas.getNormalizedSchema(), pe.getKey());

--- a/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/ValidationHandlerPredicatesIntegrationTest.java
+++ b/vertx-web-validation/src/test/java/io/vertx/ext/web/validation/ValidationHandlerPredicatesIntegrationTest.java
@@ -65,7 +65,8 @@ public class ValidationHandlerPredicatesIntegrationTest extends BaseValidationHa
       .builder(parser)
       .predicate(RequestPredicate.multipartFileUploadExists(
         "myfile",
-        Pattern.quote("text/plain")
+        Pattern.quote("text/plain"),
+        true
       ))
       .build();
 


### PR DESCRIPTION
Motivation:

in openapi with multipart/form-data , vertx-web-validation validate the upload file field regardless of whether it is set to required.

This pr check a field is required and passed it to validation.