### PR TITLE
Re-create the old PR to align with the new API

### DIFF
--- a/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/RouteToEBServiceHandler.java
+++ b/vertx-web-api-contract/src/main/java/io/vertx/ext/web/api/contract/impl/RouteToEBServiceHandler.java
@@ -1,10 +1,8 @@
 package io.vertx.ext.web.api.contract.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -52,7 +50,7 @@ public class RouteToEBServiceHandler implements Handler<RoutingContext> {
     return new JsonObject().put("context", new OperationRequest(
       ((RequestParameters)context.get("parsedParameters")).toJson(),
       context.request().headers(),
-      (context.user() != null) ? context.user().principal() : null,
+      (context.user().get() != null) ? context.user().get().principal() : null,
       (this.extraOperationContextPayloadMapper != null) ? this.extraOperationContextPayloadMapper.apply(context) : null
     ).toJson());
   }

--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
@@ -1,11 +1,9 @@
 package io.vertx.ext.web.api.service.impl;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.MultiMap;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -75,7 +73,7 @@ public class RouteToEBServiceHandlerImpl implements RouteToEBServiceHandler {
 
   private JsonObject buildPayload(RoutingContext context) {
     JsonObject params = context.get("parsedParameters") != null ? ((RequestParameters)context.get("parsedParameters")).toJson() : null;
-    User user = context.user();
+    User user = context.user().get();
     return new JsonObject().put("context", new ServiceRequest(
       params,
       context.request().headers(),

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/RouteToEBServiceHandlerTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/RouteToEBServiceHandlerTest.java
@@ -10,8 +10,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.impl.UserContextInternal;
 import io.vertx.ext.web.validation.BaseValidationHandlerTest;
-import io.vertx.ext.web.validation.ValidationHandler;
 import io.vertx.ext.web.validation.builder.ValidationHandlerBuilder;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -160,7 +160,7 @@ public class RouteToEBServiceHandlerTest extends BaseValidationHandlerTest {
       .handler(
         ValidationHandlerBuilder.create(parser).build()
       ).handler(rc -> {
-        rc.setUser(User.fromName("slinkydeveloper")); // Put user mock into context
+        ((UserContextInternal) rc.user()).setUser(User.fromName("slinkydeveloper")); // Put user mock into context
         rc.next();
       })
       .handler(

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalTest.java
@@ -46,7 +46,7 @@ class RouterBuilderSecurityOptionalTest extends RouterBuilderTestBase {
         .apiKeyHandler(APIKeyHandler.create(authProvider));
 
       rb.getRoute("pets")
-        .addHandler(ctx -> ctx.json(ctx.user().principal()));
+        .addHandler(ctx -> ctx.json(ctx.user().get().principal()));
 
       return Future.succeededFuture(rb);
     })

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1199,7 +1199,7 @@ make sure your authentication handler is before your application handlers on tho
 ----
 
 If the authentication handler has successfully authenticated the user it will inject a {@link io.vertx.ext.auth.User}
-object into the {@link io.vertx.ext.web.RoutingContext} so it's available in your handlers with:
+object into the {@link io.vertx.ext.web.UserContext} so it's available in your handlers from the routing context:
 {@link io.vertx.ext.web.RoutingContext#user()}.
 
 If you want your User object to be stored in the session so it's available between requests so you don't have to
@@ -1207,8 +1207,8 @@ authenticate on each request, then you should make sure you have a session handl
 
 Once you have your user object you can also programmatically use the methods on it to authorize the user.
 
-If you want to cause the user to be logged out you can call {@link io.vertx.ext.web.RoutingContext#clearUser()}
-on the routing context.
+If you want to cause the user to be logged out you can call {@link io.vertx.ext.web.UserContext#logout()}
+on the routing context `user` getter. The logout will remove the user from the session if there is one and perform a redirect to an optional uri or `/` by default.
 
 === HTTP Basic Authentication
 

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1368,6 +1368,38 @@ Complex chaining is also possible, for example, building logic sequences such as
 {@link examples.WebExamples#example78}
 ----
 
+=== Impersonation
+
+When using authentication handlers, it is possible that the identity of the user changes over time. For
+example, a user may require to become `admin` for a specific period of time. This can be achieved by calling:
+
+[source,$lang]
+----
+{@link examples.WebExamples#example89}
+----
+
+The operation can be reversed by calling:
+
+[source,$lang]
+----
+{@link examples.WebExamples#example90}
+----
+
+The impersonation does not require calling other router endpoints to avoid being exploited from the outside.
+
+=== Refreshing identities
+
+There are times when a critical operation may require attestation of the presence of the user. While this
+attestation is complex, we can achieve this by refreshing the identity of the user. This can be achieved by calling:
+
+[source,$lang]
+----
+{@link examples.WebExamples#example91}
+----
+
+This will require the user to authenticate again to confirm the identity.
+
+
 == Security Auditing
 
 Vert.x-Web comes with an out of the box handler for auditing security events. This handler is useful for logging to an external system like EDR/XDR. EDR stands for Endpoint Detection and Response and XDR stands for Extended Detection and Response. These are security products that are used to detect and respond to threats on endpoints. The handler is called `SecurityAuditLoggerHandler` and it used as a top level handler as:

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -1968,6 +1968,38 @@ public class WebExamples {
       });
   }
 
+  public void example89(Router router) {
+    router
+      .route("/high/security/route/check")
+      .handler(ctx -> {
+        // if the user isn't admin, we ask the user to login again as admin
+        ctx
+          .identity()
+          .loginHint("admin")
+          .impersonate();
+      });
+  }
+
+  public void example90(Router router) {
+    router
+      .route("/high/security/route/back/to/me")
+      .handler(ctx -> {
+        ctx
+          .identity()
+          .undo();
+      });
+  }
+
+  public void example91(Router router) {
+    router
+      .route("/high/security/route/refresh/me")
+      .handler(ctx -> {
+        ctx
+          .identity()
+          .refresh();
+      });
+  }
+
   public void example88(Router router) {
     router.route()
       .handler(SecurityAuditLoggerHandler.create());

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -825,7 +825,7 @@ public class WebExamples {
       // This will require a login
 
       // This will have the value true
-      boolean isAuthenticated = ctx.user() != null;
+      boolean isAuthenticated = ctx.user().authenticated();
 
     });
   }
@@ -859,7 +859,7 @@ public class WebExamples {
         // This will require a login
 
         // This will have the value true
-        boolean isAuthenticated = ctx.user() != null;
+        boolean isAuthenticated = ctx.user().authenticated();
 
       });
 
@@ -1256,8 +1256,8 @@ public class WebExamples {
   public void example53(Vertx vertx) {
 
     Handler<RoutingContext> handler = ctx -> {
-      String theSubject = ctx.user().principal().getString("sub");
-      String someKey = ctx.user().principal().getString("someKey");
+      String theSubject = ctx.user().get().principal().getString("sub");
+      String someKey = ctx.user().get().principal().getString("someKey");
     };
   }
 
@@ -1483,7 +1483,7 @@ public class WebExamples {
       // at this moment your user object should contain the info
       // from the Oauth2 response, since this is a protected resource
       // as specified above in the handler config the user object is never null
-      User user = ctx.user();
+      User user = ctx.user().get();
       // just dump it to the client for demo purposes
       ctx.response().end(user.toString());
     });
@@ -1974,7 +1974,7 @@ public class WebExamples {
       .handler(ctx -> {
         // if the user isn't admin, we ask the user to login again as admin
         ctx
-          .identity()
+          .user()
           .loginHint("admin")
           .impersonate();
       });
@@ -1985,8 +1985,8 @@ public class WebExamples {
       .route("/high/security/route/back/to/me")
       .handler(ctx -> {
         ctx
-          .identity()
-          .undo();
+          .user()
+          .restore();
       });
   }
 
@@ -1995,7 +1995,7 @@ public class WebExamples {
       .route("/high/security/route/refresh/me")
       .handler(ctx -> {
         ctx
-          .identity()
+          .user()
           .refresh();
       });
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -24,7 +24,6 @@ import io.vertx.core.http.impl.MimeMapping;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.impl.Utils;
 
@@ -220,16 +219,11 @@ public interface RoutingContext {
   boolean isSessionAccessed();
 
   /**
-   * Get the authenticated user (if any). This will usually be injected by an auth handler if authentication if successful.
-   * @return  the user, or null if the current user is not authenticated.
+   * Control the user associated with this request. The user context allows accessing the security user object as well
+   * as perform authentication refreshes, logout and other operations.
+   * @return the user context
    */
-  @Nullable User user();
-
-  /**
-   * Control the identity associated with this request.
-   * @return the identity control
-   */
-  WebIdentity identity();
+  UserContext user();
 
   /**
    * If the context is being routed to failure handlers after a failure has been triggered by calling
@@ -335,19 +329,6 @@ public interface RoutingContext {
    * @return true if the context is being routed to failure handlers.
    */
   boolean failed();
-
-  /**
-   * Set the user. Usually used by auth handlers to inject a User. You will not normally call this method.
-   *
-   * @param user  the user
-   */
-  void setUser(User user);
-
-  /**
-   * Clear the current user object in the context. This usually is used for implementing a log out feature, since the
-   * current user is unbounded from the routing context.
-   */
-  void clearUser();
 
   /**
    * Set the acceptable content type. Used by

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -226,6 +226,12 @@ public interface RoutingContext {
   @Nullable User user();
 
   /**
+   * Control the identity associated with this request.
+   * @return the identity control
+   */
+  WebIdentity identity();
+
+  /**
    * If the context is being routed to failure handlers after a failure has been triggered by calling
    * {@link #fail(Throwable)} then this will return that throwable. It can be used by failure handlers to render a response,
    * e.g. create a failure response page.

--- a/vertx-web/src/main/java/io/vertx/ext/web/WebIdentity.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/WebIdentity.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.web;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+
+/**
+ * Represents a WebIdentity. A web identity is coupled to the context user and is used to perform verifications
+ * and actions on behalf of the user. Actions can be:
+ *
+ * <ul>
+ *   <li>{@link  #refresh()} - Require a re-authentication to confirm the user is present</li>
+ *   <li>{@link  #impersonate()} - Require a re-authentication to switch user identities</li>
+ *   <li>{@link  #undo()} - De-escalate a previous impersonate call</li>
+ * </ul>
+ */
+@VertxGen
+public interface WebIdentity {
+
+  /**
+   * When performing a web identity operation, hint if possible to the identity provider to use the given login.
+   * @param loginHint the desired login name, for example: {@code admin}.
+   * @return fluent self
+   */
+  @Fluent
+  WebIdentity loginHint(String loginHint);
+
+  /**
+   * Forces the current user to re-authenticate. The user will be redirected to the same origin where this call was
+   * made. It is important to notice that the redirect will only allow sources originating from a HTTP GET request.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> refresh();
+
+  /**
+   * Forces the current user to re-authenticate. The user will be redirected to the given uri. It is important to
+   * notice that the redirect will only allow targets using an HTTP GET request.
+   *
+   * @param redirectUri the uri to redirect the user to after the re-authentication.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> refresh(String redirectUri);
+
+  /**
+   * Impersonates a second identity. The user will be redirected to the same origin where this call was
+   * made. It is important to notice that the redirect will only allow sources originating from a HTTP GET request.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> impersonate();
+
+  /**
+   * Impersonates a second identity. The user will be redirected to the given uri. It is important to
+   * notice that the redirect will only allow targets using an HTTP GET request.
+   *
+   * @param redirectUri the uri to redirect the user to after the authentication.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> impersonate(String redirectUri);
+
+  /**
+   *  Undo a previous call to a impersonation. The user will be redirected to the same origin where this call was
+   * made. It is important to notice that the redirect will only allow sources originating from a HTTP GET request.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> undo();
+
+  /**
+   * Undo a previous call to an impersonation. The user will be redirected to the given uri. It is important to
+   * notice that the redirect will only allow targets using an HTTP GET request.
+   *
+   * @param redirectUri the uri to redirect the user to after the re-authentication.
+   *
+   * @return future result of the operation.
+   */
+  Future<Void> undo(String redirectUri);
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
@@ -22,6 +22,7 @@ import io.vertx.ext.auth.otp.hotp.HotpAuth;
 import io.vertx.ext.auth.otp.totp.TotpAuth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.UserContext;
 import io.vertx.ext.web.handler.impl.HotpAuthHandlerImpl;
 import io.vertx.ext.web.handler.impl.TotpAuthHandlerImpl;
 
@@ -54,7 +55,7 @@ public interface OtpAuthHandler extends AuthenticationHandler {
   /**
    * Specify the URL where requests are to be redirected when a user is already known in the request.
    *
-   * A user is already known when the {@link RoutingContext#user()} is not {@code null}.
+   * A user is already known when the {@link UserContext#get()} is not {@code null}.
    *
    * If no redirect is provided, requests are terminated immediately with status code {@code 401}.
    *
@@ -68,7 +69,7 @@ public interface OtpAuthHandler extends AuthenticationHandler {
    * Setup the optional route where authenticators are allowed to register. Registration is only allowed on requests with
    * a valid user.
    *
-   * A user is valid when the {@link RoutingContext#user()} is not {@code null}.
+   * A user is valid when the {@link UserContext#get()} is not {@code null}.
    *
    * @param route the location where users are to register new authenticator devices/apps.
    * @return fluent self.
@@ -80,7 +81,7 @@ public interface OtpAuthHandler extends AuthenticationHandler {
    * Setup the required route where authenticators to submit the challenge response. Challenges
    * are only allowed on requests with a valid user.
    *
-   * A user is valid when the {@link RoutingContext#user()} is not {@code null}.
+   * A user is valid when the {@link UserContext#get()} is not {@code null}.
    *
    * @param route the location where users are to submit challenge responses from authenticator devices/apps.
    * @return fluent self.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
@@ -55,10 +55,11 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
 
   @Override
   public void handle(RoutingContext ctx) {
-    final User user = ctx.user();
-    if (user == null) {
+    if (!ctx.user().authenticated()) {
       ctx.fail(FORBIDDEN_CODE, FORBIDDEN_EXCEPTION);
     } else {
+      final User user = ctx.user().get();
+
       try {
         // this handler can perform asynchronous operations
         if (!ctx.request().isEnded()) {
@@ -126,7 +127,7 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
       AuthorizationProvider provider = providers.next();
       // we haven't fetched authorization from this provider yet
       if (!user.authorizations().contains(provider.getId())) {
-        provider.getAuthorizations(ctx.user())
+        provider.getAuthorizations(user)
           .onFailure(err -> {
             LOG.warn("An error occurred getting authorization - providerId: " + provider.getId(), err);
             // note that we don't 'record' the fact that we tried to fetch the authorization provider. therefore, it will be re-fetched later-on

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
@@ -97,7 +97,7 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
    * @param providers            the providers iterator
    */
   private void checkOrFetchAuthorizations(RoutingContext ctx, AuthorizationContext authorizationContext, Iterator<AuthorizationProvider> providers) {
-    final User user = ctx.user();
+    final User user = ctx.user().get();
     final SecurityAudit audit = ((RoutingContextInternal) ctx).securityAudit();
     audit.authorization(authorization);
     audit.user(user);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
@@ -60,7 +60,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       return Future.failedFuture(new HttpException(500, new IllegalStateException("No callback mounted!")));
     }
 
-    final User user = ctx.user();
+    final User user = ctx.user().get();
 
     if (user == null) {
       return Future.failedFuture(new HttpException(401));
@@ -144,7 +144,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user();
+        final User user = ctx.user().get();
         if (user == null || user.get("username") == null) {
           ctx.fail(new IllegalStateException("User object misses 'username' attribute"));
           return;
@@ -168,7 +168,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user();
+        final User user = ctx.user().get();
         if (user == null || user.get("username") == null) {
           ctx.fail(new IllegalStateException("User object misses 'username' attribute"));
           return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -108,7 +108,7 @@ public class JWTAuthHandlerImpl extends HTTPAuthorizationHandler<JWTAuth> implem
    */
   @Override
   public void postAuthentication(RoutingContext ctx) {
-    final User user = ctx.user();
+    final User user = ctx.user().get();
     if (user == null) {
       // bad state
       ctx.fail(403, new IllegalStateException("no user in the context"));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -42,6 +42,7 @@ import io.vertx.ext.web.handler.OAuth2AuthHandler;
 import io.vertx.ext.web.impl.OrderListener;
 import io.vertx.ext.web.impl.Origin;
 import io.vertx.ext.web.impl.RoutingContextInternal;
+import io.vertx.ext.web.impl.UserContextInternal;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -329,7 +330,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
   public void postAuthentication(RoutingContext ctx) {
     // the user is authenticated, however the user may not have all the required scopes
     if (scopes != null && scopes.size() > 0) {
-      final User user = ctx.user();
+      final User user = ctx.user().get();
       if (user == null) {
         // bad state
         ctx.fail(403, new IllegalStateException("no user in the context"));
@@ -494,7 +495,8 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
         .andThen(op -> audit.audit(Marker.AUTHENTICATION, op.succeeded()))
         .onFailure(ctx::fail)
         .onSuccess(user -> {
-          ctx.setUser(user);
+          ((UserContextInternal) ctx.user())
+            .setUser(user);
           String location = resource != null ? resource : "/";
           if (session != null) {
             // the user has upgraded from unauthenticated to authenticated

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SecurityAuditLoggerHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SecurityAuditLoggerHandlerImpl.java
@@ -19,14 +19,25 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.auth.audit.Marker;
 import io.vertx.ext.auth.audit.SecurityAudit;
+import io.vertx.ext.auth.audit.impl.SecurityAuditLogger;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.SecurityAuditLoggerHandler;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 public class SecurityAuditLoggerHandlerImpl implements SecurityAuditLoggerHandler {
+
+  public SecurityAuditLoggerHandlerImpl() {
+    if (!SecurityAuditLogger.isEnabled()) {
+      throw new IllegalStateException("Security audit logger is not enabled. Please check your logging configuration.");
+    }
+  }
+
   @Override
   public void handle(RoutingContext ctx) {
-    final SecurityAudit audit = ((RoutingContextInternal) ctx).securityAudit();
+    // the audit preserves state during the request, so it needs
+    // a new instance per request
+    final SecurityAudit audit = SecurityAudit.create();
+    ((RoutingContextInternal) ctx).setSecurityAudit(audit);
 
     final HttpServerRequest req = ctx.request();
     final HttpServerResponse res = ctx.response();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -28,6 +28,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.impl.RoutingContextInternal;
+import io.vertx.ext.web.impl.UserContextInternal;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.ext.web.sstore.impl.SessionInternal;
 
@@ -170,7 +171,7 @@ public class SessionHandlerImpl implements SessionHandler {
         Boolean storeUser = context.get(SESSION_STOREUSER_KEY);
         if (storeUser != null && storeUser) {
           // during the request the user might have been removed
-          if (context.user() != null) {
+          if (context.user().get() != null) {
             session.put(SESSION_USER_HOLDER_KEY, new UserHolder(context));
           }
         }
@@ -346,11 +347,13 @@ public class SessionHandlerImpl implements SessionHandler {
     return session;
   }
 
+  @Override
   public Future<Void> setUser(RoutingContext context, User user) {
     if (!cookieless) {
       context.response().removeCookie(sessionCookieName, false);
     }
-    context.setUser(user);
+    ((UserContextInternal) context.user())
+      .setUser(user);
     // signal we must store the user to link it to the session
     context.put(SESSION_STOREUSER_KEY, true);
     return flush(context, true, true);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -259,6 +259,15 @@ public class SessionHandlerImpl implements SessionHandler {
 
   @Override
   public void handle(RoutingContext context) {
+
+    // we need to keep state since we can be called again on reroute
+    if (!((RoutingContextInternal) context).seenHandler(RoutingContextInternal.SESSION_HANDLER)) {
+      ((RoutingContextInternal) context).visitHandler(RoutingContextInternal.SESSION_HANDLER);
+    } else {
+      context.next();
+      return;
+    }
+
     HttpServerRequest request = context.request();
     if (nagHttps && LOG.isDebugEnabled()) {
       String uri = request.absoluteURI();

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
@@ -60,7 +60,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       return Future.failedFuture(new HttpException(500, new IllegalStateException("No callback mounted!")));
     }
 
-    final User user = ctx.user();
+    final User user = ctx.user().get();
 
     if (user == null) {
       return Future.failedFuture(new HttpException(401));
@@ -81,7 +81,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
           return Future.failedFuture(new HttpException(302, verifyUrl));
         }
       } else {
-        return Future.succeededFuture(ctx.user());
+        return Future.succeededFuture(user);
       }
     }
   }
@@ -142,7 +142,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user();
+        final User user = ctx.user().get();
         if (user == null || user.get("username") == null) {
           ctx.fail(new IllegalStateException("User object misses 'username' attribute"));
           return;
@@ -166,7 +166,8 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user();
+        final User user = ctx.user().get();
+
         if (user == null || user.get("username") == null) {
           ctx.fail(new IllegalStateException("User object misses 'username' attribute"));
           return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
@@ -21,6 +21,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.UserContextInternal;
 import io.vertx.ext.web.impl.Utils;
 
 import java.nio.charset.StandardCharsets;
@@ -45,12 +46,13 @@ public class UserHolder implements ClusterSerializable {
   public synchronized void refresh(RoutingContext context) {
     if (this.context != null) {
       // this is a new object instance or already refreshed
-      user = this.context.user();
+      user = this.context.user().get();
     }
     // refresh the context
     this.context = context;
     if (user != null) {
-      this.context.setUser(user);
+      ((UserContextInternal) this.context.user())
+        .setUser(user);
     }
   }
 
@@ -60,7 +62,7 @@ public class UserHolder implements ClusterSerializable {
     final User user;
 
     synchronized (this) {
-      user = context != null ? context.user() : this.user;
+      user = context != null ? context.user().get() : this.user;
       // clear the context as this holder is not in a request anymore
       context = null;
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
@@ -126,6 +126,6 @@ public abstract class SockJSSocketBase implements SockJSSocket {
 
   @Override
   public User webUser() {
-    return routingContext.user();
+    return routingContext.user().get();
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -195,6 +195,11 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
+  public WebIdentity identity() {
+    return decoratedContext.identity();
+  }
+
+  @Override
   public Session session() {
     return decoratedContext.session();
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -265,6 +265,11 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
+  public void setSecurityAudit(SecurityAudit securityAudit) {
+    decoratedContext.setSecurityAudit(securityAudit);
+  }
+
+  @Override
   public SecurityAudit securityAudit() {
     return decoratedContext.securityAudit();
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -190,13 +190,8 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
-  public User user() {
+  public UserContext user() {
     return decoratedContext.user();
-  }
-
-  @Override
-  public WebIdentity identity() {
-    return decoratedContext.identity();
   }
 
   @Override
@@ -272,16 +267,6 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   @Override
   public SecurityAudit securityAudit() {
     return decoratedContext.securityAudit();
-  }
-
-  @Override
-  public void setUser(User user) {
-    decoratedContext.setUser(user);
-  }
-
-  @Override
-  public void clearUser() {
-    decoratedContext.clearUser();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -66,8 +66,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
   private List<FileUpload> fileUploads;
   private Session session;
-  private User user;
-  private WebIdentity identity;
+  private UserContext identity;
 
   private volatile boolean isSessionAccessed = false;
   private volatile boolean endHandlerCalled = false;
@@ -304,26 +303,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   }
 
   @Override
-  public User user() {
-    return user;
-  }
-
-  @Override
-  public WebIdentity identity() {
+  public UserContext user() {
     if (identity == null) {
-      identity = new WebIdentityImpl(this);
+      identity = new UserContextImpl(this);
     }
     return identity;
-  }
-
-  @Override
-  public void setUser(User user) {
-    this.user = user;
-  }
-
-  @Override
-  public void clearUser() {
-    this.user = null;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -25,10 +25,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.web.RequestBody;
-import io.vertx.ext.web.FileUpload;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.Session;
+import io.vertx.ext.web.*;
 import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.handler.impl.UserHolder;
 
@@ -70,6 +67,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private List<FileUpload> fileUploads;
   private Session session;
   private User user;
+  private WebIdentity identity;
 
   private volatile boolean isSessionAccessed = false;
   private volatile boolean endHandlerCalled = false;
@@ -308,6 +306,14 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   @Override
   public User user() {
     return user;
+  }
+
+  @Override
+  public WebIdentity identity() {
+    if (identity == null) {
+      identity = new WebIdentityImpl(this);
+    }
+    return identity;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.auth.audit.SecurityAudit;
+import io.vertx.ext.auth.audit.impl.SecurityAuditNOOP;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -29,6 +30,7 @@ import io.vertx.ext.web.handler.HttpException;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -61,7 +63,7 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   // internal runtime state
   private volatile long seen;
   // immutable security audit
-  private final SecurityAudit securityAudit;
+  private SecurityAudit securityAudit;
 
   protected Set<HttpMethod> allowedMethods = new HashSet<>();
 
@@ -69,7 +71,7 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
     this.mountPoint = mountPoint;
     this.routes = routes;
     this.iter = routes.iterator();
-    this.securityAudit = SecurityAudit.create();
+    this.securityAudit = SecurityAuditNOOP.INSTANCE;
 
     this.currentRouter = currentRouter;
     resetMatchFailure();
@@ -94,6 +96,12 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
   @Override
   public boolean normalizedMatch() {
     return normalizedMatch;
+  }
+
+  @Override
+  public void setSecurityAudit(SecurityAudit securityAudit) {
+    Objects.requireNonNull(securityAudit, "SecurityAudit cannot be null");
+    this.securityAudit = securityAudit;
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
@@ -111,4 +111,9 @@ public interface RoutingContextInternal extends RoutingContext {
    * Get or Default the security audit object.
    */
   SecurityAudit securityAudit();
+
+  /**
+   * Get or Default the security audit object.
+   */
+  void setSecurityAudit(SecurityAudit securityAudit);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextInternal.java
@@ -32,6 +32,7 @@ public interface RoutingContextInternal extends RoutingContext {
 
   int BODY_HANDLER = 1 << 1;
   int CORS_HANDLER = 1 << 2;
+  int SESSION_HANDLER = 1 << 3;
 
   /**
    * flags the current routing context as having visited the handler with {@code id}.

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -194,6 +194,11 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
+  public WebIdentity identity() {
+    return inner.identity();
+  }
+
+  @Override
   public void next() {
     if (!super.iterateNext()) {
       // We didn't route request to anything so go to parent,

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -25,7 +25,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.web.*;
 
 import java.nio.charset.Charset;
@@ -179,23 +178,8 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public void setUser(User user) {
-    inner.setUser(user);
-  }
-
-  @Override
-  public void clearUser() {
-    inner.clearUser();
-  }
-
-  @Override
-  public User user() {
+  public UserContext user() {
     return inner.user();
-  }
-
-  @Override
-  public WebIdentity identity() {
-    return inner.identity();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/UserContextInternal.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/UserContextInternal.java
@@ -1,0 +1,14 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.UserContext;
+
+public interface UserContextInternal extends UserContext {
+
+  /**
+   * Set the user. Usually used by auth handlers to inject a User. You will not normally call this method.
+   *
+   * @param user  the user
+   */
+  void setUser(User user);
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/WebIdentityImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/WebIdentityImpl.java
@@ -1,0 +1,219 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.WebIdentity;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
+import io.vertx.ext.web.handler.HttpException;
+
+import java.util.Objects;
+
+public class WebIdentityImpl implements WebIdentity {
+
+  private static final String USER_SWITCH_KEY = "__vertx.user-switch-ref";
+  private static final Logger LOG = LoggerFactory.getLogger(WebIdentity.class);
+
+  private final RoutingContext ctx;
+
+  public WebIdentityImpl(RoutingContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public WebIdentity loginHint(String loginHint) {
+    final Session session = ctx.session();
+
+    if (session == null) {
+      if (loginHint == null) {
+        // Fine, we don't need a session
+        return this;
+      }
+      // we always need a session, otherwise we can't track the state of the previous user
+      throw new IllegalStateException("SessionHandler not seen in the route. Sessions are required to keep the state");
+    }
+
+    if (loginHint == null) {
+      // we're removing the hint if present
+      session.remove("login_hint");
+    } else {
+      session
+        .put("login_hint", loginHint);
+    }
+
+    return this;
+  }
+
+  @Override
+  public Future<Void> refresh() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return refresh(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> refresh(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    final User user = ctx.user();
+
+    if (user == null) {
+      // we need to ensure that we already had a user, otherwise we can't switch
+      LOG.debug("Impersonation can only occur after a complete authn flow.");
+      return Future.failedFuture(new HttpException(401));
+    }
+
+    final Session session = ctx.session();
+
+    if (session != null) {
+      // From now on, we're changing the state
+      session
+        // force a session id regeneration to protect against replay attacks
+        .regenerateId();
+    }
+
+    // remove user from the context
+    ctx
+      .setUser(null);
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public Future<Void> impersonate() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return impersonate(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> impersonate(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    final User user = ctx.user();
+
+    if (user == null) {
+      // we need to ensure that we already had a user, otherwise we can't switch
+      LOG.debug("Impersonation can only occur after a complete authn flow.");
+      return Future.failedFuture(new HttpException(401));
+    }
+
+    final Session session = ctx.session();
+
+    if (session == null) {
+      // we always need a session, otherwise we can't track the state of the previous user
+      LOG.debug("SessionHandler not seen in the route. Sessions are required to keep the state");
+      return Future.failedFuture(new HttpException(500));
+    }
+
+    if (session.get(USER_SWITCH_KEY) != null) {
+      // we always need a session, otherwise we can't track the state of the previous user
+      LOG.debug("Impersonation already in place");
+      return Future.failedFuture(new HttpException(400));
+    }
+
+    // From now on, we're changing the state
+    session
+      // move the user out of the context (yet keep it in the session, so we can roll back
+      .put(USER_SWITCH_KEY, user)
+      // force a session id regeneration to protect against replay attacks
+      .regenerateId();
+
+    // remove the current user from the context to avoid any further access
+    ctx
+      .setUser(null);
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public Future<Void> undo() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return undo(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> undo(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    final User user = ctx.user();
+
+    if (user == null) {
+      // we need to ensure that we already had a user, otherwise we can't switch
+      LOG.debug("Impersonation can only occur after a complete authn flow.");
+      return Future.failedFuture(new HttpException(401));
+    }
+
+    final Session session = ctx.session();
+
+    if (session == null) {
+      // we always need a session, otherwise we can't track the state of the previous user
+      LOG.debug("SessionHandler not seen in the route. Sessions are required to keep the state");
+      return Future.failedFuture(new HttpException(500));
+    }
+
+    if (session.get(USER_SWITCH_KEY) == null) {
+      // we always need a session, otherwise we can't track the state of the previous user
+      LOG.debug("No previous impersonation in place");
+      return Future.failedFuture(new HttpException(400));
+    }
+
+    // From now on, we're changing the state
+    User previousUser = session.get(USER_SWITCH_KEY);
+
+    session
+      // move the user out of the context (yet keep it in the session, so we can rollback
+      .remove(USER_SWITCH_KEY);
+    // remove the previous hint
+    session
+      .remove("login_hint");
+
+    session
+      // force a session id regeneration to protect against replay attacks
+      .regenerateId();
+
+    // restore it to the context
+    ctx
+      .setUser(previousUser);
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -3595,4 +3595,19 @@ public class RouterTest extends WebTestBase {
 
     await();
   }
+
+  @Test
+  public void testExtractCallee() throws Exception {
+
+    router.route()
+      .handler(ctx -> {
+        System.out.println(ctx.request().absoluteURI());
+        ctx.end();
+      });
+
+    testRequest(
+      HttpMethod.GET,
+      "/?x=1#4",
+      200, "OK");
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/APIKeyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/APIKeyHandlerTest.java
@@ -51,7 +51,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -68,7 +68,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).header("xyz-api-key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -85,7 +85,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).parameter("api_key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -102,7 +102,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).cookie("api-key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthHandlerTestBase.java
@@ -25,6 +25,7 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.auth.properties.PropertyFileAuthorization;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.impl.UserContextInternal;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.AfterClass;
@@ -74,11 +75,12 @@ public abstract class AuthHandlerTestBase extends WebTestBase {
     AuthenticationHandler authNHandler = createAuthHandler(authNProvider);
     router.route().handler(rc -> {
       // we need to be logged in
-      if (rc.user() == null) {
+      if (!rc.user().authenticated()) {
         UsernamePasswordCredentials authInfo = new UsernamePasswordCredentials(username, "delicious:sausages");
         authNProvider.authenticate(authInfo).onComplete(res -> {
           if (res.succeeded()) {
-            rc.setUser(res.result());
+            ((UserContextInternal) rc.user())
+              .setUser(res.result());
             rc.next();
           } else {
             rc.fail(res.cause());

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthXRequestedWithTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthXRequestedWithTest.java
@@ -29,8 +29,8 @@ public class AuthXRequestedWithTest extends AuthHandlerTestBase {
   public void testNoWwwAuthenticateForAjaxCalls() throws Exception {
     String realm = BasicAuthHandler.DEFAULT_REALM;
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user());
-      assertEquals("tim", rc.user().principal().getString("username"));
+      assertNotNull(rc.user().get());
+      assertEquals("tim", rc.user().get().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -55,8 +55,8 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
   private void doLogin(String realm) throws Exception {
 
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user());
-      assertEquals("tim", rc.user().principal().getString("username"));
+      assertNotNull(rc.user().get());
+      assertEquals("tim", rc.user().get().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 
@@ -98,10 +98,10 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
       if (sessID != null) {
         assertEquals(sessID, rc.session().id());
       }
-      assertNotNull(rc.user());
-      assertEquals("tim", rc.user().principal().getString("username"));
+      assertNotNull(rc.user().get());
+      assertEquals("tim", rc.user().get().principal().getString("username"));
       if (c == 7) {
-        rc.clearUser();
+        rc.user().clear();
       }
       rc.response().end("Welcome to the protected resource!");
     };

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
@@ -43,7 +43,7 @@ public class BasicAuthImpersonationTest extends WebTestBase {
     router.route("/user-switch/impersonate")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.identity()
+        ctx.user()
           .loginHint(ctx.request().getParam("login_hint"))
           .impersonate(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -58,9 +58,9 @@ public class BasicAuthImpersonationTest extends WebTestBase {
     router.route("/user-switch/undo")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.identity()
+        ctx.user()
           .loginHint(ctx.request().getParam("login_hint"))
-          .undo(ctx.request().getParam("redirect_uri"))
+          .restore(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
             if (err instanceof HttpException) {
               ctx.fail(err);
@@ -81,8 +81,8 @@ public class BasicAuthImpersonationTest extends WebTestBase {
       .route("/protected/base")
       .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("read")).addAuthorizationProvider(authz))
       .handler(rc -> {
-        assertNotNull(rc.user());
-        userRef.set(rc.user());
+        assertNotNull(rc.user().get());
+        userRef.set(rc.user().get());
         rc.end("OK");
       });
 
@@ -92,12 +92,12 @@ public class BasicAuthImpersonationTest extends WebTestBase {
       .route("/protected/admin")
       .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("write")).addAuthorizationProvider(authz))
       .handler(rc -> {
-        assertNotNull(rc.user());
+        assertNotNull(rc.user().get());
 
         // assert that the old and new users are not the same
         User oldUser = userRef.get();
         assertNotNull(oldUser);
-        User newUser = rc.user();
+        User newUser = rc.user().get();
         assertFalse(oldUser.equals(newUser));
 
         // also the old user should be in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
@@ -1,0 +1,320 @@
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.authorization.AuthorizationProvider;
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
+import io.vertx.ext.auth.properties.PropertyFileAuthentication;
+import io.vertx.ext.auth.properties.PropertyFileAuthorization;
+import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.sstore.SessionStore;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class BasicAuthImpersonationTest extends WebTestBase {
+  AuthenticationProvider authn;
+  AuthorizationProvider authz;
+
+  private static final String USER_SWITCH_KEY = "__vertx.user-switch-ref";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    authn = PropertyFileAuthentication.create(vertx, "login/loginusers.properties");
+    authz = PropertyFileAuthorization.create(vertx, "login/loginusers.properties");
+  }
+
+  @Test
+  public void testSwitchUser() throws Exception {
+
+    /////////////////////////
+    // SETUP
+    /////////////////////////
+
+    // keep state
+    router.route()
+      .handler(SessionHandler.create(SessionStore.create(vertx)));
+
+    // switch users setup
+    // there are 2 routes for testing purposes
+    router.route("/user-switch/impersonate")
+      // this is a high precedence handler
+      .handler(ctx -> {
+        ctx.identity()
+          .loginHint(ctx.request().getParam("login_hint"))
+          .impersonate(ctx.request().getParam("redirect_uri"))
+          .onFailure(err -> {
+            if (err instanceof HttpException) {
+              ctx.fail(err);
+            } else {
+              ctx.fail(500);
+            }
+          });
+      });
+
+    router.route("/user-switch/undo")
+      // this is a high precedence handler
+      .handler(ctx -> {
+        ctx.identity()
+          .loginHint(ctx.request().getParam("login_hint"))
+          .undo(ctx.request().getParam("redirect_uri"))
+          .onFailure(err -> {
+            if (err instanceof HttpException) {
+              ctx.fail(err);
+            } else {
+              ctx.fail(500);
+            }
+          });
+      });
+
+    // protect everything under /protected
+    router.route("/protected/*")
+      .handler(BasicAuthHandler.create(authn));
+
+    final AtomicReference<User> userRef = new AtomicReference<>();
+
+    // mount 1st handler under the protected zone (regular user only can read)
+    router
+      .route("/protected/base")
+      .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("read")).addAuthorizationProvider(authz))
+      .handler(rc -> {
+        assertNotNull(rc.user());
+        userRef.set(rc.user());
+        rc.end("OK");
+      });
+
+
+    // mount 2nd handler under the protected zone (admin user can write)
+    router
+      .route("/protected/admin")
+      .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("write")).addAuthorizationProvider(authz))
+      .handler(rc -> {
+        assertNotNull(rc.user());
+
+        // assert that the old and new users are not the same
+        User oldUser = userRef.get();
+        assertNotNull(oldUser);
+        User newUser = rc.user();
+        assertFalse(oldUser.equals(newUser));
+
+        // also the old user should be in the session
+        User prevUser = rc.session().get(USER_SWITCH_KEY);
+        assertNotNull(prevUser);
+        assertEquals(prevUser, oldUser);
+
+        rc.response().end("Welcome to the 2nd protected resource!");
+      });
+
+
+    /////////////////////////
+    // TEST
+    /////////////////////////
+
+    // flow:
+    // 1. user not authenticated
+    // 2. app starts a redirect to the IdP
+    // 3. IdP calls back, user gets to the desired endpoint
+
+    final AtomicReference<String> sessionRef = new AtomicReference<>();
+
+    // 1. user isn't authenticated (no Authorization header, no Session cookie)
+    // Expectation:
+    //   * A redirect to the IdP, as we're mocking, we need to extract the state of the redirect URL so we can fake the
+    //     callback to the app
+    //   * We also need to have a session cookie otherwise we lose all the context and cannot have multiple identities
+    testRequest(HttpMethod.GET, "/protected/base", null, resp -> {
+      // in this case we should get a WWW-Authenticate
+      String redirectURL = resp.getHeader("WWW-Authenticate");
+      assertNotNull(redirectURL);
+      // there's no session yet
+      String setCookie = resp.headers().get("set-cookie");
+      assertNull(setCookie);
+    }, 401, "Unauthorized", null);
+
+    // 3. fake the redirect from the IdP. This happens with a success authn validation, we need to pass the right state
+    // Expectations:
+    //   * A new session cookie is returned, as the session id is regenerated to prevent replay attacks or privilege
+    //     escalation bugs. Old session assumed an un authenticated user, this one is for the authenticated one
+    //   * A final redirect happens to avoid caching the callback URL at the user-agent, so the browser will show
+    //     the desired original URL
+    testRequest(
+      HttpMethod.GET,
+      "/protected/base",
+      req -> {
+        req.putHeader(HttpHeaders.AUTHORIZATION, "Basic cmVndWxhcjpyZWd1bGFy");
+      }, resp -> {
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+      }, 200, "OK", null);
+
+    // 4. Confirm that we can get the secured resource
+    testRequest(
+      HttpMethod.GET,
+      "/protected/base",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "OK");
+
+    //////////////////////////////
+    // TEST SWITCHING IDENTITIES
+    /////////////////////////////
+
+    // test we can't get the admin resource (we're still base user)
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 403, "Forbidden", null);
+
+    // verify that the switch isn't possible for non authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     an Unauthorized response
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/impersonate?redirect_uri=/protected/admin&login_hint=admin",
+      req -> {
+      }, resp -> {
+      }, 401, "Unauthorized", null);
+
+    // start the switch
+
+    // flow:
+    // 1. call the switch user endpoint
+    // 2. a new Oauth2 auth flow starts like before
+    // 3. In the end there should be a new user object and the previous one shall be in the session
+
+    // User is authenticated (there is a session and a User) and a redirect to the IdP should happen
+    // Expectations:
+    //   * A redirect to the IdP should happen. (maybe there's a way to hint the desired user? This doesn't do it)
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/impersonate?redirect_uri=/protected/admin&login_hint=admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a redirect, and the session id must change
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+        // the session must change
+        assertFalse(setCookie.substring(0, setCookie.indexOf(';')).equals(sessionRef.get()));
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(destination);
+      }, 302, "Found", null);
+
+    // verify that the switch isn't possible for non authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     a redirect to the IdP response
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+      }, resp -> {
+      }, 401, "Unauthorized", null);
+
+    // verify that the switch is possible for authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     a redirect to the IdP response
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a WWW-Authenticate
+        String redirectURL = resp.getHeader("WWW-Authenticate");
+        assertNotNull(redirectURL);
+        // there's no session yet
+        String setCookie = resp.headers().get("set-cookie");
+        assertNull(setCookie);
+      }, 401, "Unauthorized", null);
+
+    // user is authenticated, it now escalates the permissions by re-doing the auth flow to upgrade the user
+    // Expectations:
+    //   * fake the IdP callback with the right state
+    //   * like before ensure that the session id changes (base user -> admin user)
+    //   * final redirect to the desired target resource, to avoid user-agents to cache the callback url
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+        req.putHeader(HttpHeaders.AUTHORIZATION, "Basic YWRtaW46YWRtaW4=");
+      }, resp -> {
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+      }, 200, "OK", null);
+
+    ////////////////////////////////////////
+    // TEST GET RESOURCE WITH NEW IDENTITY
+    ////////////////////////////////////////
+
+    // final call to verify that the desired escalated user can get the final resource
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "Welcome to the 2nd protected resource!");
+
+    ////////////////////////////////////////
+    // UNDO IMPERSONATION
+    ////////////////////////////////////////
+
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/undo?redirect_uri=/protected/base",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a redirect, and the session id must change
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+        // the session must change
+        assertFalse(setCookie.substring(0, setCookie.indexOf(';')).equals(sessionRef.get()));
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(destination);
+      }, 302, "Found", null);
+
+    // final call to verify that the desired de-escalated user can get the final resource
+    testRequest(
+      HttpMethod.GET,
+      "/protected/base",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "OK");
+
+    // final call to verify that the desired de-escalated user cannot get the admin resource
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 403, "Forbidden", null);
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/DigestAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/DigestAuthHandlerTest.java
@@ -74,8 +74,8 @@ public class DigestAuthHandlerTest extends WebTestBase {
   private void doLogin(String realm) throws Exception {
     router.clear();
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user());
-      assertEquals("Mufasa", rc.user().principal().getString("username"));
+      assertNotNull(rc.user().get());
+      assertEquals("Mufasa", rc.user().get().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -1178,7 +1178,7 @@ public class EventbusBridgeTest extends WebTestBase {
   private AuthenticationHandler addLoginHandler(AuthenticationProvider authProvider) {
     return SimpleAuthenticationHandler.create()
       .authenticate(ctx -> {
-        if (ctx.user() == null) {
+        if (ctx.user().get() == null) {
           return authProvider.authenticate(new UsernamePasswordCredentials("tim", "delicious:sausages"));
         } else {
           return Future.failedFuture("non null user");

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
@@ -51,8 +51,8 @@ public class JWTAuthHandlerTest extends WebTestBase {
   public void testLogin() throws Exception {
 
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/MultiAuthorizationHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/MultiAuthorizationHandlerTest.java
@@ -1,8 +1,6 @@
 package io.vertx.ext.web.handler;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.KeyStoreOptions;
@@ -46,8 +44,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(JWTAuthHandler.create(authProvider));
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -69,8 +67,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(AuthorizationHandler.create(RoleBasedAuthorization.create("role1")));
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -96,8 +94,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -125,8 +123,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -154,8 +152,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -198,14 +196,14 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       .addAuthorizationProvider(createProvider("authzProvider1", RoleBasedAuthorization.create("role2"))));
 
     router.route("/protected1/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user().get());
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -100,7 +100,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -162,7 +162,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -224,7 +224,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -288,7 +288,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -371,7 +371,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -470,7 +470,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
 
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -497,7 +497,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route().handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -559,7 +559,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -584,7 +584,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -663,7 +663,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -749,7 +749,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     subRouter.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     subRouter.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
+import io.vertx.ext.auth.oauth2.authorization.ScopeAuthorization;
+import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.sstore.SessionStore;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author Paulo Lopes
+ */
+public class OAuth2ImpersonationTest extends WebTestBase {
+
+  private static final String USER_SWITCH_KEY = "__vertx.user-switch-ref";
+
+  // mock an oauth2 server using code auth code flow
+  OAuth2Auth oauth2;
+
+  private static final JsonObject fixture_base = new JsonObject(
+    "{" +
+      "  \"sub\": \"base\"," +
+      "  \"access_token\": \"base\"," +
+      "  \"refresh_token\": \"base\"," +
+      "  \"token_type\": \"bearer\"," +
+      "  \"scope\": \"read\"," +
+      "  \"expires_in\": 7200" +
+      "}");
+
+  private static final JsonObject fixture_admin = new JsonObject(
+    "{" +
+      "  \"sub\": \"admin\"," +
+      "  \"access_token\": \"admin\"," +
+      "  \"refresh_token\": \"admin\"," +
+      "  \"token_type\": \"bearer\"," +
+      "  \"scope\": \"read write\"," +
+      "  \"expires_in\": 7200" +
+      "}");
+
+  private HttpServer server;
+
+  @Override
+  public void tearDown() throws Exception {
+    server.close();
+
+    super.tearDown();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
+      .setClientId("client-id")
+      .setClientSecret("client-secret")
+      .setSite("http://localhost:10000"));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicBoolean base = new AtomicBoolean(true);
+
+    server = vertx.createHttpServer();
+
+    server
+      .requestHandler(req -> {
+        if (req.method() == HttpMethod.POST && "/oauth/token".equals(req.path())) {
+          req
+            .setExpectMultipart(true)
+            .bodyHandler(buffer ->
+              req
+                .response()
+                .putHeader("Content-Type", "application/json")
+                .end(base.compareAndSet(true, false) ? fixture_base.encode() : fixture_admin.encode()));
+        } else if (req.method() == HttpMethod.POST && "/oauth/revoke".equals(req.path())) {
+          req.setExpectMultipart(true).bodyHandler(buffer -> req.response().end());
+        } else {
+          req.response().setStatusCode(400).end();
+        }
+      })
+      .listen(10000)
+      .onComplete(ready -> {
+        if (ready.failed()) {
+          throw new RuntimeException(ready.cause());
+        }
+        // ready
+        latch.countDown();
+      });
+
+    latch.await();
+  }
+
+  @Test
+  public void testSwitchUser() throws Exception {
+
+    /////////////////////////
+    // SETUP
+    /////////////////////////
+
+    // keep state
+    router.route()
+      .handler(SessionHandler.create(SessionStore.create(vertx)));
+
+    // switch users setup
+    // there are 2 routes for testing purposes
+    router.route("/user-switch/impersonate")
+      // this is a high precedence handler
+      .handler(ctx -> {
+        ctx.identity()
+          .loginHint(ctx.request().getParam("login_hint"))
+          .impersonate(ctx.request().getParam("redirect_uri"))
+          .onFailure(err -> {
+            if (err instanceof HttpException) {
+              ctx.fail(err);
+            } else {
+              ctx.fail(500);
+            }
+          });
+      });
+
+    router.route("/user-switch/undo")
+      // this is a high precedence handler
+      .handler(ctx -> {
+        ctx.identity()
+          .loginHint(ctx.request().getParam("login_hint"))
+          .undo(ctx.request().getParam("redirect_uri"))
+          .onFailure(err -> {
+            if (err instanceof HttpException) {
+              ctx.fail(err);
+            } else {
+              ctx.fail(500);
+            }
+          });
+      });
+
+    // create an oauth2 handler on our domain to the callback: "http://localhost:8080/callback" and
+    // protect everything under /protected
+    router.route("/protected/*")
+      .handler(OAuth2AuthHandler.create(vertx, oauth2, "http://localhost:8080/callback").setupCallback(router.route("/callback")));
+
+    final AtomicReference<User> userRef = new AtomicReference<>();
+
+    // mount 1st handler under the protected zone (regular user only can read)
+    router
+      .route("/protected/base")
+      .handler(
+        AuthorizationHandler
+          .create(PermissionBasedAuthorization.create("read"))
+          .addAuthorizationProvider(ScopeAuthorization.create()))
+      .handler(rc -> {
+        assertNotNull(rc.user());
+        userRef.set(rc.user());
+        rc.end("OK");
+      });
+
+
+    // mount 2nd handler under the protected zone (admin user can write)
+    router
+      .route("/protected/admin")
+      .handler(
+        AuthorizationHandler
+          .create(PermissionBasedAuthorization.create("write"))
+          .addAuthorizationProvider(ScopeAuthorization.create()))
+      .handler(rc -> {
+        assertNotNull(rc.user());
+        System.out.println(rc.user().principal().encodePrettily());
+
+        // assert that the old and new users are not the same
+        User oldUser = userRef.get();
+        assertNotNull(oldUser);
+        User newUser = rc.user();
+        assertFalse(oldUser.equals(newUser));
+
+        // also the old user should be in the session
+        User prevUser = rc.session().get(USER_SWITCH_KEY);
+        assertNotNull(prevUser);
+        assertEquals(prevUser, oldUser);
+
+        rc.response().end("Welcome to the 2nd protected resource!");
+      });
+
+
+    /////////////////////////
+    // TEST
+    /////////////////////////
+
+    // flow:
+    // 1. user not authenticated
+    // 2. app starts a redirect to the IdP
+    // 3. IdP calls back, user gets to the desired endpoint
+
+    final AtomicReference<String> stateRef = new AtomicReference<>();
+    final AtomicReference<String> sessionRef = new AtomicReference<>();
+
+    // 1. user isn't authenticated (no Authorization header, no Session cookie)
+    // Expectation:
+    //   * A redirect to the IdP, as we're mocking, we need to extract the state of the redirect URL so we can fake the
+    //     callback to the app
+    //   * We also need to have a session cookie otherwise we lose all the context and cannot have multiple identities
+    testRequest(HttpMethod.GET, "/protected/base", null, resp -> {
+      // in this case we should get a redirect
+      String redirectURL = resp.getHeader("Location");
+      assertNotNull(redirectURL);
+      String[] parts = redirectURL.substring(redirectURL.indexOf('?') + 1).split("&");
+
+      for (String part : parts) {
+        if (part.startsWith("state=")) {
+          stateRef.set(part.substring(6));
+        }
+      }
+
+      String setCookie = resp.headers().get("set-cookie");
+      assertNotNull(setCookie);
+
+      sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+    }, 302, "Found", null);
+
+    // 3. fake the redirect from the IdP. This happens with a success authn validation, we need to pass the right state
+    // Expectations:
+    //   * A new session cookie is returned, as the session id is regenerated to prevent replay attacks or privilege
+    //     escalation bugs. Old session assumed an un authenticated user, this one is for the authenticated one
+    //   * A final redirect happens to avoid caching the callback URL at the user-agent, so the browser will show
+    //     the desired original URL
+    testRequest(
+      HttpMethod.GET,
+      "/callback?state=" + stateRef.get() + "&code=1",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        stateRef.set(destination);
+      }, 302, "Found", null);
+
+    // 4. Confirm that we can get the secured resource
+    testRequest(
+      HttpMethod.GET,
+      stateRef.get(),
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "OK");
+
+    //////////////////////////////
+    // TEST SWITCHING IDENTITIES
+    /////////////////////////////
+
+    // test we can't get the admin resource (we're still base user)
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 403, "Forbidden", null);
+
+    // verify that the switch isn't possible for non authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     an Unauthorized response
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/impersonate?redirect_uri=/protected/admin&login_hint=admin",
+      req -> {
+      }, resp -> {
+      }, 401, "Unauthorized", null);
+
+    // start the switch
+
+    // flow:
+    // 1. call the switch user endpoint
+    // 2. a new Oauth2 auth flow starts like before
+    // 3. In the end there should be a new user object and the previous one shall be in the session
+
+    // User is authenticated (there is a session and a User) and a redirect to the IdP should happen
+    // Expectations:
+    //   * A redirect to the IdP should happen. (maybe there's a way to hint the desired user? This doesn't do it)
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/impersonate?redirect_uri=/protected/admin&login_hint=admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a redirect, and the session id must change
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+        // the session must change
+        assertFalse(setCookie.substring(0, setCookie.indexOf(';')).equals(sessionRef.get()));
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        stateRef.set(destination);
+      }, 302, "Found", null);
+
+    // verify that the switch isn't possible for non authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     a redirect to the IdP response
+    testRequest(
+      HttpMethod.GET,
+      stateRef.get(),
+      req -> {
+      }, resp -> {
+        // in this case we should get a redirect
+        String redirectURL = resp.getHeader("Location");
+        assertNotNull(redirectURL);
+
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+
+        // the session must be different
+        assertFalse(setCookie.substring(0, setCookie.indexOf(';')).equals(sessionRef.get()));
+      }, 302, "Found", null);
+
+    // verify that the switch is possible for authn requests
+    // Expectations:
+    //   * Given that there is no cookie and no authorization header, no user will be present in the request, forcing
+    //     a redirect to the IdP response
+    testRequest(
+      HttpMethod.GET,
+      stateRef.get(),
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a redirect
+        String redirectURL = resp.getHeader("Location");
+        assertNotNull(redirectURL);
+        String[] parts = redirectURL.substring(redirectURL.indexOf('?') + 1).split("&");
+        boolean hintSeen = false;
+
+        for (String part : parts) {
+          if (part.startsWith("state=")) {
+            stateRef.set(part.substring(6));
+          }
+          if (part.startsWith("login_hint=")) {
+            hintSeen = true;
+          }
+        }
+
+        // we should respect the hint
+        assertTrue(hintSeen);
+
+        // we're on the right session
+        String setCookie = resp.headers().get("set-cookie");
+        assertNull(setCookie);
+      }, 302, "Found", null);
+
+    // user is authenticated, it now escalates the permissions by re-doing the auth flow to upgrade the user
+    // Expectations:
+    //   * fake the IdP callback with the right state
+    //   * like before ensure that the session id changes (base user -> admin user)
+    //   * final redirect to the desired target resource, to avoid user-agents to cache the callback url
+    testRequest(
+      HttpMethod.GET,
+      "/callback?state=" + stateRef.get() + "&code=1",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        stateRef.set(destination);
+      }, 302, "Found", null);
+
+    ////////////////////////////////////////
+    // TEST GET RESOURCE WITH NEW IDENTITY
+    ////////////////////////////////////////
+
+    // final call to verify that the desired escalated user can get the final resource
+    testRequest(
+      HttpMethod.GET,
+      stateRef.get(),
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "Welcome to the 2nd protected resource!");
+
+    ////////////////////////////////////////
+    // UNDO IMPERSONATION
+    ////////////////////////////////////////
+
+    testRequest(
+      HttpMethod.GET,
+      "/user-switch/undo?redirect_uri=/protected/base",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+        // in this case we should get a redirect, and the session id must change
+        // session upgrade (secure against replay attacks)
+        String setCookie = resp.headers().get("set-cookie");
+        assertNotNull(setCookie);
+        // the session must change
+        assertFalse(setCookie.substring(0, setCookie.indexOf(';')).equals(sessionRef.get()));
+
+        sessionRef.set(setCookie.substring(0, setCookie.indexOf(';')));
+
+        String destination = resp.getHeader(HttpHeaders.LOCATION);
+        stateRef.set(destination);
+      }, 302, "Found", null);
+
+    // final call to verify that the desired de-escalated user can get the final resource
+    testRequest(
+      HttpMethod.GET,
+      stateRef.get(),
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 200, "OK", "OK");
+
+    // final call to verify that the desired de-escalated user cannot get the admin resource
+    testRequest(
+      HttpMethod.GET,
+      "/protected/admin",
+      req -> {
+        req.putHeader(HttpHeaders.COOKIE, sessionRef.get());
+      }, resp -> {
+      }, 403, "Forbidden", null);
+  }
+}

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
@@ -130,7 +130,7 @@ public class OAuth2ImpersonationTest extends WebTestBase {
     router.route("/user-switch/impersonate")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.identity()
+        ctx.user()
           .loginHint(ctx.request().getParam("login_hint"))
           .impersonate(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -145,9 +145,9 @@ public class OAuth2ImpersonationTest extends WebTestBase {
     router.route("/user-switch/undo")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.identity()
+        ctx.user()
           .loginHint(ctx.request().getParam("login_hint"))
-          .undo(ctx.request().getParam("redirect_uri"))
+          .restore(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
             if (err instanceof HttpException) {
               ctx.fail(err);
@@ -172,8 +172,8 @@ public class OAuth2ImpersonationTest extends WebTestBase {
           .create(PermissionBasedAuthorization.create("read"))
           .addAuthorizationProvider(ScopeAuthorization.create()))
       .handler(rc -> {
-        assertNotNull(rc.user());
-        userRef.set(rc.user());
+        assertNotNull(rc.user().get());
+        userRef.set(rc.user().get());
         rc.end("OK");
       });
 
@@ -186,13 +186,13 @@ public class OAuth2ImpersonationTest extends WebTestBase {
           .create(PermissionBasedAuthorization.create("write"))
           .addAuthorizationProvider(ScopeAuthorization.create()))
       .handler(rc -> {
-        assertNotNull(rc.user());
-        System.out.println(rc.user().principal().encodePrettily());
+        assertNotNull(rc.user().get());
+        System.out.println(rc.user().get().principal().encodePrettily());
 
         // assert that the old and new users are not the same
         User oldUser = userRef.get();
         assertNotNull(oldUser);
-        User newUser = rc.user();
+        User newUser = rc.user().get();
         assertFalse(oldUser.equals(newUser));
 
         // also the old user should be in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
@@ -22,7 +22,6 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.sstore.LocalSessionStore;
@@ -59,7 +58,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
       Session sess = rc.session();
       assertNotNull(sess);
       assertEquals(sessionCookie.get().substring(18, 50), sess.id());
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
     // And request it again
@@ -67,7 +66,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
     }, 200, "OK", "Welcome to the protected resource!");
     // Now logout
     router.route("/logout").handler(rc -> {
-      rc.clearUser();
+      rc.user().clear();
       rc.response().end("logged out");
     });
     testRequest(HttpMethod.GET, "/logout", req -> req.putHeader("cookie", sessionCookie.get()), resp -> {
@@ -245,7 +244,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
       Session sess = rc.session();
       assertNotNull(sess);
       assertEquals(sessionCookie.get().substring(18, 54), sess.id());
-      assertNotNull(rc.user());
+      assertNotNull(rc.user().get());
       rc.response().end("Welcome to the protected resource!");
     });
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SecurityAuditLoggerHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SecurityAuditLoggerHandlerTest.java
@@ -131,7 +131,7 @@ public class SecurityAuditLoggerHandlerTest extends WebTestBase {
 
     router.route("/protected/page1").handler(rc -> {
       assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
+      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/sockjs/SockJSHandlerTest.java
@@ -390,7 +390,7 @@ public class SockJSHandlerTest extends WebTestBase {
           assertEquals(session, sock.webSession());
           ((RoutingContextInternal) sock.routingContext()).setSession(session);
           assertEquals(sock.webSession(), sock.routingContext().session());
-          assertEquals(sock.webUser(), sock.routingContext().user());
+          assertEquals(sock.webUser(), sock.routingContext().user().get());
           assertEquals(sock.webUser(), user);
           assertEquals(session, sock.webSession());
           assertEquals(session, store.get(session.id()).result());

--- a/vertx-web/src/test/resources/login/loginusers.properties
+++ b/vertx-web/src/test/resources/login/loginusers.properties
@@ -2,3 +2,7 @@ user.tim = delicious:sausages,morris_dancer,developer
 user.bob = socks,developer
 role.morris_dancer=dance,bang_sticks
 role.developer=do_actual_work
+user.regular=regular,read
+user.admin=admin,read,write
+role.read=read_files
+role.write=write_files


### PR DESCRIPTION
Motivation:

Adding support to allow web identities to be refreshed or impersonated.

This is a remake of an old PR that has been shown in conferences but wasn't prime time yet. Missing docs, tests and was triggered by an HTTP endpoint (like Spring Security). Imho, the HTTP approach was wrong, as it could be an opportunity to open a door for privilege escalation from the outside of the application.