### PR TITLE
Bump com.graphql-java:graphql-java from 18.2 to 18.3

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -33,7 +33,7 @@
     Update these properties in the vertx-lang-* modules too
      -->
     <graphql.java.major.version>18</graphql.java.major.version>
-    <graphql.java.version>${graphql.java.major.version}.2</graphql.java.version>
+    <graphql.java.version>${graphql.java.major.version}.3</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
> This is a security bugfix release containing only one PR: https://github.com/graphql-java/graphql-java/pull/2897
> 
> GraphQL Java has a max token limit per request preventing DOS attacks. But in some circumstances it was not enough to prevent malicious requests. This release fixes this problem.
> 
> All details can be found here: https://github.com/graphql-java/graphql-java/pull/2892
> 

Eventually we should merge #2244 but it seems that we need to do some work  as there are broken tests 

See https://github.com/graphql-java/graphql-java/releases/tag/v18.3