### PR TITLE
Attempt to allow multiple regex'es in cors

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
@@ -34,12 +34,15 @@ import java.util.Set;
 public interface CorsHandler extends SecurityPolicyHandler {
 
   /**
+   * @deprecated patterns should use the relative origin method.
+   *
    * Create a CORS handler using a regular expression to match origins. An origin follows rfc6454#section-7
    * and is expected to have the format: {@code <scheme> "://" <hostname> [ ":" <port> ]}
    *
    * @param allowedOriginPattern  the allowed origin pattern
    * @return  the handler
    */
+  @Deprecated
   static CorsHandler create(String allowedOriginPattern) {
     return new CorsHandlerImpl(allowedOriginPattern);
   }
@@ -60,6 +63,24 @@ public interface CorsHandler extends SecurityPolicyHandler {
    */
   @Fluent
   CorsHandler addOrigin(String origin);
+
+  /**
+   * Set the list of allowed relative origins.
+   * A relative origin is a regex that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
+   * @param origins the well formatted relative origin list
+   * @return self
+   */
+  @Fluent
+  CorsHandler addRelativeOrigins(List<String> origins);
+
+  /**
+   * Add a relative origin to the list of allowed Origins.
+   * A relative origin is a regex that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
+   * @param origin the well formatted static origin
+   * @return self
+   */
+  @Fluent
+  CorsHandler addRelativeOrigin(String origin);
 
   /**
    * Set the list of allowed origins. An origin follows rfc6454#section-7

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
@@ -44,7 +44,12 @@ public interface CorsHandler extends SecurityPolicyHandler {
    */
   @Deprecated
   static CorsHandler create(String allowedOriginPattern) {
-    return new CorsHandlerImpl(allowedOriginPattern);
+    // restore old behavior
+    if ("*".equals(allowedOriginPattern)) {
+      allowedOriginPattern = ".*";
+    }
+    return create()
+      .addRelativeOrigin(allowedOriginPattern);
   }
 
   /**

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -243,7 +243,7 @@ public class CorsHandlerImpl implements CorsHandler {
 
       } else {
         // when it is possible to determine if only one origin is allowed, we can skip this extra caching header
-        if (!uniqueOrigin()) {
+        if (!starOrigin() && !uniqueOrigin()) {
           Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
         }
         addCredentialsAndOriginHeader(response, origin);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -71,7 +71,7 @@ public class CorsHandlerImpl implements CorsHandler {
     return relativeOrigins == null && staticOrigins == null;
   }
 
-  private boolean staticOrigin() {
+  private boolean uniqueOrigin() {
     return relativeOrigins == null && staticOrigins != null && staticOrigins.size() == 1;
   }
 
@@ -212,7 +212,7 @@ public class CorsHandlerImpl implements CorsHandler {
       // https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
       // If CORS protocol requirements are more complicated than setting `Access-Control-Allow-Origin` to *
       // or a static origin, `Vary` is to be used.
-      if (!starOrigin() && !staticOrigin()) {
+      if (!starOrigin() && !uniqueOrigin()) {
         Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
       }
       // Not a CORS request - we don't set any headers and just call the next handler

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -53,15 +53,6 @@ public class CorsHandlerImpl implements CorsHandler {
   private final Set<String> allowedHeaders = new LinkedHashSet<>();
   private final Set<String> exposedHeaders = new LinkedHashSet<>();
 
-  @Deprecated
-  public CorsHandlerImpl(String allowedOriginPattern) {
-    Objects.requireNonNull(allowedOriginPattern);
-    if (!"*".equals(allowedOriginPattern)) {
-      addRelativeOrigin(allowedOriginPattern);
-    }
-    staticOrigins = null;
-  }
-
   public CorsHandlerImpl() {
     relativeOrigins = null;
     staticOrigins = null;
@@ -110,15 +101,15 @@ public class CorsHandlerImpl implements CorsHandler {
     Objects.requireNonNull(origin, "'origin' cannot be null");
 
     if (relativeOrigins == null) {
-      if (origin.equals("*")) {
+      if (origin.equals(".*")) {
         // we signal any as null
         return this;
       }
       relativeOrigins = new LinkedHashSet<>();
     } else {
-      if (origin.equals("*")) {
+      if (origin.equals(".*")) {
         // we signal any as null
-        throw new IllegalStateException("Cannot mix '*' with relative origins");
+        throw new IllegalStateException("Cannot mix '/.*/' with relative origins");
       }
     }
     relativeOrigins.add(Pattern.compile(origin));

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -56,7 +56,7 @@ public class CORSHandlerTest extends WebTestBase {
 
   @Test
   public void testAcceptAllAllowedOrigin() throws Exception {
-    router.route().handler(CorsHandler.create("*"));
+    router.route().handler(CorsHandler.create());
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> checkHeaders(resp, "*", null, null, null), 200, "OK", null);
   }
@@ -222,14 +222,14 @@ public class CORSHandlerTest extends WebTestBase {
   @Test
   public void testRealRequestCredentialsWildcard() throws Exception {
     Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
-    router.route().handler(CorsHandler.create("*").allowedMethods(allowedMethods).allowCredentials(true));
+    router.route().handler(CorsHandler.create().allowedMethods(allowedMethods).allowCredentials(true));
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> checkHeaders(resp, "http://vertx.io", null, null, null, "true", null), 200, "OK", null);
   }
 
   @Test
   public void testChaining() throws Exception {
-    CorsHandler cors = CorsHandler.create("*");
+    CorsHandler cors = CorsHandler.create();
     assertNotNull(cors);
     assertSame(cors, cors.allowedMethod(HttpMethod.POST));
     assertSame(cors, cors.allowedMethod(HttpMethod.DELETE));

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -689,4 +689,29 @@ public class CORSHandlerTest extends WebTestBase {
       assertNull(resp.getHeader(HttpHeaders.VARY));
     }, 200, "OK", null);
   }
+
+  @Test
+  public void testCORSSetupStarOriginShouldNotHaveVary() throws Exception {
+    // when we allow any origin, the response is not dependent on it, so we tell caches not to consider origin in
+    // the cache key
+    router
+      .route()
+      .handler(CorsHandler.create()
+        .allowCredentials(true)
+        .allowedHeader("Content-Type")
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedMethod(HttpMethod.OPTIONS)
+        .allowedHeader("Access-Control-Allow-Origin"))
+      .handler(BodyHandler.create().setBodyLimit(1))
+      .handler(context -> context.response().end());
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.headers().add("origin", "https://mydomain.org:3000");
+    }, resp -> {
+      assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+      assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+      assertNull(resp.getHeader(HttpHeaders.VARY));
+    }, 200, "OK", null);
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -621,4 +621,21 @@ public class CORSHandlerTest extends WebTestBase {
       assertEquals("https://mydomain.org:3000", orig);
     }, 200, "OK", null);
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCORSSetupMixedOrigin() throws Exception {
+
+    router
+      .route()
+      .handler(CorsHandler.create()
+        .addRelativeOrigin("https://.*:3000")
+        .addOrigin("https://foo:9443")
+        .allowCredentials(true)
+        .allowedHeader("Content-Type")
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedMethod(HttpMethod.OPTIONS)
+        .allowedHeader("Access-Control-Allow-Origin"))
+      .handler(context -> context.response().end());
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -566,6 +566,59 @@ public class CORSHandlerTest extends WebTestBase {
       assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
       assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
     }, 413, "Request Entity Too Large", null);
+  }
 
+  @Test
+  public void testCORSSetupSingleOrigin() throws Exception {
+
+    router
+      .route()
+      .handler(CorsHandler.create()
+        .addOrigin("https://mydomain.org:3000")
+        .addOrigin("https://mydomain.org:9443")
+        .allowCredentials(true)
+        .allowedHeader("Content-Type")
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedMethod(HttpMethod.OPTIONS)
+        .allowedHeader("Access-Control-Allow-Origin"))
+      .handler(context -> context.response().end());
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.headers().add("origin", "https://mydomain.org:3000");
+    }, resp -> {
+      String cred = resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS);
+      String orig = resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+      assertNotNull(cred);
+      assertNotNull(orig);
+      assertEquals("https://mydomain.org:3000", orig);
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCORSSetupSingleRelativeOrigin() throws Exception {
+
+    router
+      .route()
+      .handler(CorsHandler.create()
+        .addRelativeOrigin("https://.*:3000")
+        .addRelativeOrigin("https://.*:9443")
+        .allowCredentials(true)
+        .allowedHeader("Content-Type")
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedMethod(HttpMethod.OPTIONS)
+        .allowedHeader("Access-Control-Allow-Origin"))
+      .handler(context -> context.response().end());
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.headers().add("origin", "https://mydomain.org:3000");
+    }, resp -> {
+      String cred = resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS);
+      String orig = resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+      assertNotNull(cred);
+      assertNotNull(orig);
+      assertEquals("https://mydomain.org:3000", orig);
+    }, 200, "OK", null);
   }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This PR relaxes the CORS handler to allow both lists of patterns OR lists of static origins

Fixes: https://github.com/vert-x3/vertx-web/issues/2311