### PR TITLE
Web client callback removal

### DIFF
--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -3,7 +3,7 @@
 :lang: $lang
 :$lang: $lang
 
-Vert.x Web Client is an asynchronous HTTP and HTTP/2 client.
+Vert.x Web Client is a non-blocking  HTTP and HTTP/2 client.
 
 The Web Client makes easy to do HTTP request/response interactions with a web server, and provides advanced
 features like:
@@ -13,6 +13,8 @@ features like:
 * request parameters
 * unified error handling
 * form submissions
+* caching support
+* cookies support
 
 The Web Client does not deprecate the Vert.x Core {@link io.vertx.core.http.HttpClient}, indeed it is based on
 this client and inherits its configuration and great features like pooling, HTTP/2 support, pipelining support, etc...
@@ -20,7 +22,7 @@ The {@link io.vertx.core.http.HttpClient} should be used when fine grained contr
 requests/responses is necessary.
 
 The Web Client does not provide a WebSocket API, the Vert.x Core {@link io.vertx.core.http.HttpClient} should
-be used. It also does not handle cookies at the moment.
+be used.
 
 == Using the Web Client
 
@@ -81,7 +83,7 @@ Otherwise you lose a lot of benefits such as connection pooling and may leak res
 
 == Making requests
 
-=== Simple requests with no body
+=== Simple requests without bodies
 
 Often, you’ll want to make HTTP requests with no request body. This is usually the case with HTTP GET, OPTIONS
 and HEAD requests
@@ -149,7 +151,7 @@ The POST will not be chunked.
 ==== Json bodies
 
 Often you’ll want to send Json body requests, to send a {@link io.vertx.core.json.JsonObject}
-use the {@link io.vertx.ext.web.client.HttpRequest#sendJsonObject(io.vertx.core.json.JsonObject, io.vertx.core.Handler)}
+use the {@link io.vertx.ext.web.client.HttpRequest#sendJsonObject(io.vertx.core.json.JsonObject)}
 
 [source,$lang]
 ----
@@ -170,7 +172,7 @@ to Json.
 
 ==== Form submissions
 
-You can send http form submissions bodies with the {@link io.vertx.ext.web.client.HttpRequest#sendForm(io.vertx.core.MultiMap, io.vertx.core.Handler)}
+You can send http form submissions bodies with the {@link io.vertx.ext.web.client.HttpRequest#sendForm(io.vertx.core.MultiMap)}
 variant.
 
 [source,$lang]
@@ -178,7 +180,7 @@ variant.
 {@link examples.WebClientExamples#sendForm(io.vertx.ext.web.client.WebClient)}
 ----
 
-By default the form is submitted with the `application/x-www-form-urlencoded` content type header. You can set
+By default, the form is submitted with the `application/x-www-form-urlencoded` content type header. You can set
 the `content-type` header to `multipart/form-data` instead
 
 [source,$lang]
@@ -187,7 +189,7 @@ the `content-type` header to `multipart/form-data` instead
 ----
 
 If you want to upload files and send attributes, you can create a {@link io.vertx.ext.web.multipart.MultipartForm} and
- use {@link io.vertx.ext.web.client.HttpRequest#sendMultipartForm(io.vertx.ext.web.multipart.MultipartForm, io.vertx.core.Handler)}.
+ use {@link io.vertx.ext.web.client.HttpRequest#sendMultipartForm(io.vertx.ext.web.multipart.MultipartForm)}.
 
 [source,$lang]
 ----
@@ -240,7 +242,7 @@ You can configure the request to add bearer token authentication as follows:
 
 === Reusing requests
 
-The {@link io.vertx.ext.web.client.HttpRequest#send(io.vertx.core.Handler)} method can be called multiple times
+The {@link io.vertx.ext.web.client.HttpRequest#send()} method can be called multiple times
 safely, making it very easy to configure and reuse {@link io.vertx.ext.web.client.HttpRequest} objects
 
 [source,$lang]
@@ -336,7 +338,7 @@ You pass a JSON parser that emits the read JSON streams from the HTTP response:
 {@link examples.WebClientExamples#receiveResponseAsJsonStream(io.vertx.ext.web.client.WebClient)}
 ----
 
-Finally if you are not interested at all by the response content, the {@link io.vertx.ext.web.codec.BodyCodec#none()}
+Finally, if you are not interested at all by the response content, the {@link io.vertx.ext.web.codec.BodyCodec#none()}
 simply discards the entire response body
 
 [source,$lang]
@@ -712,7 +714,7 @@ endif::[]
 
 == Domain sockets
 
-Since 3.7.1 the Web Client supports domain sockets, e.g you can interact with the https://docs.docker.com/engine/reference/commandline/dockerd/[local Docker daemon].
+The Web Client supports domain sockets, e.g you can interact with the https://docs.docker.com/engine/reference/commandline/dockerd/[local Docker daemon].
 
 To achieve this, the {@link io.vertx.core.Vertx} instance must be created using a native transport, you can read
 the Vert.x core documentation that explains it clearly.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -459,97 +459,47 @@ public interface HttpRequest<T> {
   String traceOperation();
 
   /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} stream.
+   * Like {@link #send()} but with an HTTP request {@code body} stream.
    *
    * @param body the body
    */
-  void sendStream(ReadStream<Buffer> body, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendStream(ReadStream<Buffer> body);
 
   /**
-   * @param body the body
-   * @see HttpRequest#sendStream(ReadStream, Handler)
-   */
-  default Future<HttpResponse<T>> sendStream(ReadStream<Buffer> body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendStream(body, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} buffer.
+   * Like {@link #send()} but with an HTTP request {@code body} buffer.
    *
    * @param body the body
    */
-  void sendBuffer(Buffer body, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendBuffer(Buffer body);
 
   /**
-   * @param body the body
-   * @see HttpRequest#sendBuffer(Buffer, Handler)
-   */
-  default Future<HttpResponse<T>> sendBuffer(Buffer body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendBuffer(body, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} object encoded as json and the content type
+   * Like {@link #send()} but with an HTTP request {@code body} object encoded as json and the content type
    * set to {@code application/json}.
    *
    * @param body the body
    */
-  void sendJsonObject(JsonObject body, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendJsonObject(JsonObject body);
 
   /**
-   * @param body the body
-   * @see HttpRequest#sendJsonObject(JsonObject, Handler)
-   */
-  default Future<HttpResponse<T>> sendJsonObject(JsonObject body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendJsonObject(body, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} object encoded as json and the content type
+   * Like {@link #send()} but with an HTTP request {@code body} object encoded as json and the content type
    * set to {@code application/json}.
    *
    * @param body the body
    */
-  void sendJson(@Nullable Object body, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendJson(@Nullable Object body);
 
   /**
-   * @param body the body
-   * @see HttpRequest#sendJson(Object, Handler)
-   */
-  default Future<HttpResponse<T>> sendJson(@Nullable Object body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendJson(body, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} multimap encoded as form and the content type
+   * Like {@link #send()} but with an HTTP request {@code body} multimap encoded as form and the content type
    * set to {@code application/x-www-form-urlencoded}.
    * <p>
    * When the content type header is previously set to {@code multipart/form-data} it will be used instead.
    *
    * @param body the body
    */
-  void sendForm(MultiMap body, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendForm(MultiMap body);
 
   /**
-   * @param body the body
-   * @see HttpRequest#sendForm(MultiMap, Handler)
-   */
-  default Future<HttpResponse<T>> sendForm(MultiMap body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendForm(body, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} multimap encoded as form and the content type
+   * Like {@link #send()} but with an HTTP request {@code body} multimap encoded as form and the content type
    * set to {@code application/x-www-form-urlencoded}.
    * <p>
    * When the content type header is previously set to {@code multipart/form-data} it will be used instead.
@@ -558,49 +508,22 @@ public interface HttpRequest<T> {
    * encoded form since the charset to use must be UTF-8.
    *
    * @param body the body
+   * @return the response future
    */
-  void sendForm(MultiMap body, String charset, Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> sendForm(MultiMap body, String charset);
 
   /**
-   * @param body the body
-   * @param charset the charset
-   * @see HttpRequest#sendForm(MultiMap, String, Handler)
-   */
-  default Future<HttpResponse<T>> sendForm(MultiMap body, String charset) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendForm(body, charset, promise);
-    return promise.future();
-  }
-
-  /**
-   * Like {@link #send(Handler)} but with an HTTP request {@code body} multimap encoded as form and the content type
+   * Like {@link #send()} but with an HTTP request {@code body} multimap encoded as form and the content type
    * set to {@code multipart/form-data}. You may use this method to send attributes and upload files.
    *
    * @param body the body
+   * @return the response future
    */
-  void sendMultipartForm(MultipartForm body, Handler<AsyncResult<HttpResponse<T>>> handler);
-
-  /**
-   * @param body the body
-   * @see HttpRequest#sendMultipartForm(MultipartForm, Handler)
-   */
-  default Future<HttpResponse<T>> sendMultipartForm(MultipartForm body) {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    sendMultipartForm(body, promise);
-    return promise.future();
-  }
+  Future<HttpResponse<T>> sendMultipartForm(MultipartForm body);
 
   /**
    * Send a request, the {@code handler} will receive the response as an {@link HttpResponse}.
    */
-  void send(Handler<AsyncResult<HttpResponse<T>>> handler);
+  Future<HttpResponse<T>> send();
 
-  /**
-   * @see HttpRequest#send(Handler)
-   */
-  default Future<HttpResponse<T>> send() {
-    Promise<HttpResponse<T>> promise = Promise.promise();
-    send(promise);
-    return promise.future();
-  }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientInternal;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.impl.WebClientBase;
 import io.vertx.uritemplate.UriTemplate;
@@ -65,7 +66,7 @@ public interface WebClient {
    * @return the created web client
    */
   static WebClient create(Vertx vertx, WebClientOptions options) {
-    return new WebClientBase(vertx.createHttpClient(options), options);
+    return new WebClientBase((VertxInternal) vertx, vertx.createHttpClient(options), options);
   }
 
   /**
@@ -91,7 +92,7 @@ public interface WebClient {
   static WebClient wrap(HttpClient httpClient, WebClientOptions options) {
     WebClientOptions actualOptions = new WebClientOptions(((HttpClientInternal) httpClient).options());
     actualOptions.init(options);
-    return new WebClientBase(httpClient, actualOptions);
+    return new WebClientBase(((HttpClientInternal)httpClient).vertx(), httpClient, actualOptions);
   }
 
   /**

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -41,7 +41,7 @@ import java.util.*;
  */
 public class HttpContext<T> {
 
-  private final Handler<AsyncResult<HttpResponse<T>>> handler;
+  private final Promise<HttpResponse<T>> handler;
   private final HttpClientInternal client;
   private final WebClientOptions options;
   private final List<Handler<HttpContext<?>>> interceptors;
@@ -64,7 +64,7 @@ public class HttpContext<T> {
   private List<String> redirectedLocations = Collections.emptyList();
   private CacheStore privateCacheStore;
 
-  HttpContext(HttpClientInternal client, WebClientOptions options, List<Handler<HttpContext<?>>> interceptors, Handler<AsyncResult<HttpResponse<T>>> handler) {
+  HttpContext(HttpClientInternal client, WebClientOptions options, List<Handler<HttpContext<?>>> interceptors, Promise<HttpResponse<T>> handler) {
     this.handler = handler;
     this.client = client;
     this.options = options;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -17,13 +17,14 @@ package io.vertx.ext.web.client.impl;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.QueryStringEncoder;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
@@ -385,48 +386,62 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   @Override
-  public void sendStream(ReadStream<Buffer> body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send(null, body, handler);
+  public Future<HttpResponse<T>> send() {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send(null, null, promise);
+    return promise.future();
   }
 
   @Override
-  public void send(Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send(null, null, handler);
+  public Future<HttpResponse<T>> sendStream(ReadStream<Buffer> body) {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send(null, body, promise);
+    return promise.future();
   }
 
   @Override
-  public void sendBuffer(Buffer body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send(null, body, handler);
+  public Future<HttpResponse<T>> sendBuffer(Buffer body) {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send(null, body, promise);
+    return promise.future();
   }
 
   @Override
-  public void sendJsonObject(JsonObject body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send("application/json", body,handler);
+  public Future<HttpResponse<T>> sendJsonObject(JsonObject body) {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send("application/json", body, promise);
+    return promise.future();
   }
 
   @Override
-  public void sendJson(Object body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send("application/json", body, handler);
+  public Future<HttpResponse<T>> sendJson(@Nullable Object body) {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send("application/json", body, promise);
+    return promise.future();
   }
 
   @Override
-  public void sendForm(MultiMap body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    sendForm(body, "UTF-8", handler);
+  public Future<HttpResponse<T>> sendForm(MultiMap body) {
+    return sendForm(body, "UTF-8");
   }
 
   @Override
-  public void sendForm(MultiMap body, String charset, Handler<AsyncResult<HttpResponse<T>>> handler) {
+  public Future<HttpResponse<T>> sendForm(MultiMap body, String charset) {
     MultipartForm parts = MultipartForm.create();
     for (Map.Entry<String, String> attribute : body) {
       parts.attribute(attribute.getKey(), attribute.getValue());
     }
     parts.setCharset(charset);
-    send("application/x-www-form-urlencoded", parts, handler);
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send("application/x-www-form-urlencoded", parts, promise);
+    return promise.future();
   }
 
   @Override
-  public void sendMultipartForm(MultipartForm body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    send("multipart/form-data", body, handler);
+  public Future<HttpResponse<T>> sendMultipartForm(MultipartForm body) {
+    Promise<HttpResponse<T>> promise = client.vertx.promise();
+    send("multipart/form-data", body, promise);
+    return promise.future();
   }
 
   RequestOptions buildRequestOptions() throws URISyntaxException, MalformedURLException {
@@ -499,8 +514,8 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     return requestOptions;
   }
 
-  void send(String contentType, Object body, Handler<AsyncResult<HttpResponse<T>>> handler) {
-    HttpContext<T> ctx = client.createContext(handler);
+  void send(String contentType, Object body, Promise<HttpResponse<T>> promise) {
+    HttpContext<T> ctx = client.createContext(promise);
     ctx.prepareRequest(this, contentType, body);
   }
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -15,10 +15,7 @@
  */
 package io.vertx.ext.web.client.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.VertxException;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -26,6 +23,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientInternal;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
@@ -46,17 +44,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class WebClientBase implements WebClientInternal {
 
+  final VertxInternal vertx;
   final HttpClient client;
   final WebClientOptions options;
   final List<Handler<HttpContext<?>>> interceptors;
 
-  public WebClientBase(HttpClient client, WebClientOptions options) {
+  public WebClientBase(VertxInternal vertx, HttpClient client, WebClientOptions options) {
 
     options = new WebClientOptions(options);
     if (options.getTemplateExpandOptions() == null) {
       options.setTemplateExpandOptions(new ExpandOptions());
     }
 
+    this.vertx = vertx;
     this.client = client;
     this.options = options;
     this.interceptors = new CopyOnWriteArrayList<>();
@@ -66,6 +66,7 @@ public class WebClientBase implements WebClientInternal {
   }
 
   WebClientBase(WebClientBase webClient) {
+    this.vertx = webClient.vertx;
     this.client = webClient.client;
     this.options = new WebClientOptions(webClient.options);
     this.interceptors = new CopyOnWriteArrayList<>(webClient.interceptors);
@@ -155,7 +156,7 @@ public class WebClientBase implements WebClientInternal {
   }
 
   @Override
-  public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
+  public <T> HttpContext<T> createContext(Promise<HttpResponse<T>> handler) {
     HttpClientInternal client = (HttpClientInternal) this.client;
     return new HttpContext<>(client, options, interceptors, handler);
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -17,6 +17,7 @@ package io.vertx.ext.web.client.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
@@ -25,7 +26,7 @@ import io.vertx.ext.web.client.WebClient;
  */
 public interface WebClientInternal extends WebClient {
 
-  <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler);
+  <T> HttpContext<T> createContext(Promise<HttpResponse<T>> handler);
 
   /**
    * Add interceptor in the chain.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientSessionAware.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientSessionAware.java
@@ -13,6 +13,7 @@ package io.vertx.ext.web.client.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -84,7 +85,7 @@ public class WebClientSessionAware extends WebClientBase implements WebClientSes
   }
 
   @Override
-  public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
+  public <T> HttpContext<T> createContext(Promise<HttpResponse<T>> handler) {
     return super.createContext(handler).privateCacheStore(cacheStore);
   }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/package-info.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/package-info.java
@@ -1,4 +1,4 @@
-@ModuleGen(name = "vertx-web-client", groupPackage = "io.vertx")
+@ModuleGen(name = "vertx-web-client", groupPackage = "io.vertx", useFutures = true)
 package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/CachingWebClientTest.java
@@ -100,7 +100,7 @@ public class CachingWebClientTest {
 
     reqConsumer.accept(request);
 
-    request.send(context.asyncAssertSuccess(response -> {
+    request.send().onComplete(context.asyncAssertSuccess(response -> {
       body.set(response.bodyAsString());
       waiter.complete();
     }));
@@ -136,7 +136,7 @@ public class CachingWebClientTest {
     Async request2 = context.async();
     List<HttpResponse<Buffer>> responses = new ArrayList<>(2);
 
-    client.request(method, "localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    client.request(method, "localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       responses.add(resp);
       request1.complete();
     }));
@@ -144,7 +144,7 @@ public class CachingWebClientTest {
     // Wait for request 1 to finish first to make sure the cache stored a value if necessary
     request1.await();
 
-    client.request(method, "localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    client.request(method, "localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       responses.add(resp);
       request2.complete();
     }));
@@ -358,13 +358,13 @@ public class CachingWebClientTest {
       req.response().headers().set("Expires", expires);
     });
 
-    defaultClient.get("localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    defaultClient.get("localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       body1.set(resp.bodyAsString());
       req1.complete();
     }));
     req1.await();
 
-    defaultClient.get("localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    defaultClient.get("localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       body2.set(resp.bodyAsString());
       req2.complete();
     }));
@@ -374,7 +374,7 @@ public class CachingWebClientTest {
     vertx.setTimer(2000, l -> waiter.complete());
     waiter.await();
 
-    defaultClient.get("localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    defaultClient.get("localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       body3.set(resp.bodyAsString());
       req3.complete();
     }));
@@ -584,7 +584,7 @@ public class CachingWebClientTest {
     vertx.setTimer(3000L, l -> waiter2.complete());
     waiter2.await();
 
-    defaultClient.get("localhost", "/").send(context.asyncAssertSuccess(resp -> {
+    defaultClient.get("localhost", "/").send().onComplete(context.asyncAssertSuccess(resp -> {
       response.set(resp);
       request.complete();
     }));

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/HandlerExceptionTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/HandlerExceptionTest.java
@@ -41,8 +41,10 @@ public class HandlerExceptionTest {
     });
 
     WebClient client = WebClient.create(vertx);
-    client.get(8080, "localhost", "")
-      .send(resp -> {
+    client
+      .get(8080, "localhost", "")
+      .send()
+      .onComplete(resp -> {
         tc.assertTrue(resp.succeeded());
         tc.assertTrue(Context.isOnEventLoopThread());
         throw new RuntimeException("Expected exception");

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
@@ -78,7 +78,7 @@ public class InterceptorTest extends HttpTestBase {
     startServer();
     client.addInterceptor(this::handleMutateRequest);
     HttpRequest<Buffer> builder = client.get("/somepath").host("another-host").port(8081);
-    builder.send(onSuccess(resp -> complete()));
+    builder.send().onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -100,7 +100,7 @@ public class InterceptorTest extends HttpTestBase {
     AsyncFile foo = vertx.fileSystem().openBlocking(f.getAbsolutePath(), new OpenOptions().setSync(true).setTruncateExisting(true));
     client.addInterceptor(this::handleMutateCodec);
     HttpRequest<Void> builder = client.get("/somepath").as(BodyCodec.pipe(foo));
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       foo.write(Buffer.buffer("bar!"));
       foo.close(onSuccess(v -> {
         assertEquals("bar!", vertx.fileSystem().readFileBlocking(f.getAbsolutePath()).toString());
@@ -133,7 +133,7 @@ public class InterceptorTest extends HttpTestBase {
     startServer();
     client.addInterceptor(this::mutateResponseHandler);
     HttpRequest<Buffer> builder = client.get("/somepath");
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(200, resp.statusCode());
       complete();
     }));
@@ -154,7 +154,7 @@ public class InterceptorTest extends HttpTestBase {
       context.next();
     });
     HttpRequest<Buffer> builder = client.get("/somepath");
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(Arrays.asList(
         "PREPARE_REQUEST_1", "PREPARE_REQUEST_2",
         "CREATE_REQUEST_1", "CREATE_REQUEST_2",
@@ -193,7 +193,7 @@ public class InterceptorTest extends HttpTestBase {
     });
 
     HttpRequest<Buffer> builder = client.get("/somepath");
-    builder.send(onFailure(err -> {
+    builder.send().onComplete(onFailure(err -> {
       assertEquals(Arrays.asList(
         "PREPARE_REQUEST_1", "PREPARE_REQUEST_2", "PREPARE_REQUEST_3",
         "CREATE_REQUEST_1", "CREATE_REQUEST_2",
@@ -234,7 +234,7 @@ public class InterceptorTest extends HttpTestBase {
       context.next();
     });
     HttpRequest<Buffer> builder = client.get("/somepath");
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       Thread contextThread = Thread.currentThread();
       assertEquals(abc.apply(testThread, contextThread), phaseThreads);
       complete();
@@ -275,7 +275,7 @@ public class InterceptorTest extends HttpTestBase {
     AtomicInteger respCount = new AtomicInteger();
     client.addInterceptor(retryInterceptorHandler(reqCount, respCount, num));
     HttpRequest<Buffer> builder = client.get("/");
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(num + 1, reqCount.get());
       assertEquals(num + 1, respCount.get());
       assertEquals(503, resp.statusCode());
@@ -298,7 +298,7 @@ public class InterceptorTest extends HttpTestBase {
     startServer();
     client.addInterceptor(this::cacheInterceptorHandler);
     HttpRequest<Buffer> builder = client.get("/somepath").host("localhost").port(8080);
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(200, resp.statusCode());
       complete();
     }));
@@ -396,7 +396,7 @@ public class InterceptorTest extends HttpTestBase {
       ctx.next();
     });
     HttpRequest<Buffer> builder = client.get("/1").host("localhost").port(8080);
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(200, resp.statusCode());
       assertEquals(Arrays.asList(
         ClientPhase.PREPARE_REQUEST,
@@ -427,7 +427,7 @@ public class InterceptorTest extends HttpTestBase {
       ctx.next();
     });
     HttpRequest<Buffer> builder = client.get("/").host("localhost").port(8080);
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(302, resp.statusCode());
       assertEquals(Arrays.asList(
         ClientPhase.PREPARE_REQUEST,
@@ -530,7 +530,9 @@ public class InterceptorTest extends HttpTestBase {
       ctx.next();
     });
     HttpRequest<Buffer> builder = client.get("/somepath").host("localhost").port(8080);
-    builder.send(onSuccess(resp -> {
+    builder
+      .send()
+      .onComplete(onSuccess(resp -> {
       long prev = 0L;
       for (long val : list) {
         assertTrue(val >= prev);
@@ -551,7 +553,9 @@ public class InterceptorTest extends HttpTestBase {
       fail("Should never be executed");
     });
     HttpRequest<Buffer> builder = client.get("/somepath").host("localhost").port(8080);
-    builder.send(onFailure(err -> {
+    builder
+      .send()
+      .onComplete(onFailure(err -> {
       assertSame(failure, err);
       testComplete();
     }));
@@ -571,7 +575,9 @@ public class InterceptorTest extends HttpTestBase {
       ctx.next();
     });
     HttpRequest<Buffer> builder = client.get("/somepath").host("localhost").port(8080);
-    builder.send(onSuccess(resp -> {
+    builder
+      .send()
+      .onComplete(onSuccess(resp -> {
       testComplete();
     }));
     await();

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/JsonStreamTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/JsonStreamTest.java
@@ -70,11 +70,11 @@ public class JsonStreamTest {
       })
       .endHandler(x -> async.complete());
 
-    client.get("/?separator=nl&count=10").as(BodyCodec.jsonStream(parser)).send(x -> {
-      if (x.failed()) {
-        tc.fail(x.cause());
-      }
-    });
+    client
+      .get("/?separator=nl&count=10")
+      .as(BodyCodec.jsonStream(parser))
+      .send()
+      .onComplete(tc.asyncAssertSuccess());
   }
 
   @Test
@@ -90,11 +90,10 @@ public class JsonStreamTest {
       })
       .endHandler(x -> async.complete());
 
-    client.get("/?separator=bl&count=10").as(BodyCodec.jsonStream(parser)).send(x -> {
-      if (x.failed()) {
-        tc.fail(x.cause());
-      }
-    });
+    client.get("/?separator=bl&count=10")
+      .as(BodyCodec.jsonStream(parser))
+      .send()
+      .onComplete(tc.asyncAssertSuccess());
   }
 
 }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/UriTemplateTest.java
@@ -90,7 +90,7 @@ public class UriTemplateTest extends WebClientTestBase {
       .setTemplateExpandOptions(new ExpandOptions()
         .setAllowVariableMiss(false)));
     HttpRequest<Buffer> request = webClient.get(template);
-    request.send(onFailure(err -> {
+    request.send().onComplete(onFailure(err -> {
       assertEquals(NoSuchElementException.class, err.getClass());
       testComplete();
     }));

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientSessionOauth2Test.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientSessionOauth2Test.java
@@ -106,14 +106,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     oauth2WebClient
       .withCredentials(oauthConfig)
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient.countDown();
+      }));
 
     awaitLatch(latchClient);
   }
@@ -155,14 +152,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     oauth2WebClient
       .withCredentials(oauthConfig)
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient.countDown();
+      }));
 
     awaitLatch(latchClient);
   }
@@ -181,13 +175,10 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
 
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          latchClient.countDown();
-        } else {
-          fail("Should require credentials");
-        }
-      });
+      .send()
+      .onComplete(onFailure(err -> {
+        latchClient.countDown();
+      }));
 
     awaitLatch(latchClient);
   }
@@ -237,14 +228,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
 
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient1.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient1.countDown();
+      }));
 
     awaitLatch(latchClient1);
     final CountDownLatch latchClient2 = new CountDownLatch(1);
@@ -252,14 +240,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     // again, but this time we should not get a token
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient2.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient2.countDown();
+      }));
 
     awaitLatch(latchClient2);
   }
@@ -309,14 +294,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
 
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient1.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient1.countDown();
+      }));
 
     // sleep so the user expires
     Thread.sleep(2000L);
@@ -327,14 +309,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     // again, but this time we should not get a token
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient2.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient2.countDown();
+      }));
 
     awaitLatch(latchClient2);
   }
@@ -389,14 +368,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
 
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient1.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient1.countDown();
+      }));
 
     // sleep so the user expires
     Thread.sleep(2000L);
@@ -407,14 +383,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     // again, but this time we should not get a token
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient2.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient2.countDown();
+      }));
 
     awaitLatch(latchClient2);
   }
@@ -464,14 +437,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
 
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient1.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient1.countDown();
+      }));
 
     // sleep so the user expires
     Thread.sleep(2000L);
@@ -482,14 +452,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     // again, but this time we should not get a token
     oauth2WebClient
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient2.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient2.countDown();
+      }));
 
     awaitLatch(latchClient2);
   }
@@ -539,14 +506,11 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     oauth2WebClient
       .withCredentials(oauthConfig)
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          assertEquals(200, result.result().statusCode());
-          latchClient.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        assertEquals(200, res.statusCode());
+        latchClient.countDown();
+      }));
 
     awaitLatch(latchClient);
   }
@@ -593,15 +557,12 @@ public class WebClientSessionOauth2Test extends WebClientTestBase {
     oauth2WebClient
       .withCredentials(oauthConfig)
       .get(8080, "localhost", "/protected/path")
-      .send(result -> {
-        if (result.failed()) {
-          fail(result.cause());
-        } else {
-          // this one will fail as we fail to refresh request after request
-          assertEquals(401, result.result().statusCode());
-          latchClient.countDown();
-        }
-      });
+      .send()
+      .onComplete(onSuccess(res -> {
+        // this one will fail as we fail to refresh request after request
+        assertEquals(401, res.statusCode());
+        latchClient.countDown();
+      }));
 
     awaitLatch(latchClient);
   }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -192,7 +192,7 @@ public class WebClientTest extends WebClientTestBase {
 
     WebClient agentFreeClient = WebClient.create(vertx, clientOptions);
     HttpRequest<Buffer> builder = agentFreeClient.post("somehost", "somepath");
-    builder.sendJson(payload, onSuccess(resp -> complete()));
+    builder.sendJson(payload).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -287,17 +287,12 @@ public class WebClientTest extends WebClientTestBase {
     webClient
       .get("http://checkip.amazonaws.com/")
       .proxy(new ProxyOptions().setPort(proxy.port()))
-      .send(ar -> {
-        if (ar.succeeded()) {
-          // Obtain response
-          HttpResponse<Buffer> response = ar.result();
-          assertEquals(200, response.statusCode());
-          assertEquals("http://checkip.amazonaws.com/", proxy.getLastUri());
-          testComplete();
-        } else {
-          fail(ar.cause());
-        }
-      });
+      .send()
+      .onComplete(onSuccess(response -> {
+        assertEquals(200, response.statusCode());
+        assertEquals("http://checkip.amazonaws.com/", proxy.getLastUri());
+        testComplete();
+      }));
     await();
   }
 
@@ -336,7 +331,7 @@ public class WebClientTest extends WebClientTestBase {
   @Test
   public void testConnectError() throws Exception {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
-    get.send(onFailure(err -> {
+    get.send().onComplete(onFailure(err -> {
       assertTrue(err instanceof ConnectException);
       complete();
     }));
@@ -357,7 +352,8 @@ public class WebClientTest extends WebClientTestBase {
     webClient
       .get(8080, "localhost", "/")
       .timeout(1)
-      .send(onFailure(err -> {
+      .send()
+      .onComplete(onFailure(err -> {
         testComplete();
       }));
     await();
@@ -406,7 +402,7 @@ public class WebClientTest extends WebClientTestBase {
             endHandler.set(handler);
             return this;
           }
-        }, onFailure(err -> {
+        }).onComplete(onFailure(err -> {
           // Should be a connection reset by peer or closed
 //          assertNotNull(endHandler.get());
 //          assertNotNull(dataHandler.get());
@@ -465,7 +461,7 @@ public class WebClientTest extends WebClientTestBase {
           public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
             return this;
           }
-        }, onFailure(err -> {
+        }).onComplete(onFailure(err -> {
           if (err instanceof StreamResetException && cause == err.getCause()) {
             complete();
           } else {
@@ -519,7 +515,7 @@ public class WebClientTest extends WebClientTestBase {
       public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
         return this;
       }
-    }, onFailure(err -> {
+    }).onComplete(onFailure(err -> {
       assertEquals(StreamResetException.class, err.getClass());
       assertSame(cause, err.getCause());
       complete();
@@ -533,11 +529,13 @@ public class WebClientTest extends WebClientTestBase {
     server.requestHandler(req -> req.response().end(expected));
     startServer();
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
-    get.send(onSuccess(resp -> {
-      assertEquals(200, resp.statusCode());
-      assertEquals(expected, resp.body());
-      testComplete();
-    }));
+    get
+      .send()
+      .onComplete(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        assertEquals(expected, resp.body());
+        testComplete();
+      }));
     await();
   }
 
@@ -599,7 +597,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.jsonArray())
-      .send(onSuccess(resp -> {
+      .send()
+      .onComplete(onSuccess(resp -> {
         assertEquals(200, resp.statusCode());
         assertEquals(expected, resp.body());
         testComplete();
@@ -640,7 +639,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.json(List.class))
-      .send(onSuccess(resp -> {
+      .send()
+      .onComplete(onSuccess(resp -> {
         assertEquals(200, resp.statusCode());
         assertEquals(expected.getList(), resp.body());
         testComplete();
@@ -679,7 +679,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(bodyCodec)
-      .send(checker);
+      .send()
+      .onComplete(checker);
     await();
   }
 
@@ -825,7 +826,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.pipe(stream, close))
-      .send(onSuccess(resp -> {
+      .send()
+      .onComplete(onSuccess(resp -> {
       assertEquals(close, ended.get());
       assertEquals(200, resp.statusCode());
       assertEquals(null, resp.body());
@@ -857,7 +859,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.pipe(stream))
-      .send(onFailure(err -> testComplete()));
+      .send()
+      .onComplete(onFailure(err -> testComplete()));
     assertWaitUntil(() -> received.get() == 2048);
     fail.complete(null);
     await();
@@ -888,7 +891,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.pipe(stream))
-      .send(onFailure(err -> {
+      .send()
+      .onComplete(onFailure(err -> {
       assertSame(cause, err);
       testComplete();
     }));
@@ -910,7 +914,9 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Void> request = get.as(BodyCodec.pipe(stream));
     assertNotNull(stream.exceptionHandler);
     stream.exceptionHandler.handle(cause);
-    request.send(onFailure(err -> {
+    request
+      .send()
+      .onComplete(onFailure(err -> {
       assertSame(cause, err);
       testComplete();
     }));
@@ -989,7 +995,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.pipe(file))
-      .send(onSuccess(v -> {
+      .send()
+      .onComplete(onSuccess(v -> {
         assertEquals(1024 * 1024, received.get());
         assertTrue(closed.get());
         testComplete();
@@ -1034,7 +1041,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(codec)
-      .send(onSuccess(resp -> {
+      .send()
+      .onComplete(onSuccess(resp -> {
       assertEquals(403, resp.statusCode());
       assertNull(resp.body());
       testComplete();
@@ -1053,7 +1061,8 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.jsonObject())
-      .send(onFailure(err -> {
+      .send()
+      .onComplete(onFailure(err -> {
       assertTrue(err instanceof VertxException);
       testComplete();
     }));
@@ -1066,7 +1075,10 @@ public class WebClientTest extends WebClientTestBase {
     server.requestHandler(req -> count.incrementAndGet());
     startServer();
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
-    get.timeout(50).send(onFailure(err -> {
+    get
+      .timeout(50)
+      .send()
+      .onComplete(onFailure(err -> {
       assertTrue(err instanceof TimeoutException);
       testComplete();
     }));
@@ -1131,7 +1143,7 @@ public class WebClientTest extends WebClientTestBase {
     MultiMap form = MultiMap.caseInsensitiveMultiMap();
     form.add("param1", "param1_value");
     HttpRequest<Buffer> builder = webClient.post("/somepath");
-    builder.sendForm(form, onSuccess(resp -> complete()));
+    builder.sendForm(form).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1151,7 +1163,7 @@ public class WebClientTest extends WebClientTestBase {
     MultiMap form = MultiMap.caseInsensitiveMultiMap();
     form.add("param1", str);
     HttpRequest<Buffer> builder = webClient.post("/somepath");
-    builder.sendForm(form, StandardCharsets.ISO_8859_1.name(), onSuccess(resp -> complete()));
+    builder.sendForm(form, StandardCharsets.ISO_8859_1.name()).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1170,7 +1182,7 @@ public class WebClientTest extends WebClientTestBase {
       .set("grant_type", "client_credentials")
       .set("resource", "https://management.core.windows.net/");
     HttpRequest<Buffer> builder = webClient.post("/somepath");
-    builder.sendForm(form, onSuccess(resp -> complete()));
+    builder.sendForm(form).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1188,7 +1200,7 @@ public class WebClientTest extends WebClientTestBase {
     form.add("param1", "param1_value");
     HttpRequest<Buffer> builder = webClient.post("/somepath");
     builder.putHeader("content-type", "multipart/form-data");
-    builder.sendForm(form, onSuccess(resp -> complete()));
+    builder.sendForm(form).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1206,7 +1218,7 @@ public class WebClientTest extends WebClientTestBase {
     form.add("param1", "param1_value");
     HttpRequest<Buffer> builder = webClient.post("/somepath");
     builder.putHeader("content-type", "multipart/form-data");
-    builder.sendForm(form, "ISO-8859-1", onSuccess(resp -> complete()));
+    builder.sendForm(form, "ISO-8859-1").onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1361,7 +1373,7 @@ public class WebClientTest extends WebClientTestBase {
 
     HttpRequest<Buffer> builder = webClient.post("somepath");
     builder.multipartMixed(multipartMixed);
-    builder.sendMultipartForm(form, onSuccess(resp -> complete()));
+    builder.sendMultipartForm(form).onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -1392,7 +1404,7 @@ public class WebClientTest extends WebClientTestBase {
     MultipartForm form = MultipartForm.create()
       .textFileUpload("file", "nonexistentFilename", "nonexistentPathname", "text/plain");
 
-    builder.sendMultipartForm(form, onFailure(err -> {
+    builder.sendMultipartForm(form).onComplete(onFailure(err -> {
       assertEquals(err.getClass(), HttpPostRequestEncoder.ErrorDataEncoderException.class);
       assertEquals(err.getCause().getClass(), FileNotFoundException.class);
       complete();
@@ -1409,7 +1421,7 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> builder = webClient.post("somepath");
     MultipartForm form = MultipartForm.create()
       .textFileUpload("file", "nonexistentFilename", "nonexistentPathname", "text/plain");
-    builder.sendMultipartForm(form, onFailure(err -> {
+    builder.sendMultipartForm(form).onComplete(onFailure(err -> {
       assertEquals(err.getClass(), HttpPostRequestEncoder.ErrorDataEncoderException.class);
       complete();
     }));
@@ -1458,7 +1470,7 @@ public class WebClientTest extends WebClientTestBase {
     if (set != null) {
       builder = builder.followRedirects(set);
     }
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       if (expect) {
         assertEquals(200, resp.statusCode());
         assertEquals("/ok", resp.body().toString());
@@ -1496,7 +1508,7 @@ public class WebClientTest extends WebClientTestBase {
     webClient.get("/redirect")
       .putHeader("foo", "bar")
       .followRedirects(true)
-      .send(onSuccess(resp -> {
+      .send().onComplete(onSuccess(resp -> {
         assertEquals(200, resp.statusCode());
         assertEquals("/ok", resp.body().toString());
         assertEquals(2, resp.followedRedirects().size());
@@ -1518,7 +1530,7 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> builder = webClient
       .post("/redirect")
       .followRedirects(true);
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(302, resp.statusCode());
       assertEquals("http://www.google.com", resp.getHeader("Location"));
       assertNull(resp.body());
@@ -1539,7 +1551,7 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> builder = webClient
       .get("/redirect")
       .followRedirects(true);
-    builder.send(onSuccess(resp -> {
+    builder.send().onComplete(onSuccess(resp -> {
       assertEquals(302, resp.statusCode());
       assertEquals(location, resp.getHeader("Location"));
       assertNull(resp.body());
@@ -1556,7 +1568,7 @@ public class WebClientTest extends WebClientTestBase {
     });
     startServer();
     HttpRequest<Buffer> req = webClient.get("/test").virtualHost("another-host");
-    req.send(onSuccess(resp -> testComplete()));
+    req.send().onComplete(onSuccess(resp -> testComplete()));
     await();
   }
 
@@ -1569,7 +1581,7 @@ public class WebClientTest extends WebClientTestBase {
     startServer();
     SocketAddress addr = SocketAddress.inetSocketAddress(8080, "localhost");
     HttpRequest<Buffer> req = webClient.request(HttpMethod.GET, addr, 8080, "another-host", "/test");
-    req.send(onSuccess(resp -> testComplete()));
+    req.send().onComplete(onSuccess(resp -> testComplete()));
     await();
   }
 
@@ -1733,7 +1745,7 @@ public class WebClientTest extends WebClientTestBase {
     try {
       startServer(sslServer);
       HttpRequest<Buffer> builder = requestProvider.apply(sslClient);
-      builder.send(onSuccess(resp -> testComplete()));
+      builder.send().onComplete(onSuccess(resp -> testComplete()));
       await();
     } finally {
       sslClient.close();
@@ -1752,18 +1764,13 @@ public class WebClientTest extends WebClientTestBase {
     options.setProxyOptions(new ProxyOptions().setPort(proxy.port()));
     WebClient client = WebClient.create(vertx, options);
     client
-    .get("ftp://ftp.gnu.org/gnu/")
-    .send(ar -> {
-      if (ar.succeeded()) {
-        // Obtain response
-        HttpResponse<Buffer> response = ar.result();
+      .get("ftp://ftp.gnu.org/gnu/")
+      .send()
+      .onComplete(onSuccess(response -> {
         assertEquals(200, response.statusCode());
         assertEquals("ftp://ftp.gnu.org/gnu/", proxy.getLastUri());
         testComplete();
-      } else {
-        fail(ar.cause());
-      }
-    });
+      }));
     await();
   }
 
@@ -1778,9 +1785,9 @@ public class WebClientTest extends WebClientTestBase {
     WebClient webClient = WebClient.create(vertx);
     try {
       server.requestHandler(req -> webClient.postAbs("http://localhost:8081/")
-        .sendStream(req, onSuccess(resp -> req.response().end("ok"))));
+        .sendStream(req).onComplete(onSuccess(resp -> req.response().end("ok"))));
       startServer();
-      webClient.post(8080, "localhost", "/").sendBuffer(expected, onSuccess(resp -> {
+      webClient.post(8080, "localhost", "/").sendBuffer(expected).onComplete(onSuccess(resp -> {
         assertEquals("ok", resp.bodyAsString());
         complete();
       }));
@@ -1995,7 +2002,7 @@ public class WebClientTest extends WebClientTestBase {
     HttpRequest<Buffer> request = webClient
       .get("/test");
     modifier.accept(request);
-    request.send(ar -> {
+    request.send().onComplete(ar -> {
       if (ar.succeeded()) {
         assertFalse("Expected response success", shouldFail);
       } else {
@@ -2106,7 +2113,7 @@ public class WebClientTest extends WebClientTestBase {
     });
     startServer();
     HttpRequest<Buffer> req = webClient.get("/test").addQueryParam("c:d", "e");
-    req.send(onSuccess(resp -> testComplete()));
+    req.send().onComplete(onSuccess(resp -> testComplete()));
     await();
   }
 
@@ -2118,7 +2125,7 @@ public class WebClientTest extends WebClientTestBase {
     });
     startServer();
     HttpRequest<Buffer> req = webClient.get("/test/?c:d=e");
-    req.send(onSuccess(resp -> testComplete()));
+    req.send().onComplete(onSuccess(resp -> testComplete()));
     await();
   }
 }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
@@ -83,8 +83,8 @@ public class WebClientTestBase extends HttpTestBase {
     });
     startServer();
     HttpRequest<Buffer> builder = reqFactory.apply(webClient);
-    builder.send(onSuccess(resp -> complete()));
-    builder.send(onSuccess(resp -> complete()));
+    builder.send().onComplete(onSuccess(resp -> complete()));
+    builder.send().onComplete(onSuccess(resp -> complete()));
     await();
   }
 
@@ -123,7 +123,7 @@ public class WebClientTestBase extends HttpTestBase {
       if (!chunked) {
         builder = builder.putHeader("Content-Length", "" + expected.length());
       }
-      builder.sendStream(asyncFile, onSuccess(resp -> {
+      builder.sendStream(asyncFile).onComplete(onSuccess(resp -> {
         assertEquals(200, resp.statusCode());
         complete();
       }));
@@ -135,7 +135,7 @@ public class WebClientTestBase extends HttpTestBase {
     server.requestHandler(req -> req.response().end(body));
     startServer();
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
-    get.send(checker);
+    get.send().onComplete(checker);
     await();
   }
 
@@ -149,11 +149,11 @@ public class WebClientTestBase extends HttpTestBase {
     startServer();
     HttpRequest<Buffer> post = webClient.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     if (body instanceof Buffer) {
-      post.sendBuffer((Buffer) body, onSuccess(resp -> complete()));
+      post.sendBuffer((Buffer) body).onComplete(onSuccess(resp -> complete()));
     } else if (body instanceof JsonObject) {
-      post.sendJsonObject((JsonObject) body, onSuccess(resp -> complete()));
+      post.sendJsonObject((JsonObject) body).onComplete(onSuccess(resp -> complete()));
     } else {
-      post.sendJson(body, onSuccess(resp -> complete()));
+      post.sendJson(body).onComplete(onSuccess(resp -> complete()));
     }
     await();
   }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/it/WebClientDatabindTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/it/WebClientDatabindTest.java
@@ -37,7 +37,7 @@ public class WebClientDatabindTest extends WebClientTestBase {
     HttpRequest<Buffer> get = webClient.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
     get
       .as(BodyCodec.json(WineAndCheese.class))
-      .send(onSuccess(resp -> {
+      .send().onComplete(onSuccess(resp -> {
         assertEquals(200, resp.statusCode());
         assertEquals(new WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.body());
         testComplete();


### PR DESCRIPTION
Draft for WebClient callback removals, this PR does 3 things:

1/ tests are updated to use futures instead of callbacks
2/ documentation cleanup which was still referring to callback API
3/ the codegen module declares future to true and the callbacks are removed from the API effectively

Commits 1/ and 2/ can be back-ported to Vert.x 4.4
