### PR TITLE
Backport: Pass `RequestOptions.traceOperation` from `HttpRequest` to `HttpClientRequest`

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -337,6 +337,15 @@ public interface HttpRequest<T> {
   HttpRequest<T> multipartMixed(boolean allow);
 
   /**
+   * Trace operation name override.
+   *
+   * @param traceOperation Name of operation to use in traces
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpRequest<T> traceOperation(String traceOperation);
+
+  /**
    * Like {@link #send(Handler)} but with an HTTP request {@code body} stream.
    *
    * @param body the body

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -458,6 +458,7 @@ public class HttpContext<T> {
     }
     options.setTimeout(request.timeout);
     options.setProxyOptions(request.proxyOptions);
+    options.setTraceOperation(request.traceOperation);
     createRequest(options);
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -61,6 +61,7 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   boolean followRedirects;
   Boolean ssl;
   boolean multipartMixed = true;
+  String traceOperation = null;
   public List<ResponsePredicate> expectations;
 
   HttpRequestImpl(WebClientInternal client, HttpMethod method, SocketAddress serverAddress, Boolean ssl, Integer port, String host, String uri, BodyCodec<T>
@@ -288,6 +289,12 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   @Override
   public HttpRequest<T> multipartMixed(boolean allow) {
     multipartMixed = allow;
+    return this;
+  }
+
+  @Override
+  public HttpRequest<T> traceOperation(String traceOperation) {
+    this.traceOperation = traceOperation;
     return this;
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -198,6 +198,7 @@ public class WebClientBase implements WebClientInternal {
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, RequestOptions requestOptions) {
       HttpRequestImpl<Buffer> request = new HttpRequestImpl<>(this, method, serverAddress, requestOptions.isSsl(), requestOptions.getPort(),
       requestOptions.getHost(), requestOptions.getURI(), BodyCodecImpl.BUFFER, options, requestOptions.getProxyOptions());
+      request.traceOperation(requestOptions.getTraceOperation());
       return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
   }
 


### PR DESCRIPTION
This is a back port of #2233 to 4.2 series

The option is already supported by `HttpClient`, `WebClient` just doesn’t pass it on.

Motivation:

This is a very useful option for tracing in telemetry. It's already supported by HttpClient, it's now just passed on properly by WebClient.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
