### PR TITLE
Bump snakeYAML to fix CVE-2022-38752

### DIFF
--- a/vertx-web-openapi/pom.xml
+++ b/vertx-web-openapi/pom.xml
@@ -32,7 +32,7 @@
     <junit5.version>5.7.0</junit5.version>
     <mockito.version>3.3.0</mockito.version>
     <assertj.version>3.15.0</assertj.version>
-    <snakeyaml.version>1.31</snakeyaml.version>
+    <snakeyaml.version>1.32</snakeyaml.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Current snakeYAML 1.31 is still affected by CVE-2022-38752 which was fixed in 1.32.