### PR TITLE
Ensure that stores are returning futures on the right context

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -16,6 +16,7 @@ import io.vertx.ext.web.AllowForwardHeaders;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -178,7 +179,7 @@ class HttpServerRequestWrapper implements HttpServerRequestInternal {
       params = MultiMap.caseInsensitiveMultiMap();
       // if there is no query it's not really needed to parse it
       if (query != null) {
-        QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri);
+        QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, Charset.forName(delegate.getParamsCharset()));
         Map<String, List<String>> prms = queryStringDecoder.parameters();
         if (!prms.isEmpty()) {
           for (Map.Entry<String, List<String>> entry : prms.entrySet()) {
@@ -218,6 +219,21 @@ class HttpServerRequestWrapper implements HttpServerRequestInternal {
   @Override
   public String getHeader(CharSequence charSequence) {
     return delegate.getHeader(charSequence);
+  }
+
+  @Override
+  public HttpServerRequest setParamsCharset(String s) {
+    String old = delegate.getParamsCharset();
+    delegate.setParamsCharset(s);
+    if (!s.equals(old)) {
+      params = null;
+    }
+    return this;
+  }
+
+  @Override
+  public String getParamsCharset() {
+    return delegate.getParamsCharset();
   }
 
   @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/it/SessionHandlerRegression.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/it/SessionHandlerRegression.java
@@ -1,0 +1,55 @@
+package io.vertx.ext.web.it;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.LocalSessionStore;
+import io.vertx.ext.web.sstore.SessionStore;
+
+public class SessionHandlerRegression {
+
+  public static void main(String[] args) {
+    Vertx vertx = Vertx.vertx();
+    LocalSessionStore store = LocalSessionStore.create(vertx);
+    // vertx.deployVerticle(() -> new MyVerticle(), new DeploymentOptions().setInstances(1)); // Works fine
+    vertx.deployVerticle(() -> new MyVerticle(store), new DeploymentOptions().setInstances(1)); // Fails with IllegalStateException
+  }
+
+  public static class MyVerticle extends AbstractVerticle {
+    SessionStore sessionStore;
+
+    public MyVerticle(final SessionStore sessionStore) {
+      this.sessionStore = sessionStore;
+    }
+
+    public MyVerticle() {
+      super();
+    }
+
+    public void start(final Promise<Void> startPromise) {
+      if (sessionStore == null) {
+        sessionStore = LocalSessionStore.create(vertx);
+      }
+      Router router = Router.router(vertx);
+      router.route().handler(SessionHandler.create(sessionStore));
+      router.route().handler(context -> {
+        try {
+          Thread.sleep(1000); // that's a lot, but it's for example purpose...
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        context.request()
+          .endHandler(unused -> context.response()
+            .end("hello"));
+      });
+      HttpServerOptions options = new HttpServerOptions();
+      vertx.createHttpServer(options)
+        .requestHandler(router)
+        .listen(8080, ar -> startPromise.complete());
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Session stores were returing futures on the `ctor` context, not on the caller context and this is problematic as 2 event loops may be involved on fetching the data from the store and the request event loop would loose the body.