### PR TITLE
build(deps): bump com.graphql-java:graphql-java from 19.1 to 19.2

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -33,7 +33,7 @@
     Update these properties in the vertx-lang-* modules too
      -->
     <graphql.java.major.version>19</graphql.java.major.version>
-    <graphql.java.version>${graphql.java.major.version}.1</graphql.java.version>
+    <graphql.java.version>${graphql.java.major.version}.2</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
Dependabot does not support this syntax. See : https://github.com/dependabot/dependabot-core/issues/5438

Release notes : https://github.com/graphql-java/graphql-java/releases/tag/v19.2

