### PR TITLE
Pass `RequestOptions.traceOperation` from `HttpRequest` to `HttpClientRequest`

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -378,6 +378,15 @@ public interface HttpRequest<T> {
   HttpRequest<T> multipartMixed(boolean allow);
 
   /**
+   * Trace operation name override.
+   *
+   * @param traceOperation Name of operation to use in traces
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> traceOperation(String traceOperation);
+
+  /**
    * Like {@link #send(Handler)} but with an HTTP request {@code body} stream.
    *
    * @param body the body

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -68,6 +68,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   boolean followRedirects;
   Boolean ssl;
   boolean multipartMixed = true;
+  String traceOperation = null;
   public List<ResponsePredicate> expectations;
 
   private HttpRequestImpl(WebClientBase client,
@@ -234,6 +235,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     this.mergeHeaders(requestOptions);
     requestOptions.setTimeout(this.timeout);
     requestOptions.setProxyOptions(this.proxyOptions);
+    requestOptions.setTraceOperation(this.traceOperation);
     return requestOptions;
   }
 
@@ -394,6 +396,12 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   @Override
   public HttpRequest<T> multipartMixed(boolean allow) {
     multipartMixed = allow;
+    return this;
+  }
+
+  @Override
+  public HttpRequest<T> traceOperation(String traceOperation) {
+    this.traceOperation = traceOperation;
     return this;
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -90,6 +90,7 @@ public class WebClientBase implements WebClientInternal {
     }
     HttpRequestImpl<Buffer> request = request(method, serverAddress, port, host, requestOptions.getURI());
     request.ssl(requestOptions.isSsl());
+    request.traceOperation(requestOptions.getTraceOperation());
     return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
   }
 


### PR DESCRIPTION
The option is already supported by `HttpClient`, `WebClient` just doesn’t pass it on.

Motivation:

This is a very useful option for tracing in telemetry. It's already supported by `HttpClient`, it's now just passed on properly by `WebClient`.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
