### PR TITLE
Update RouteToEBServiceHandler.java

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/RouteToEBServiceHandler.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/RouteToEBServiceHandler.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 /**
  * Handler that proxy the request to an event bus endpoint, waits for the reply and then writes the HTTP response. <br/>
  *
- * The HTTP request is sent encapsulated into a {@link ServiceRequest} object through the event bus. The expected reply is a {@link ServiceResponse} <br/>
+ * The HTTP request is sent encapsulated into a {@link ServiceRequest} object through the event bus. The expected reply is a {@link ServiceResponse}, encapsulated as a {@link JsonObject}<br/>
  *
  * This handler requires a {@link io.vertx.ext.web.validation.ValidationHandler} that process request parameters, so they can be encapsulated by this handler inside the {@link ServiceRequest}
  *


### PR DESCRIPTION
Motivation:

When I response a `ServiceResponse` I get the following error:

`No message codec for type: class io.vertx.ext.web.api.service.ServiceResponse`

My first guess was to implement a local codec. But then I looked into the implementation and actually I think that RouteToEBServiceHandler expects a ServiceResponse.toJson(). 

Is this correct? If yes, we should maybe consider updating the documentation.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
