### PR TITLE
Avoid depending on databind for internal usage only

### DIFF
--- a/vertx-web-openapi/pom.xml
+++ b/vertx-web-openapi/pom.xml
@@ -56,14 +56,10 @@
       <artifactId>vertx-json-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.30</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-    </dependency>
-
     <!-- For docs -->
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ContractEndpointHandler.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/ContractEndpointHandler.java
@@ -1,10 +1,5 @@
 package io.vertx.ext.web.openapi.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -15,7 +10,10 @@ import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.openapi.ErrorType;
 import io.vertx.ext.web.openapi.OpenAPIHolder;
 import io.vertx.ext.web.openapi.RouterBuilderException;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,18 +58,13 @@ public class ContractEndpointHandler implements Handler<RoutingContext> {
   }
 
   public static ContractEndpointHandler create(OpenAPIHolder holder) {
-    JsonObject openapi = holder.getOpenAPI();
-
-    ObjectMapper jsonMapper = new JsonMapper();
-    try {
-      JsonNode node = jsonMapper.readTree(openapi.toString());
-      ObjectMapper yamlMapper = new YAMLMapper();
-      byte[] yamlBytes = yamlMapper.writeValueAsBytes(node);
-      return new ContractEndpointHandler(openapi.toBuffer(), Buffer.buffer(yamlBytes));
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-      throw new RouterBuilderException("Cannot generate yaml contract",
-        ErrorType.UNSUPPORTED_SPEC, e);
+    try (StringWriter writer = new StringWriter()) {
+      JsonObject openapi = holder.getOpenAPI();
+      Yaml yaml = new Yaml();
+      yaml.dump(openapi.getMap(), writer);
+      return new ContractEndpointHandler(openapi.toBuffer(), Buffer.buffer(writer.toString()));
+    } catch (IOException | RuntimeException e) {
+      throw new RouterBuilderException("Cannot generate yaml contract", ErrorType.UNSUPPORTED_SPEC, e);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

databind is a source of CVEs, for all internal usages we should avoid pulling it to ensure that the library code is less prone to attacks.