### PR TITLE
force SnakeYaml to use java.time.Instant instead of java.util.Date (#…

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
@@ -23,7 +23,6 @@ import io.vertx.json.schema.common.SchemaURNId;
 import io.vertx.json.schema.common.URIUtils;
 import io.vertx.json.schema.draft7.Draft7SchemaParser;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,7 +58,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
     this.options = options;
     SchemaRouter router = SchemaRouter.create(vertx, client, fs, options.toSchemaRouterOptions());
     SchemaParser parser = Draft7SchemaParser.create(router);
-    this.yamlMapper = new Yaml(new SafeConstructor());
+    this.yamlMapper = new Yaml(new OpenAPIYamlConstructor());
     this.openapiSchema = parser.parseFromString(OpenAPI3Utils.openapiSchemaJson);
   }
 

--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIYamlConstructor.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIYamlConstructor.java
@@ -1,0 +1,22 @@
+package io.vertx.ext.web.openapi.impl;
+
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import java.util.Date;
+
+public class OpenAPIYamlConstructor extends SafeConstructor {
+
+  public OpenAPIYamlConstructor() {
+    super();
+    this.yamlConstructors.put(Tag.TIMESTAMP, new ConstructInstantTimestamp());
+  }
+
+  private static class ConstructInstantTimestamp extends SafeConstructor.ConstructYamlTimestamp {
+    public Object construct(Node node) {
+      Date date = (Date) super.construct(node);
+      return date.toInstant();
+    }
+  }
+}


### PR DESCRIPTION
Fix for Openapi date or date-time format supported ? RouterBuilder: Illegal type in Json: class java.util.Date #2338

Problem:
SnakeYaml read yaml files into JsonObject consisting of `java.util.Date` that is not supported by `JsonObject.deepCopy()`
https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/json/impl/JsonUtil.java#L118 

Solution:
Override SnakeYaml to read dateTime object as `java.time.Instant`
