### PR TITLE
Make `WebClient.close()` return `Future<Void>`

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -16,6 +16,7 @@
 package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -763,6 +764,7 @@ public interface WebClient {
   /**
    * Close the client. Closing will close down any pooled connections.
    * Clients should always be closed after use.
+   * @return a future completed with the result
    */
-  void close();
+  Future<Void> close();
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -16,6 +16,7 @@
 package io.vertx.ext.web.client.impl;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
@@ -145,7 +146,7 @@ public class WebClientBase implements WebClientInternal {
   }
 
   @Override
-  public void close() {
-    client.close();
+  public Future<Void> close() {
+    return client.close();
   }
 }


### PR DESCRIPTION
Motivation:

Shouldn't `WebClient.close()` return a `Future<Void>` instance like the other `close()` functions in Vert.x, such as the wrapped `HttpClient.close()`?