### PR TITLE
Fix CORS cache behavior with allow credentials

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -234,7 +234,8 @@ public class CorsHandlerImpl implements CorsHandler {
 
       } else {
         // when it is possible to determine if only one origin is allowed, we can skip this extra caching header
-        if (!starOrigin() && !uniqueOrigin()) {
+        // If allow credentials is set, the response cannot be '*' thus we need to vary on origin
+        if (!(starOrigin() && !allowCredentials) && !uniqueOrigin()) {
           Utils.appendToMapIfAbsent(response.headers(), VARY, ",", ORIGIN);
         }
         addCredentialsAndOriginHeader(response, origin);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CORSHandlerTest.java
@@ -697,6 +697,30 @@ public class CORSHandlerTest extends WebTestBase {
     router
       .route()
       .handler(CorsHandler.create()
+        .allowCredentials(false)
+        .allowedHeader("Content-Type")
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedMethod(HttpMethod.OPTIONS)
+        .allowedHeader("Access-Control-Allow-Origin"))
+      .handler(BodyHandler.create().setBodyLimit(1))
+      .handler(context -> context.response().end());
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.headers().add("origin", "https://mydomain.org:3000");
+    }, resp -> {
+      assertNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+      assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+      assertNull(resp.getHeader(HttpHeaders.VARY));
+    }, 200, "OK", null);
+  }
+
+  @Test
+  public void testCORSSetupStarOriginWithAllowCredentialsShouldHaveVary() throws Exception {
+    // When allow credentials is set with any origin, the response is dependent on the origin
+    router
+      .route()
+      .handler(CorsHandler.create()
         .allowCredentials(true)
         .allowedHeader("Content-Type")
         .allowedMethod(HttpMethod.GET)
@@ -711,7 +735,7 @@ public class CORSHandlerTest extends WebTestBase {
     }, resp -> {
       assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
       assertNotNull(resp.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
-      assertNull(resp.getHeader(HttpHeaders.VARY));
+      assertEquals("origin", resp.getHeader(HttpHeaders.VARY));
     }, 200, "OK", null);
   }
 }


### PR DESCRIPTION
When allow origin * is used in conjunction with allow credentials, the allow origin response headers is set to the requested origin. Thus the Vary origin header needs to be included to ensure browsers receive the correct response.

Motivation:

Fix for: https://github.com/vert-x3/vertx-web/issues/2319

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
