### PR TITLE
Fix the webroot escape to classpath on windows

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -20,6 +20,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
@@ -73,10 +74,12 @@ public class Utils {
     }
 
     if (!route.isExactPath()) {
-      final String rest = context.pathParam("*");
+      String rest = context.pathParam("*");
       if (rest != null) {
         // normalize
         if (rest.length() > 0) {
+          // remove any attempt to escape the web root and use UNIX style path separators
+          rest = HttpUtils.removeDots(rest.replace('\\', '/'));
           if (rest.charAt(0) == '/') {
             return rest;
           } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerWindowsTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/StaticHandlerWindowsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.WebTestBase;
+import org.junit.Test;
+
+public class StaticHandlerWindowsTest extends WebTestBase {
+
+  @Test
+  public void testEscapeToClasspathFromWildcard() throws Exception {
+    router.clear();
+    router.route("/*").handler(StaticHandler.create("www"));
+    // attempt to escape to classpath, given that the handler is mounted on a wildcard,
+    // reading the wildcard must return a sanitized path and therefore not allow to escape.
+    testRequest(HttpMethod.GET, "/..\\.htdigest", 404, "Not Found");
+  }
+
+  @Test
+  public void testEscapeToClasspathFromNull() throws Exception {
+    router.clear();
+    router.route().handler(StaticHandler.create("www"));
+    // attempt to escape to classpath, given that the handler is mounted on a catch all path
+    testRequest(HttpMethod.GET, "/..\\.htdigest", 404, "Not Found");
+  }
+
+  @Test
+  public void testEscapeToClasspathFromRegEx() throws Exception {
+    router.clear();
+    router.routeWithRegex(".*").handler(StaticHandler.create("www"));
+    // attempt to escape to classpath, given that the handler is mounted on a regex,
+    testRequest(HttpMethod.GET, "/..\\.htdigest", 404, "Not Found");
+  }
+
+  @Test
+  public void testEscapeToClasspathFromFixedPath() throws Exception {
+    router.clear();
+    router.routeWithRegex("/").handler(StaticHandler.create("www"));
+    // attempt to escape to classpath, given that the handler is mounted on a regex,
+    testRequest(HttpMethod.GET, "/..\\.htdigest", 404, "Not Found");
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSRawTransportTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSRawTransportTest.java
@@ -83,7 +83,7 @@ public class SockJSRawTransportTest extends SockJSTestBase {
         .setAllowOriginHeader(false),
       onFailure(err -> {
         assertNotNull(err);
-        assertEquals("WebSocket upgrade failure: 403 (Forbidden)", err.getMessage());
+        assertEquals("WebSocket upgrade failure: 403", err.getMessage());
         testComplete();
       }));
     await();
@@ -125,7 +125,7 @@ public class SockJSRawTransportTest extends SockJSTestBase {
     startServers(new SockJSHandlerOptions().setOrigin("https://www.google.com"));
     client.webSocket("/test/websocket", onFailure(err -> {
       assertNotNull(err);
-      assertEquals("WebSocket upgrade failure: 403 (Forbidden)", err.getMessage());
+      assertEquals("WebSocket upgrade failure: 403", err.getMessage());
       testComplete();
     }));
     await();


### PR DESCRIPTION
Fix the webroot escape to classpath on windows