### PR TITLE
allow setting 'Secure' flag on XSRF Token cookie

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CSRFHandler.java
@@ -81,6 +81,16 @@ public interface CSRFHandler extends InputTrustHandler {
   CSRFHandler setCookieHttpOnly(boolean httpOnly);
 
   /**
+   * Sets the cookie {@code secure} flag. When set this flag instructs browsers to only send the cookie over HTTPS.
+   *
+   *
+   * @param secure true to set the secure flag on the cookie
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CSRFHandler setCookieSecure(boolean secure);
+
+  /**
    * Set the header name. By default X-XSRF-TOKEN is used as it is the expected name by AngularJS however other
    * frameworks might use other names.
    *

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
@@ -55,6 +55,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
 
   private Origin origin;
   private boolean httpOnly;
+  private boolean cookieSecure;
 
   public CSRFHandlerImpl(final Vertx vertx, final String secret) {
     try {
@@ -94,6 +95,12 @@ public class CSRFHandlerImpl implements CSRFHandler {
   }
 
   @Override
+  public CSRFHandler setCookieSecure(boolean secure) {
+    this.cookieSecure = secure;
+    return this;
+  }
+
+  @Override
   public CSRFHandler setHeaderName(String headerName) {
     this.headerName = headerName;
     return this;
@@ -125,6 +132,7 @@ public class CSRFHandlerImpl implements CSRFHandler {
         Cookie.cookie(cookieName, token)
           .setPath(cookiePath)
           .setHttpOnly(httpOnly)
+          .setSecure(cookieSecure)
           // it's not an option to change the same site policy
           .setSameSite(CookieSameSite.STRICT));
 


### PR DESCRIPTION
Motivation:

Adds a method to add the flag 'Secure' to the XSRF-Token cookie.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
