### PR TITLE
fix: WebClient ignoring RequestOptions.setTimeout/setFollowRedirects/setProxyOptions (#2265)

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -291,6 +291,11 @@ public interface HttpRequest<T> {
   HttpRequest<T> timeout(long value);
 
   /**
+   * @return the current timeout in milliseconds
+   */
+  long timeout();
+
+  /**
    * Add a query parameter to the request.
    *
    * @param paramName  the param name

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -260,6 +260,11 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   @Override
+  public long timeout() {
+      return timeout;
+  }
+
+  @Override
   public HttpRequest<T> addQueryParam(String paramName, String paramValue) {
     queryParams().add(paramName, paramValue);
     return this;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -94,6 +94,12 @@ public class WebClientBase implements WebClientInternal {
     }
     HttpRequestImpl<Buffer> request = request(method, serverAddress, port, host, requestOptions.getURI());
     request.ssl(requestOptions.isSsl());
+    request.timeout(requestOptions.getTimeout());
+    request.followRedirects(requestOptions.getFollowRedirects());
+    ProxyOptions proxyOptions = requestOptions.getProxyOptions();
+    if (proxyOptions != null) {
+      request.proxy(new ProxyOptions(proxyOptions));
+    }
     request.traceOperation(requestOptions.getTraceOperation());
     return requestOptions.getHeaders() == null ? request : request.putHeaders(requestOptions.getHeaders());
   }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -1589,6 +1589,23 @@ public class WebClientTest extends WebClientTestBase {
   }
 
   @Test
+  public void testRequestOptions() throws Exception {
+    ProxyOptions proxyOptions = new ProxyOptions().setHost("proxy-host");
+    RequestOptions options = new RequestOptions().setHost("another-host").setPort(8080).setSsl(true)
+      .setURI("/test").setTimeout(500).setProxyOptions(proxyOptions).setFollowRedirects(true);
+    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, options);
+
+    assertThat(request.host(), equalTo("another-host"));
+    assertThat(request.port(), equalTo(8080));
+    assertThat(request.ssl(), equalTo(true));
+    assertThat(request.uri(), equalTo("/test"));
+    assertThat(request.timeout(), equalTo(500l));
+    assertThat(request.followRedirects(), equalTo(true));
+    assertThat(request.proxy(), is(not(equalTo(proxyOptions))));
+    assertThat(request.proxy().getHost(), equalTo("proxy-host"));
+  }
+
+  @Test
   public void testTLSEnabled() throws Exception {
     testTLS(true, true, client -> client.get("/"));
   }


### PR DESCRIPTION
See #2265