### PR TITLE
Encrypt instead of sign: cookie store

### DIFF
--- a/vertx-web-session-stores/vertx-web-sstore-cookie/pom.xml
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/pom.xml
@@ -36,6 +36,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/CookieSessionStore.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/CookieSessionStore.java
@@ -17,15 +17,13 @@ package io.vertx.ext.web.sstore.cookie;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.ext.web.sstore.cookie.impl.CookieSessionStoreImpl;
 
 /**
  * A SessionStore that uses a Cookie to store the session data. All data is stored in
- * plain sight and signed using a HMAC using the given secret.
- *
- * The signature ensures that the cookie payload is not tampered when returning from
- * the user agent (browser) back to the server.
+ * encrypted form using {@code AES-256 with AES/CBC/PKCS5Padding}.
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
@@ -35,15 +33,16 @@ public interface CookieSessionStore extends SessionStore {
   /**
    * Creates a CookieSessionStore.
    *
-   * Cookie data will be signed using the given secret. The secret as the name
+   * Cookie data will be encrypted using the given secret and salt. The secret as the name
    * reflects, should never leave the server, otherwise user agents could tamper
-   * with the payload.
+   * with the payload. The salt adds an extra later of security and should be a random.
    *
    * @param vertx a vert.x instance
-   * @param secret a secret to feed the HMAC algorithm
+   * @param secret a secret to derive a secure private key
+   * @param salt a binary salt used in the key derivation
    * @return the store
    */
-  static CookieSessionStore create(Vertx vertx, String secret) {
-    return new CookieSessionStoreImpl(vertx, secret);
+  static CookieSessionStore create(Vertx vertx, String secret, Buffer salt) {
+    return new CookieSessionStoreImpl(vertx, secret, salt);
   }
 }

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/impl/CookieSession.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/impl/CookieSession.java
@@ -19,7 +19,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.auth.prng.VertxContextPRNG;
 import io.vertx.ext.web.sstore.AbstractSession;
 
-import javax.crypto.Mac;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -33,20 +35,23 @@ public class CookieSession extends AbstractSession {
 
   private static final Charset UTF8 = StandardCharsets.UTF_8;
 
-  private final Mac mac;
+  private final Cipher encrypt;
+  private final Cipher decrypt;
   // track the original version
   private int oldVersion = 0;
   // track the original crc
   private int oldCrc = 0;
 
-  public CookieSession(Mac mac, VertxContextPRNG prng, long timeout, int length) {
+  public CookieSession(Cipher encrypt, Cipher decrypt, VertxContextPRNG prng, long timeout, int length) {
     super(prng, timeout, length);
-    this.mac = mac;
+    this.encrypt = encrypt;
+    this.decrypt = decrypt;
   }
 
-  public CookieSession(Mac mac, VertxContextPRNG prng) {
+  public CookieSession(Cipher encrypt, Cipher decrypt, VertxContextPRNG prng) {
     super(prng);
-    this.mac = mac;
+    this.encrypt = encrypt;
+    this.decrypt = decrypt;
   }
 
   @Override
@@ -61,10 +66,11 @@ public class CookieSession extends AbstractSession {
     buff.appendInt(version());
     writeDataToBuffer(buff);
 
-    String b64 = base64UrlEncode(buff.getBytes());
-    String signature = base64UrlEncode(mac.doFinal(b64.getBytes(StandardCharsets.US_ASCII)));
-
-    return b64 + "." + signature;
+    try {
+      return base64UrlEncode(encrypt.doFinal(buff.getBytes()));
+    } catch (IllegalBlockSizeException | BadPaddingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -84,39 +90,44 @@ public class CookieSession extends AbstractSession {
       throw new NullPointerException();
     }
 
-    String[] tokens = payload.split("\\.");
-    if (tokens.length != 2) {
-      // no signature present, force a regeneration
-      // by claiming this session as invalid
+//    String[] tokens = payload.split("\\.");
+//    if (tokens.length != 2) {
+//      // no signature present, force a regeneration
+//      // by claiming this session as invalid
+//      return null;
+//    }
+//
+//    String signature = base64UrlEncode(mac.doFinal(tokens[0].getBytes(StandardCharsets.US_ASCII)));
+//
+//    if(!signature.equals(tokens[1])) {
+//      throw new RuntimeException("Session data was Tampered!");
+//    }
+
+    try {
+      final Buffer buffer = Buffer.buffer(decrypt.doFinal(base64UrlDecode(payload)));
+
+      // reconstruct the session
+      int pos = 0;
+      int len = buffer.getInt(0);
+      pos += 4;
+      byte[] bytes = buffer.getBytes(pos, pos + len);
+      pos += len;
+      setId(new String(bytes, UTF8));
+      setTimeout(buffer.getLong(pos));
+      pos += 8;
+      setLastAccessed(buffer.getLong(pos));
+      pos += 8;
+      setVersion(buffer.getInt(pos));
+      pos += 4;
+      readDataFromBuffer(pos, buffer);
+
+      // defaults
+      oldVersion = version();
+      oldCrc = crc();
+    } catch (IllegalBlockSizeException | BadPaddingException e) {
+      // this is a bad session, force a regeneration
       return null;
     }
-
-    String signature = base64UrlEncode(mac.doFinal(tokens[0].getBytes(StandardCharsets.US_ASCII)));
-
-    if(!signature.equals(tokens[1])) {
-      throw new RuntimeException("Session data was Tampered!");
-    }
-
-    final Buffer buffer = Buffer.buffer(base64UrlDecode(tokens[0]));
-
-    // reconstruct the session
-    int pos = 0;
-    int len = buffer.getInt(0);
-    pos += 4;
-    byte[] bytes = buffer.getBytes(pos, pos + len);
-    pos += len;
-    setId(new String(bytes, UTF8));
-    setTimeout(buffer.getLong(pos));
-    pos += 8;
-    setLastAccessed(buffer.getLong(pos));
-    pos += 8;
-    setVersion(buffer.getInt(pos));
-    pos += 4;
-    readDataFromBuffer(pos, buffer);
-
-    // defaults
-    oldVersion = version();
-    oldCrc = crc();
 
     return this;
   }

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/impl/CookieSessionStoreImpl.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/impl/CookieSessionStoreImpl.java
@@ -71,7 +71,14 @@ public class CookieSessionStoreImpl implements CookieSessionStore {
 
     try {
       byte[] iv = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-      random.nextBytes(iv);
+      if (options.containsKey("iv")) {
+        byte[] tmp = options.getBinary("iv");
+        for (int i = 0; i < tmp.length && i < iv.length; i++) {
+          iv[i] = tmp[i];
+        }
+      } else {
+        random.nextBytes(iv);
+      }
       IvParameterSpec ivspec = new IvParameterSpec(iv);
 
       SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/CookieSessionCreateTest.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/CookieSessionCreateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.sstore.cookie;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.sstore.SessionStore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class CookieSessionCreateTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  public void testCreateStoreAll() throws Exception {
+    SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!").put("salt", "salt").put("iv", "iv"));
+    assertNotNull(store);
+    assertTrue(store instanceof CookieSessionStore);
+  }
+
+  @Test
+  public void testCreateStoreNoIV() throws Exception {
+    SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!").put("salt", "salt"));
+    assertNotNull(store);
+    assertTrue(store instanceof CookieSessionStore);
+  }
+
+  @Test
+  public void testCreateStoreNoSalt() throws Exception {
+    SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!"));
+    assertNotNull(store);
+    // salt is missing, default to LocalStore as we don't want to leak session data if config isn't complete
+    assertFalse(store instanceof CookieSessionStore);
+  }
+}

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/CookieSessionHandlerTest.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/CookieSessionHandlerTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.sstore.cookie;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
@@ -33,7 +34,7 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    store = CookieSessionStore.create(vertx, "KeyboardCat!");
+    store = CookieSessionStore.create(vertx, "KeyboardCat!", Buffer.buffer("salt"));
   }
 
   @Test

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1090,8 +1090,7 @@ Here are some examples of creating a clustered {@link io.vertx.ext.web.sstore.Se
 Other stores are also available, these stores can be used by importing the correct jar
 to the project. One example of such stores is the cookie store. This store has the advantage
 that it requires no backend or server side state, which can be useful it some situations
-**BUT** all session data will be sent back to the client in the Cookie, so if you need to store
-private information this should not be used.
+**BUT** all session data will be sent back to the client in the **encrypted** Cookie, so if you need to store private information this should not be used.
 
 This store is appropriate if you're using sticky sessions, i.e. your load balancer is
 distributing different requests from the same browser to different servers.


### PR DESCRIPTION
Motivation:

The Cookie store was used as a template to create other stores, given that some users are asking to use it in prod, for 5.0.0 the recommended way is to have the content, not signed, but encrypted.

Signed was proving non repudiation and tampering, encryption adds non-disclosure to the implementation.