### PR TITLE
Type Pollution Agent: save casting to HttpServerRequestInternal in the hot path

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -27,7 +27,7 @@ import java.util.Set;
  */
 class HttpServerRequestWrapper implements HttpServerRequestInternal {
 
-  private final HttpServerRequestInternal delegate;
+  private final HttpServerRequest delegate;
   private final ForwardedParser forwardedParser;
 
   private boolean modified;
@@ -40,7 +40,7 @@ class HttpServerRequestWrapper implements HttpServerRequestInternal {
   private MultiMap params;
 
   HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward) {
-    delegate = (HttpServerRequestInternal) request;
+    delegate = request;
     forwardedParser = new ForwardedParser(delegate, allowForward);
   }
 
@@ -431,12 +431,12 @@ class HttpServerRequestWrapper implements HttpServerRequestInternal {
 
   @Override
   public Context context() {
-    return delegate.context();
+    return ((HttpServerRequestInternal) delegate).context();
   }
 
   @Override
   public Object metric() {
-    return delegate.metric();
+    return ((HttpServerRequestInternal) delegate).metric();
   }
 
   @Override


### PR DESCRIPTION
Motivation:

[Type Pollution Agent](https://github.com/RedHatPerf/type-pollution-agent) reports:
```
6:	io.quarkus.vertx.http.runtime.ResumingRequestWrapper
Count:	224054639
Types:
	io.vertx.core.http.impl.HttpServerRequestInternal
	io.vertx.core.http.HttpServerRequest
Traces:
	io.vertx.ext.web.impl.HttpServerRequestWrapper.<init>(HttpServerRequestWrapper.java:43)
		class: io.vertx.core.http.impl.HttpServerRequestInternal
		count: 112072385
	io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:37)
		class: io.vertx.core.http.HttpServerRequest
		count: 111982254
```
causing a potential scalability issue due to https://bugs.openjdk.org/browse/JDK-8180450.
The potential treat doesn't 100% translate to a real one due to JIT optimizations, but worth fixing it, if reported, if it won't
cause an evident code quality degradation.

@vietj The context method is still an hot path? If yes I should think to a different way to address it