### PR TITLE
Upgrade snakeyaml from 1.30 to 1.31 fixing CVE-2022-25857

### DIFF
--- a/vertx-web-openapi/pom.xml
+++ b/vertx-web-openapi/pom.xml
@@ -32,6 +32,7 @@
     <junit5.version>5.7.0</junit5.version>
     <mockito.version>3.3.0</mockito.version>
     <assertj.version>3.15.0</assertj.version>
+    <snakeyaml.version>1.31</snakeyaml.version>
   </properties>
 
   <dependencies>
@@ -58,7 +59,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.30</version>
+      <version>${snakeyaml.version}</version>
     </dependency>
     <!-- For docs -->
     <dependency>


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Upgrading org.yaml:snakeyaml from 1.30 to 1.31 in vertx-config-yaml
fixes a Denial of Service (DoS) vulnerability caused by a missing
nested depth limitation for collections.

https://nvd.nist.gov/vuln/detail/CVE-2022-25857