### PR TITLE
Fix https://github.com/vert-x3/vertx-auth/issues/568

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -378,10 +378,13 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
 
   @Override
   public void onOrder(int order) {
-    this.order = order;
-    // callback route already known, but waiting for order
-    if (callback != null) {
-      mountCallback();
+    // order isn't known yet, we can attempt to mount
+    if (this.order == -1) {
+      this.order = order;
+      // callback route already known, but waiting for order
+      if (callback != null) {
+        mountCallback();
+      }
     }
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -747,4 +747,20 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     }, 200, "OK", "Welcome to the protected resource!");
 
     server.close();
-  }}
+  }
+
+  @Test
+  public void testSharing() throws Exception {
+    OAuth2AuthHandler oauth2 = OAuth2AuthHandler.create(vertx, OAuth2Auth.create(vertx, new OAuth2Options()
+      .setClientId("client-id")
+      .setClientSecret("client-secret")
+      .setSite("http://localhost:10000")), "http://localhost:8080/secret/callback");
+
+    router.route("/protected/*").handler(oauth2.setupCallback(router.route("/callback")));
+    router.route("/protected/userinfo").handler(oauth2);
+
+    assertEquals("/callback", router.getRoutes().get(0).getPath());
+    assertEquals("/protected/", router.getRoutes().get(1).getPath());
+    assertEquals("/protected/userinfo", router.getRoutes().get(2).getPath());
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

When the oauth2 handler is shared it can trigger onmount events multiple times which would re-attempt to setup the callback handler. This PR ensures that it only mounts once.