### PR TITLE
Support AuthorizationHandlers on OpenAPI Operations

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/Operation.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/Operation.java
@@ -7,12 +7,21 @@ import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.AuthorizationHandler;
 
 /**
  * Interface representing an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject">Operation</a>
  */
 @VertxGen
 public interface Operation {
+
+  /**
+   * Mount an {@link io.vertx.ext.web.handler.AuthorizationHandler} for this operation
+   *
+   * @param handler
+   * @return
+   */
+  @Fluent Operation authorizationHandler(AuthorizationHandler handler);
 
   /**
    * Mount an handler for this operation

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPI3RouterBuilderImpl.java
@@ -290,6 +290,9 @@ public class OpenAPI3RouterBuilderImpl implements RouterBuilder {
         handlersToLoad.add(authnHandler);
       }
 
+      // Authorization Handlers
+      handlersToLoad.addAll(operation.getAuthorizationHandlers());
+
       // Generate ValidationHandler
       ValidationHandlerImpl validationHandler = validationHandlerGenerator.create(operation);
       handlersToLoad.add(validationHandler);

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OperationImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OperationImpl.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.AuthorizationHandler;
 import io.vertx.ext.web.openapi.OpenAPIHolder;
 import io.vertx.ext.web.openapi.Operation;
 
@@ -28,6 +29,7 @@ public class OperationImpl implements Operation {
 
   private Map<JsonPointer, JsonObject> parameters;
   private List<String> tags;
+  private List<AuthorizationHandler> authzHandlers;
   private List<Handler<RoutingContext>> userHandlers;
   private List<Handler<RoutingContext>> userFailureHandlers;
 
@@ -69,8 +71,15 @@ public class OperationImpl implements Operation {
         .noneMatch(j -> j.getString("in").equalsIgnoreCase(paramIn) && j.getString("name").equals(paramName)))
         this.parameters.put(pathPointer.copy().append(i), parameterModel);
     }
+    this.authzHandlers = new ArrayList<>();
     this.userHandlers = new ArrayList<>();
     this.userFailureHandlers = new ArrayList<>();
+  }
+
+  @Override
+  public Operation authorizationHandler(AuthorizationHandler handler) {
+    this.authzHandlers.add(handler);
+    return this;
   }
 
   @Override
@@ -127,6 +136,10 @@ public class OperationImpl implements Operation {
 
   protected JsonObject getPathModel() {
     return pathModel;
+  }
+
+  protected List<AuthorizationHandler> getAuthorizationHandlers() {
+    return authzHandlers;
   }
 
   protected List<Handler<RoutingContext>> getUserHandlers() {

--- a/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterBuilderAuthZTest.java
+++ b/vertx-web-openapi/src/test/java/io/vertx/ext/web/openapi/RouterBuilderAuthZTest.java
@@ -1,0 +1,122 @@
+package io.vertx.ext.web.openapi;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.Authorization;
+import io.vertx.ext.auth.authorization.AuthorizationContext;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.AuthenticationHandler;
+import io.vertx.ext.web.handler.AuthorizationHandler;
+import io.vertx.ext.web.handler.SimpleAuthenticationHandler;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static io.vertx.ext.web.validation.testutils.TestRequest.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ExtendWith(VertxExtension.class)
+@Timeout(1000)
+public class RouterBuilderAuthZTest extends BaseRouterBuilderTest {
+
+    private static final String SECURITY_TESTS = "src/test/resources/specs/security_test.yaml";
+
+    private static final RouterBuilderOptions FACTORY_OPTIONS = new RouterBuilderOptions()
+            .setRequireSecurityHandlers(true)
+            .setMountNotImplementedHandler(false);
+
+    @Test
+    public void routerBuilderFailsWithAuthZ(Vertx vertx, VertxTestContext testContext) {
+        Checkpoint checkpoint = testContext.checkpoint();
+        loadBuilderAndStartServer(vertx, SECURITY_TESTS, testContext, routerBuilder -> {
+            routerBuilder
+                    .setOptions(FACTORY_OPTIONS)
+                    .securityHandler("api_key")
+                    .bindBlocking(config -> mockSuccessfulAuthHandler(routingContext -> routingContext.put("api_key", "1")))
+                    .operation("listPetsSingleSecurity")
+                    .handler(mockAuthorizationHandler(true));
+
+            testContext.verify(() -> {
+                assertThatCode(routerBuilder::createRouter)
+                        .isInstanceOfSatisfying(IllegalStateException.class, ise ->
+                                assertThat(ise.getMessage())
+                                        .contains("AUTHORIZATION"));
+                checkpoint.flag();
+            });
+        });
+    }
+
+    @Test
+    public void mountAuthZSuccess(Vertx vertx, VertxTestContext testContext) {
+        Checkpoint checkpoint = testContext.checkpoint();
+        loadBuilderAndStartServer(vertx, SECURITY_TESTS, testContext, routerBuilder ->
+            routerBuilder
+                    .setOptions(FACTORY_OPTIONS)
+                    .securityHandler("api_key")
+                    .bindBlocking(config -> mockSuccessfulAuthHandler(routingContext -> routingContext.put("api_key", "1")))
+                    .operation("listPetsSingleSecurity")
+                    .authorizationHandler(mockAuthorizationHandler(true))
+                    .handler(routingContext ->
+                        routingContext
+                                .response()
+                                .setStatusCode(200)
+                                .setStatusMessage(routingContext.get("api_key"))
+                                .end()))
+        .onComplete(h ->
+                testRequest(client, HttpMethod.GET, "/pets_single_security")
+                        .expect(statusCode(200), statusMessage("1"))
+                        .send(testContext, checkpoint));
+    }
+
+    @Test
+    public void mountAuthZFailure(Vertx vertx, VertxTestContext testContext) {
+        Checkpoint checkpoint = testContext.checkpoint();
+        loadBuilderAndStartServer(vertx, SECURITY_TESTS, testContext, routerBuilder ->
+                routerBuilder
+                        .setOptions(FACTORY_OPTIONS)
+                        .securityHandler("api_key")
+                        .bindBlocking(config -> mockSuccessfulAuthHandler(routingContext -> routingContext.put("api_key", "1")))
+                        .operation("listPetsSingleSecurity")
+                        .authorizationHandler(mockAuthorizationHandler(false))
+                        .handler(routingContext ->
+                                routingContext
+                                        .response()
+                                        .setStatusCode(200)
+                                        .setStatusMessage(routingContext.get("api_key"))
+                                        .end()))
+                .onComplete(h ->
+                        testRequest(client, HttpMethod.GET, "/pets_single_security")
+                                .expect(statusCode(403), statusMessage("Forbidden"))
+                                .send(testContext, checkpoint));
+    }
+
+    private AuthorizationHandler mockAuthorizationHandler(boolean authorized) {
+        return AuthorizationHandler.create(new Authorization() {
+            @Override
+            public boolean match(AuthorizationContext authorizationContext) {
+                return authorized;
+            }
+
+            @Override
+            public boolean verify(Authorization authorization) {
+                return authorized;
+            }
+        });
+    }
+
+    private AuthenticationHandler mockSuccessfulAuthHandler(Handler<RoutingContext> mockHandler) {
+        return SimpleAuthenticationHandler.create()
+                .authenticate(ctx -> {
+                    mockHandler.handle(ctx);
+                    return Future.succeededFuture(User.create(new JsonObject()));
+                });
+    }
+}


### PR DESCRIPTION
When attempting to register an AuthorizationHandler on an Operation within the OpenAPI3RouterBuilder the resultant router will fail to build because the AuthZ handler is registered after the generated validation handler.

Adding the ability to register AuthorizationHandlers on an Operation. All handlers added using the new authorizationHandler method will be registered after the security handlers but before the validation and user handlers.

Motivation:

https://github.com/vert-x3/vertx-web/issues/2191

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
