### PR TITLE
fix #2240 HTTP 400 error with vertx-web-openapi backend and Swagger UI

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3Utils.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3Utils.java
@@ -64,6 +64,8 @@ class OpenAPI3Utils {
     return Arrays.stream(listContentTypes.split(","))
       .map(String::trim)
       .map(pattern -> {
+        if (pattern.equals("*/*"))
+          return ".*/.*";
         int wildcardIndex = pattern.indexOf("/*");
         if (wildcardIndex != -1) {
           return Pattern.quote(pattern.substring(0, wildcardIndex + 1)) + ".*";

--- a/vertx-web-openapi/src/test/resources/specs/multipart.yaml
+++ b/vertx-web-openapi/src/test/resources/specs/multipart.yaml
@@ -57,6 +57,32 @@ paths:
       responses:
         200:
           description: successful operation
+  /testMultipartMatchAllWildcard:
+    post:
+      operationId: testMultipartMatchAllWildcard
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - type
+                - file1
+              properties:
+                file1:
+                  type: string
+                  description: File1
+                  format: binary
+                type:
+                  type: string
+                  description: Model type
+            encoding:
+              file1:
+                contentType: '*/*'
+        required: true
+      responses:
+        200:
+          description: successful operation
   /testMultipartMultipleWildcard:
     post:
       operationId: testMultipartMultipleWildcard


### PR DESCRIPTION
Motivation:

According to a discussion in the OpenAPI specification github repo (discussion including Mike Ralphson, a major OpenAPI contributor), it seems that:

1. `*/*` is an acceptable value
2. application/octet-stream is not equivalent to `*/*`:

https://github.com/OAI/OpenAPI-Specification/issues/1692#issuecomment-423610318

But it is true that, when omitted in the spec, the `application/octet-stream` mime type is implied (and this precisely what Vert.x is doing):

https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#special-considerations-for-multipart-content

Supporting the `*/*` content type will allow writing upload forms that will accept any type of file sent by Swagger UI.
