### PR TITLE
Check for computed content length before using chunked encoding

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -445,7 +445,7 @@ public class HttpContext<T> {
         requestPromise.future().onComplete(ar -> {
           if (ar.succeeded()) {
             HttpClientRequest req = ar.result();
-            if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
+            if (requestOptions.getHeaders() == null || !requestOptions.getHeaders().contains(HttpHeaders.CONTENT_LENGTH)) {
               req.setChunked(true);
             }
             pipe.endOnFailure(false);


### PR DESCRIPTION
Currently, the code only checks if content length has been set in the initial request, and ignores any content length computed from the request body. This means that when using form data (sendForm()), even though a content length is computed and added to requestOptions, the request itself will always be sent in chunked mode unless content-length was added to the request earlier (even with an incorrect value).

Changing to requestOptions.getHeaders() will check for both initially set content length and computed content length when encoding form data.