### PR TITLE
H2 requests are chunked due to framing

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -87,8 +87,11 @@ public class BodyHandlerImpl implements BodyHandler {
       // or `content-length` headers set.
       // http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
       final long parsedContentLength = parseContentLengthHeader(request);
+      // http2 never transmits a `transfer-encoding` as frames are chunks.
+      final boolean hasTransferEncoding =
+        request.version() == HttpVersion.HTTP_2 || request.headers().contains(HttpHeaders.TRANSFER_ENCODING);
 
-      if (!request.headers().contains(HttpHeaders.TRANSFER_ENCODING) && parsedContentLength == -1) {
+      if (!hasTransferEncoding && parsedContentLength == -1) {
         // there is no "body", so we can skip this handler
         context.next();
         return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -30,6 +30,7 @@ import io.vertx.ext.auth.VertxContextPRNG;
 import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.authentication.TokenCredentials;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
 import io.vertx.ext.auth.oauth2.Oauth2Credentials;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
@@ -434,6 +435,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
       }
 
       final Oauth2Credentials credentials = new Oauth2Credentials()
+        .setFlow(OAuth2FlowType.AUTH_CODE)
         .setCode(code);
 
       // the state that was passed to the IdP server. The state can be


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes #2282

H2 requests are framed and should not include the `Tranfer-Encoding` header (reserved for HTTP1.1) for this reasons we can always assume that requests are chunked.

Also passes for empty body:

```java
  @Test
  void shouldUploadHttp2NoContent(final VertxTestContext context) {
    final var router = Router.router(vertx);

    router.route().handler(BodyHandler.create());
    router.route().handler(routingContext -> {
      context.verify(
        () -> Assertions.assertEquals("application/json", routingContext.parsedHeaders().contentType().value())
      );
      routingContext.response().end();
    });

    final var server = vertx.createHttpServer(new HttpServerOptions().setLogActivity(true).setActivityLogDataFormat(ByteBufFormat.HEX_DUMP))
      .requestHandler(router)
      .listen(8080)
      .mapEmpty();

    final var client = vertx.createHttpClient(new HttpClientOptions()
        .setProtocolVersion(HttpVersion.HTTP_2)
        .setHttp2ClearTextUpgrade(false)
      )
      .request(new RequestOptions().setURI("/file").setPort(8080)
        .setHeaders(HttpHeaders.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json"))
      )
      .compose(
        HttpClientRequest::send
      )
      .onSuccess(response -> context.verify(() -> Assertions.assertEquals(200, response.statusCode())))
      .mapEmpty();

    CompositeFuture.all(server, client)
      .onComplete(context.succeedingThenComplete());
  }
```