### PR TITLE
Bump com.graphql-java:graphql-java from 19.0 to 19.1

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -33,7 +33,7 @@
     Update these properties in the vertx-lang-* modules too
      -->
     <graphql.java.major.version>19</graphql.java.major.version>
-    <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>
+    <graphql.java.version>${graphql.java.major.version}.1</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
Dependabot does not support this syntax. See : https://github.com/dependabot/dependabot-core/issues/5438

Release notes : https://github.com/graphql-java/graphql-java/releases/tag/v19.1

> This bug fix release was made to address a specific NullPointerException problem if consumers are explicitly setting the ExecutionInput to null
> 
> See https://github.com/graphql-java/graphql-java/pull/2908 for the code details.
> 
> The other fixes are included because they are... well... fixes and where ready at the time.
> 
> What's Changed
> Defaults Locale when calling validation by @bbakerman in https://github.com/graphql-java/graphql-java/pull/2908
> Handles isDeprecated not being present in the json by @bbakerman in https://github.com/graphql-java/graphql-java/pull/2910
> Fix typo in description of skip directive by @acanda in https://github.com/graphql-java/graphql-java/pull/2915
> Xuorig Fix PR - Edge case with GraphQLTypeReference and Schema Transforms by @bbakerman in https://github.com/graphql-java/graphql-java/pull/2906
> Reduce calculation for fragments in ExecutableNormalizedOperation by @dondonz in https://github.com/graphql-java/graphql-java/pull/2911
> New Contributors
> @acanda made their first contribution in https://github.com/graphql-java/graphql-java/pull/2915
> Full Changelog: https://github.com/graphql-java/graphql-java/compare/v19.0...v19.1