### PR TITLE
Add an "advanced" LoggerFormatter API to expose more request metadata

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerFormatterAdvanced.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerFormatterAdvanced.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web.handler;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Implement to format the output of the {@link LoggerHandler}
+ *
+ * @author <a href="mailto:oded@geek.co.il">Oded Arbel</a>
+ */
+@VertxGen
+@FunctionalInterface
+public interface LoggerFormatterAdvanced {
+
+  /**
+   * Formats and returns the log statement
+   * 
+   * @param routingContext The routing context
+   * @param timestamp The system time in milliseconds when the request was handled by the {@link LoggerHandler}
+   * @param remoteClient The remote client's host address
+   * @param versionFormatted The HTTP version as formatted for display (normally {@code HTTP/x.x})
+   * @param method The request's HTTP method
+   * @param uri The request's URI
+   * @param status The response's HTTP status code
+   * @param contentLength The amount of bytes that were written in the response
+   * @param ms The number of milliseconds since first receiving the request
+   * @return The formatted string to log
+   */
+  String format(RoutingContext routingContext, long timestamp, String remoteClient, String versionFormatted,
+    HttpMethod method, String uri, int status, long contentLength, long ms);
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerHandler.java
@@ -69,7 +69,7 @@ public interface LoggerHandler extends PlatformHandler {
    *
    * @deprecated Superseded by {@link #customFormatter(LoggerFormatter)}
    * @param formatter the formatting function
-   * @return the formatted log string
+   * @return self
    * @throws IllegalStateException if current format is not {@link LoggerFormat#CUSTOM}
    */
   @Deprecated
@@ -80,9 +80,19 @@ public interface LoggerHandler extends PlatformHandler {
    * Set the custom formatter to be used by the handler.
    *
    * @param formatter the formatter
-   * @return the formatted log string
+   * @return self
    * @throws IllegalStateException if current format is not {@link LoggerFormat#CUSTOM}
    */
   @Fluent
   LoggerHandler customFormatter(LoggerFormatter formatter);
+
+  /**
+   * Set the custom formatter to be used by the handler.
+   *
+   * @param formatter the formatter
+   * @return self
+   * @throws IllegalStateException if current format is not {@link LoggerFormat#CUSTOM}
+   */
+  @Fluent
+  LoggerHandler customFormatter(LoggerFormatterAdvanced formatter);
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/LoggerHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/LoggerHandlerTest.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.handler;
 
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebTestBase;
 import org.junit.Test;
 
@@ -82,5 +83,17 @@ public class LoggerHandlerTest extends WebTestBase {
     testRequest(HttpMethod.GET, "/somedir", 200, "OK");
   }
 
+  @Test
+  public void testLogger6() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    LoggerHandler logger = LoggerHandler.create(true, LoggerFormat.CUSTOM).customFormatter((
+      RoutingContext routingContext, long timestamp, String remoteClient, String versionFormatted,
+      HttpMethod method, String uri, int status, long contentLength, long ms) -> {
+        latch.countDown();
+        return "custom log message";
+    });
+    testLogger(logger);
+    latch.await();
+  }
 
 }


### PR DESCRIPTION
As LoggerHandlerImpl already calculated this important information, that is otherwise hard/impossible to get (e.g. request start time), so if we want to use that metadata in a formatter (e.g. to mimic LoggerFormat.DEFAULT) - it'd be best if we don't need to repeat work that had already been done.

I'm not happy with the new class's name - I'm just drawing a complete blank on what would be a good name. Suggestions are welcome :sweat_smile: .

Motivation:

Implement the feature request in issue #2367 

