### PR TITLE
Various changes to web client HttpRequest

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -81,12 +81,23 @@ public interface HttpRequest<T> {
   HttpRequest<T> method(HttpMethod value);
 
   /**
+   * @return the request method
+   */
+  HttpMethod method();
+
+  /**
    * Configure the request to use a new port {@code value}.
+   * <p> This overrides the port set by absolute URI requests
    *
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   HttpRequest<T> port(int value);
+
+  /**
+   * @return the request port or {@code 0}  when none is set for absolute URI templates
+   */
+  int port();
 
   /**
    * Configure the request to decode the response with the {@code responseCodec}.
@@ -97,12 +108,23 @@ public interface HttpRequest<T> {
   <U> HttpRequest<U> as(BodyCodec<U> responseCodec);
 
   /**
+   * @return the request body codec
+   */
+  BodyCodec<T> bodyCodec();
+
+  /**
    * Configure the request to use a new host {@code value}.
+   * <p> This overrides the host set by absolute URI requests
    *
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   HttpRequest<T> host(String value);
+
+  /**
+   * @return the request host or {@code null} when none is set for absolute URI templates
+   */
+  String host();
 
   /**
    * Configure the request to use a virtual host {@code value}.
@@ -122,15 +144,25 @@ public interface HttpRequest<T> {
   HttpRequest<T> virtualHost(String value);
 
   /**
+   * @return the request virtual host if any or {@code null}
+   */
+  String virtualHost();
+
+  /**
    * Configure the request to use a new request URI {@code value}.
-   * <p>
-   * When the uri has query parameters, they are set in the {@link #queryParams()} multimap, overwritting
-   * any parameters previously set.
+   * <p> This overrides the port set by absolute URI requests
+   * <p> When the uri has query parameters, they are set in the {@link #queryParams()}, overwriting
+   * any parameters previously set
    *
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   HttpRequest<T> uri(String value);
+
+  /**
+   * @return the request uri or {@code null} when none is set for absolute URI templates
+   */
+  String uri();
 
   /**
    * Configure the request to add multiple HTTP headers .
@@ -232,8 +264,19 @@ public interface HttpRequest<T> {
     return authentication(new TokenCredentials(bearerToken).applyHttpChallenge(null));
   }
 
+  /**
+   * Configure the request whether to use SSL.
+   * <p> This overrides the SSL value set by absolute URI requests
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
   @Fluent
   HttpRequest<T> ssl(Boolean value);
+
+  /**
+   * @return whether the request uses SSL or {@code null} when none is set for absolute URI templates
+   */
+  Boolean ssl();
 
   /**
    * Configures the amount of time in milliseconds after which if the request does not return any data within the timeout
@@ -298,7 +341,7 @@ public interface HttpRequest<T> {
   HttpRequest<T> setTemplateParam(String paramName, Map<String, String> paramValue);
 
   /**
-   * Set wether or not to follow the directs for the request.
+   * Set whether to follow request redirections
    *
    * @param value true if redirections should be followed
    * @return a reference to this, so the API can be used fluently
@@ -306,6 +349,10 @@ public interface HttpRequest<T> {
   @Fluent
   HttpRequest<T> followRedirects(boolean value);
 
+  /**
+   * @return whether to follow request redirections
+   */
+  boolean followRedirects();
 
   /**
    * Configure the request to set a proxy for this request.
@@ -317,6 +364,11 @@ public interface HttpRequest<T> {
    */
   @Fluent
   HttpRequest<T> proxy(ProxyOptions proxyOptions);
+
+  /**
+   * @return the proxy for this request
+   */
+  ProxyOptions proxy();
 
   /**
    * Add an expectation that the response is valid according to the provided {@code predicate}.
@@ -341,6 +393,11 @@ public interface HttpRequest<T> {
    */
   @Fluent
   HttpRequest<T> expect(ResponsePredicate predicate);
+
+  /**
+   * @return a read-only list of the response predicate expectations
+   */
+  List<ResponsePredicate> expectations();
 
   /**
    * Return the current query parameters.
@@ -378,6 +435,11 @@ public interface HttpRequest<T> {
   HttpRequest<T> multipartMixed(boolean allow);
 
   /**
+   * @return whether multipart mixed encoding is allowed
+   */
+  boolean multipartMixed();
+
+  /**
    * Trace operation name override.
    *
    * @param traceOperation Name of operation to use in traces
@@ -385,6 +447,11 @@ public interface HttpRequest<T> {
    */
   @Fluent
   HttpRequest<T> traceOperation(String traceOperation);
+
+  /**
+   * @return the trace operation name override
+   */
+  String traceOperation();
 
   /**
    * Like {@link #send(Handler)} but with an HTTP request {@code body} stream.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -245,7 +245,7 @@ public class HttpContext<T> {
    */
   public void receiveResponse(HttpClientResponse clientResponse) {
     int sc = clientResponse.statusCode();
-    int maxRedirects = request.followRedirects ? client.options().getMaxRedirects() : 0;
+    int maxRedirects = request.followRedirects() ? client.options().getMaxRedirects() : 0;
     this.clientResponse = clientResponse;
     if (redirects < maxRedirects && sc >= 300 && sc < 400) {
       redirects++;
@@ -418,7 +418,7 @@ public class HttpContext<T> {
         MultipartFormUpload multipartForm;
         try {
           boolean multipart = "multipart/form-data".equals(contentType);
-          HttpPostRequestEncoder.EncoderMode encoderMode = this.request.multipartMixed ? HttpPostRequestEncoder.EncoderMode.RFC1738 : HttpPostRequestEncoder.EncoderMode.HTML5;
+          HttpPostRequestEncoder.EncoderMode encoderMode = this.request.multipartMixed() ? HttpPostRequestEncoder.EncoderMode.RFC1738 : HttpPostRequestEncoder.EncoderMode.HTML5;
           multipartForm = new MultipartFormUpload(context,  (MultipartForm) this.body, multipart, encoderMode);
           this.body = multipartForm;
         } catch (Exception e) {
@@ -509,7 +509,7 @@ public class HttpContext<T> {
       }
     });
     Pipe<Buffer> pipe = resp.pipe();
-    request.codec.create(ar1 -> {
+    request.bodyCodec().create(ar1 -> {
       if (ar1.succeeded()) {
         BodyStream<T> stream = ar1.result();
         pipe.to(stream, ar2 -> {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/SessionAwareInterceptor.java
@@ -54,7 +54,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     }
     headers.addAll(parentClient.headers());
 
-    String domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
+    String domain = context.request().virtualHost();
     if (domain == null) {
       domain = requestOptions.getHost();
     }
@@ -81,8 +81,8 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     RequestOptions originalRequest = context.requestOptions();
     CookieStore cookieStore = parentClient.cookieStore();
     String domain = URI.create(context.clientResponse().request().absoluteURI()).getHost();
-    if (domain.equals(originalRequest.getHost()) && ((HttpRequestImpl<?>)context.request()).virtualHost != null) {
-      domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
+    if (domain.equals(originalRequest.getHost()) && context.request().virtualHost() != null) {
+      domain = context.request().virtualHost();
     }
     final String finalDomain = domain;
     cookieHeaders.forEach(header -> {
@@ -105,8 +105,8 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
     RequestOptions originalRequest = context.requestOptions();
     String redirectHost = redirectRequest.getHost();
     String domain;
-    if (redirectHost.equals(originalRequest.getHost()) && ((HttpRequestImpl<?>)context.request()).virtualHost != null) {
-      domain = ((HttpRequestImpl<?>)context.request()).virtualHost;
+    if (redirectHost.equals(originalRequest.getHost()) && context.request().virtualHost() != null) {
+      domain = context.request().virtualHost();
     } else {
       domain = redirectHost;
     }
@@ -160,7 +160,7 @@ public class SessionAwareInterceptor implements Handler<HttpContext<?>> {
         if (cookie.domain() == null) {
           // Set the domain if missing, because we need to send cookies
           // only to the domains we received them from.
-          cookie.setDomain(((HttpRequestImpl<?>)context.request()).virtualHost != null ? ((HttpRequestImpl<?>)context.request()).virtualHost : request.getHost());
+          cookie.setDomain(context.request().virtualHost() != null ? context.request().virtualHost() : request.getHost());
         }
         cookieStore.put(cookie);
       }


### PR DESCRIPTION
- provide convenient getters on the HttpRequest interface allowing to retrieve relevant information
- the HttpRequest implementation now overrides ssl/host/port/uri when an absolute URI template is used, just like with an absolute URI string

fixes #2237