### PR TITLE
Fixes #2185: use the right class hierarchy to compute the basePath

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1024,7 +1024,7 @@ final class RouteState {
         }
 
         context.matchRest = -1;
-        context.matchNormalized = useNormalizedPath;
+        context.normalizedMatch = useNormalizedPath;
 
         if (m.groupCount() > 0) {
           if (!exactPath) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -287,6 +287,16 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
+  public int restIndex() {
+    return decoratedContext.restIndex();
+  }
+
+  @Override
+  public boolean normalizedMatch() {
+    return decoratedContext.normalizedMatch();
+  }
+
+  @Override
   public void setUser(User user) {
     decoratedContext.setUser(user);
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -108,7 +108,6 @@ public class RoutingContextImpl extends RoutingContextImplBase {
         HeaderParser.sort(HeaderParser.convertToParsedHeaderValues(acceptLanguage, ParsableLanguageValue::new)),
         new ParsableMIMEValue(contentType)
     );
-
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -54,7 +54,7 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   int matchFailure;
   // the current path matched string
   int matchRest = -1;
-  boolean matchNormalized;
+  boolean normalizedMatch;
   // internal runtime state
   private volatile long seen;
 
@@ -76,6 +76,16 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   @Override
   public boolean seenHandler(int id) {
     return (seen & id) != 0;
+  }
+
+  @Override
+  public int restIndex() {
+    return matchRest;
+  }
+
+  @Override
+  public boolean normalizedMatch() {
+    return normalizedMatch;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
@@ -84,4 +84,25 @@ public interface RoutingContextInternal extends RoutingContext {
    * @param session  the session
    */
   void setSession(Session session);
+
+  int restIndex();
+
+  boolean normalizedMatch();
+
+  default String basePath() {
+    // if we're on a sub router already we need to skip the matched path
+    String mountPoint = mountPoint();
+
+    int skip = mountPoint != null ? mountPoint.length() : 0;
+    if (normalizedMatch()) {
+      return normalizedPath().substring(skip, skip + restIndex());
+    } else {
+      String path = request().path();
+      if (path != null) {
+        return path.substring(skip, skip + restIndex());
+      }
+      return null;
+    }
+
+  };
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/SubRouterTest.java
@@ -690,5 +690,55 @@ public class SubRouterTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/rest/1/files/2", 200, "OK");
   }
-}
 
+  @Test
+  public void testHierarchicalWithParamsSimple() throws Exception {
+
+    Router restRouter = Router.router(vertx);
+    Router productRouter = Router.router(vertx);
+    Router instanceRouter = Router.router(vertx);
+
+    router.route("/rest*").subRouter(restRouter);
+    restRouter.route("/product*").subRouter(productRouter);
+    productRouter.route("/:id*").subRouter(instanceRouter);
+    instanceRouter.get("/").handler(ctx -> {
+      // id is extracted from the root router
+      assertEquals("123", ctx.pathParam("id"));
+      ctx.response().end();
+    });
+
+    // router
+    // /rest -> restRouter
+    //      /product -> productRouter
+    //            /:id -> instanceRouter
+    //                  / -> OK
+
+    testRequest(HttpMethod.GET, "/rest/product/123", 200, "OK");
+  }
+
+  @Test
+  public void testHierarchicalWithParamsSimpleWithDummy() throws Exception {
+
+    Router restRouter = Router.router(vertx);
+    Router productRouter = Router.router(vertx);
+    Router instanceRouter = Router.router(vertx);
+
+    router.route("/rest*").subRouter(restRouter);
+    restRouter.route("/product*").subRouter(productRouter);
+    productRouter.route("/:id*").subRouter(instanceRouter);
+    instanceRouter.get("/:foo").handler(ctx -> {
+      // id is extracted from the root router
+      assertEquals("123", ctx.pathParam("id"));
+      assertEquals("bar", ctx.pathParam("foo"));
+      ctx.response().end();
+    });
+
+    // router
+    // /rest -> restRouter
+    //      /product -> productRouter
+    //            /:id -> instanceRouter
+    //                  /:foo -> OK
+
+    testRequest(HttpMethod.GET, "/rest/product/123/bar", 200, "OK");
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

The current algorithm was using the wrong parent class, which leads to getting the wrong basepath.