### PR TITLE
Bump com.graphql-java:graphql-java from 18.2 to 19.0

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -32,8 +32,8 @@
     <!--
     Update these properties in the vertx-lang-* modules too
      -->
-    <graphql.java.major.version>18</graphql.java.major.version>
-    <graphql.java.version>${graphql.java.major.version}.2</graphql.java.version>
+    <graphql.java.major.version>19</graphql.java.major.version>
+    <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 

--- a/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
+++ b/vertx-web-graphql/src/test/java/io/vertx/ext/web/handler/graphql/LocaleTest.java
@@ -100,17 +100,19 @@ public class LocaleTest extends WebTestBase {
   }
 
   @Test
-  public void testWrongLocale() throws Exception {
+  public void testEmptyLocaleDefaulsToSystemLocale() throws Exception {
     GraphQLRequest request = new GraphQLRequest()
       .setMethod(GET)
       .setLocale("")
       .setGraphQLQuery("query { locale }");
     request.send(client, onSuccess(body -> {
-      if (body.getJsonObject("data").getString("locale") != null) {
-        fail(body.toString());
-      } else {
-        testComplete();
-      }
+
+      Locale expectedLocale = Locale.getDefault();
+      String actualLocale = body.getJsonObject("data").getString("locale");
+      assertEquals(expectedLocale.toLanguageTag(),actualLocale);
+
+      testComplete();
+
     }));
     await();
   }


### PR DESCRIPTION
> This is release 19.0 of GraphQL Java. This release doesn't contain any breaking changes.
> 
> It contains one security related bugfix hardening GraphQL Java more against malicious requests: https://github.com/graphql-java/graphql-java/pull/2892
> 
> GraphQL Java now shades Antlr runtime to prevent any further dependency conflicts. Antrl is used internally for parsing and validating of GraphQL requests and SDL. https://github.com/graphql-java/graphql-java/pull/2854
> 
> It includes some performance improvements (https://github.com/graphql-java/graphql-java/pull/2786, https://github.com/graphql-java/graphql-java/pull/2769, https://github.com/graphql-java/graphql-java/pull/2839) and several bugfixes and general improvements.
> 
> Bugfixes
> https://github.com/graphql-java/graphql-java/pull/2892 Security bugfix to prevent DOS attacks
> 
> https://github.com/graphql-java/graphql-java/pull/2818 Fix silent thread leak for chained instrumentation
> 
> https://github.com/graphql-java/graphql-java/pull/2825 Fixup Introspection input field deprecation filterting
> 
> https://github.com/graphql-java/graphql-java/pull/2842 fix runtime exception for deep async queries
> 
> https://github.com/graphql-java/graphql-java/pull/2856 SchemaPrinter description bugfix
> 
> Improvements
> https://github.com/graphql-java/graphql-java/pull/2786 performance improvements for validation
> 
> https://github.com/graphql-java/graphql-java/pull/2769 State is passed explicitly to instrumentation and parameters are NOT mutated
> 
> https://github.com/graphql-java/graphql-java/pull/2854 Shade Antlr Runtime
> 
> https://github.com/graphql-java/graphql-java/pull/2896 Update DataLoader to 3.2.0
> 
> https://github.com/graphql-java/graphql-java/pull/2878 i18n for validation error messages
> 
> https://github.com/graphql-java/graphql-java/pull/2881 Improve SchemaPrinter
> 
> https://github.com/graphql-java/graphql-java/pull/2872 Improve AST compact printing
> 
> https://github.com/graphql-java/graphql-java/pull/2846 Subscription root field valiation
> 
> All changes
> all PRs: https://github.com/graphql-java/graphql-java/milestone/38?closed=1