### PR TITLE
Properly handle the verification of protocol upgrade

### DIFF
--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ApolloWSHandlerImpl.java
@@ -18,7 +18,6 @@ package io.vertx.ext.web.handler.graphql.impl;
 
 import graphql.GraphQL;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
@@ -30,7 +29,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
 
-import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.ext.web.impl.Utils.canUpgradeToWebsocket;
 
 /**
  * @author Rogelio Orts
@@ -152,8 +151,7 @@ public class ApolloWSHandlerImpl implements ApolloWSHandler {
 
   @Override
   public void handle(RoutingContext ctx) {
-    MultiMap headers = ctx.request().headers();
-    if (headers.contains(CONNECTION) && headers.contains(UPGRADE, WEBSOCKET, true)) {
+    if (canUpgradeToWebsocket(ctx.request())) {
       if (!Origin.check(origin, ctx)) {
         ctx.fail(403, new IllegalStateException("Invalid Origin"));
         return;

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/GraphQLWSHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/GraphQLWSHandlerImpl.java
@@ -18,7 +18,6 @@ package io.vertx.ext.web.handler.graphql.impl.ws;
 
 import graphql.GraphQL;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.ExecutionInputBuilderWithContext;
@@ -29,7 +28,7 @@ import io.vertx.ext.web.handler.graphql.ws.Message;
 
 import java.util.Objects;
 
-import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.ext.web.impl.Utils.canUpgradeToWebsocket;
 
 public class GraphQLWSHandlerImpl implements GraphQLWSHandler {
 
@@ -76,8 +75,7 @@ public class GraphQLWSHandlerImpl implements GraphQLWSHandler {
 
   @Override
   public void handle(RoutingContext rc) {
-    MultiMap headers = rc.request().headers();
-    if (headers.contains(CONNECTION) && headers.contains(UPGRADE, WEBSOCKET, true)) {
+    if (canUpgradeToWebsocket(rc.request())) {
       ContextInternal context = (ContextInternal) rc.vertx().getOrCreateContext();
       rc
         .request()

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/RawWebSocketTransport.java
@@ -48,6 +48,7 @@ import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 import io.vertx.ext.web.impl.Origin;
 
 import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.ext.web.impl.Utils.canUpgradeToWebsocket;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -75,7 +76,7 @@ class RawWebSocketTransport {
 
   private void handleGet(RoutingContext ctx) {
     HttpServerRequest req = ctx.request();
-    if (!req.headers().contains(CONNECTION, UPGRADE, true)) {
+    if (!canUpgradeToWebsocket(req)) {
       ctx.response().setStatusCode(400);
       ctx.response().end("Can \"Upgrade\" only to \"WebSocket\".");
       return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/WebSocketTransport.java
@@ -51,6 +51,7 @@ import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 import io.vertx.ext.web.impl.Origin;
 
 import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.ext.web.impl.Utils.canUpgradeToWebsocket;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -80,7 +81,7 @@ class WebSocketTransport extends BaseTransport {
 
   private void handleGet(RoutingContext ctx) {
     HttpServerRequest req = ctx.request();
-    if (!req.headers().contains(CONNECTION, UPGRADE, true)) {
+    if (!canUpgradeToWebsocket(req)) {
       ctx.response().setStatusCode(400);
       ctx.response().end("Can \"Upgrade\" only to \"WebSocket\".");
       return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -228,4 +228,26 @@ public class Utils {
 
     return true;
   }
+
+  public static boolean canUpgradeToWebsocket(HttpServerRequest req) {
+    // verify if we can upgrade
+    // 1. Connection header contains "Upgrade"
+    // 2. Upgrade header is "websocket"
+    final MultiMap headers = req.headers();
+    if (headers.contains(HttpHeaders.CONNECTION)) {
+      for (String connection : headers.getAll(HttpHeaders.CONNECTION)) {
+        if (connection.toLowerCase().contains(HttpHeaders.UPGRADE)) {
+          if (headers.contains(HttpHeaders.UPGRADE)) {
+            for (String upgrade : headers.getAll(HttpHeaders.UPGRADE)) {
+              if (upgrade.toLowerCase().contains(HttpHeaders.WEBSOCKET)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return false;
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -16,14 +16,13 @@
 
 package io.vertx.ext.web;
 
-import io.vertx.core.MultiMap;
 import io.vertx.core.http.*;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 
-import static io.vertx.core.http.HttpHeaders.*;
 import static io.vertx.ext.web.AllowForwardHeaders.*;
+import static io.vertx.ext.web.impl.Utils.canUpgradeToWebsocket;
 
 public class ForwardedTest extends WebTestBase {
 
@@ -344,8 +343,7 @@ public class ForwardedTest extends WebTestBase {
     String address = "1.2.3.4";
     router.allowForward(ALL).route("/ws").handler(rc -> {
       HttpServerRequest request = rc.request();
-      MultiMap headers = request.headers();
-      if (headers.contains(CONNECTION) && headers.contains(UPGRADE, WEBSOCKET, true)) {
+      if (canUpgradeToWebsocket(request)) {
         request
           .toWebSocket(onSuccess(socket -> {
             assertTrue(socket.host().equals(host));


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Properly process the the headers `Connection` and `Upgrade` to verify if a connection can be upgraded to websocket.
Fixes: #2209 