### PR TITLE
Fix #2219: update documentation and include support for scopes from m…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
@@ -32,7 +32,8 @@ import java.util.List;
 public interface JWTAuthHandler extends AuthenticationHandler {
 
   /**
-   * Create a JWT auth handler
+   * Create a JWT auth handler. When no scopes are explicit declared, the default scopes will be looked up from the
+   * route metadata.
    *
    * @param authProvider  the auth provider to use
    * @return the auth handler
@@ -42,7 +43,8 @@ public interface JWTAuthHandler extends AuthenticationHandler {
   }
 
   /**
-   * Create a JWT auth handler
+   * Create a JWT auth handler. When no scopes are explicit declared, the default scopes will be looked up from the
+   * route metadata.
    *
    * @param authProvider  the auth provider to use
    * @return the auth handler
@@ -52,32 +54,31 @@ public interface JWTAuthHandler extends AuthenticationHandler {
   }
 
   /**
-   * Return a new instance with the internal state copied from the caller but the scopes delimiter set
-   * to be unique to the instance.
+   * Set the scope delimiter. By default this is a space character.
    *
    * @param delimiter scope delimiter.
-   * @return new instance of this interface.
+   * @return fluent self.
    */
   @Fluent
   JWTAuthHandler scopeDelimiter(String delimiter);
 
   /**
    * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
-   * request are unique to the instance.
+   * request are unique to the instance. When scopes are applied to the handler, the default scopes from the route
+   * metadata will be ignored.
    *
    * @param scope scope.
    * @return new instance of this interface.
    */
-  @Fluent
   JWTAuthHandler withScope(String scope);
 
   /**
    * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
-   * request are unique to the instance.
+   * request are unique to the instance. When scopes are applied to the handler, the default scopes from the route
+   * metadata will be ignored.
    *
    * @param scopes scopes.
    * @return new instance of this interface.
    */
-  @Fluent
   JWTAuthHandler withScopes(List<String> scopes);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -35,11 +35,14 @@ import java.util.List;
 public interface OAuth2AuthHandler extends AuthenticationHandler {
 
   /**
-   * Create a OAuth2 auth handler with host pinning
+   * Create a OAuth2 auth handler with host pinning. When no scopes are explicit declared, the default scopes will be
+   * looked up from the route metadata under the key {@code scopes} which can either be a single {@link String} or a
+   * {@link List<String>}.
    *
    * @param vertx  the vertx instance
    * @param authProvider  the auth provider to use
-   * @param callbackURL the callback URL you entered in your provider admin console, usually it should be something like: `https://myserver:8888/callback`
+   * @param callbackURL the callback URL you entered in your provider admin console, usually it should be something
+   *                    like: {@code https://myserver:8888/callback}
    * @return the auth handler
    */
   static OAuth2AuthHandler create(Vertx vertx, OAuth2Auth authProvider, String callbackURL) {
@@ -50,9 +53,10 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
   }
 
   /**
-   * Create a OAuth2 auth handler without host pinning.
-   * Most providers will not look to the redirect url but always redirect to
-   * the preconfigured callback. So this factory does not provide a callback url.
+   * Create a OAuth2 auth handler without host pinning.Most providers will not look to the redirect url but always
+   * redirect to the preconfigured callback. So this factory does not provide a callback url. When no scopes are
+   * explicit declared, the default scopes will be looked up from the route metadata under the key {@code scopes}
+   * which can either be a single {@link String} or a {@link List<String>}.
    *
    * @param vertx  the vertx instance
    * @param authProvider  the auth provider to use
@@ -72,8 +76,9 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
   OAuth2AuthHandler extraParams(JsonObject extraParams);
 
   /**
-   * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
-   * request are unique to the instance.
+   * Return a <b>new instance</b> with the internal state copied from the caller but the scopes to be requested during
+   * a token request are unique to the instance. When scopes are applied to the handler, the default scopes from the
+   * route metadata will be ignored.
    *
    * @param scope scope.
    * @return new instance of this interface.
@@ -82,8 +87,9 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
   OAuth2AuthHandler withScope(String scope);
 
   /**
-   * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token
-   * request are unique to the instance.
+   * Return a <b>new instance</b> with the internal state copied from the caller but the scopes to be requested during
+   * a token request are unique to the instance. When scopes are applied to the handler, the default scopes from the
+   * route metadata will be ignored.
    *
    * @param scopes scopes.
    * @return new instance of this interface.
@@ -98,9 +104,14 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
    *
    * <ul>
    *   <li><b>login</b> will force the user to enter their credentials on that request, negating single-sign on.</li>
-   *   <li><b>none</b> is the opposite - it will ensure that the user isn't presented with any interactive prompt whatsoever. If the request can't be completed silently via single-sign on, the Microsoft identity platform endpoint will return an interaction_required error.</li>
-   *   <li><b>consent</b> will trigger the OAuth consent dialog after the user signs in, asking the user to grant permissions to the app.</li>
-   *   <li><b>select_account</b> will interrupt single sign-on providing account selection experience listing all the accounts either in session or any remembered account or an option to choose to use a different account altogether.</li>
+   *   <li><b>none</b> is the opposite - it will ensure that the user isn't presented with any interactive prompt
+   *      whatsoever. If the request can't be completed silently via single-sign on, the Microsoft identity platform
+   *      endpoint will return an interaction_required error.</li>
+   *   <li><b>consent</b> will trigger the OAuth consent dialog after the user signs in, asking the user to grant
+   *      permissions to the app.</li>
+   *   <li><b>select_account</b> will interrupt single sign-on providing account selection experience listing all the
+   *      accounts either in session or any remembered account or an option to choose to use a different account
+   *      altogether.</li>
    *   <li><b></b></li>
    * </ul>
    *
@@ -125,7 +136,7 @@ public interface OAuth2AuthHandler extends AuthenticationHandler {
 
   /**
    * add the callback handler to a given route.
-   * @param route a given route e.g.: `/callback`
+   * @param route a given route e.g.: {@code /callback}
    * @return self
    */
   @Fluent

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ScopedAuthentication.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ScopedAuthentication.java
@@ -1,13 +1,18 @@
 package io.vertx.ext.web.handler.impl;
 
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.AuthenticationHandler;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Internal interface for scope aware Authentication handlers.
- * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ *
  * @param <SELF>
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 public interface ScopedAuthentication<SELF extends AuthenticationHandler> {
 
@@ -28,4 +33,39 @@ public interface ScopedAuthentication<SELF extends AuthenticationHandler> {
    * @return new instance of this interface.
    */
   SELF withScopes(List<String> scopes);
+
+  /**
+   * Return the list of scopes provided as the 1st argument, unless the list is empty. In this case, the list of scopes
+   * is obtained from the routing context metadata if possible. In case the metadata is not available, the list of
+   * scopes is always an empty list.
+   */
+  default List<String> getScopesOrSearchMetadata(List<String> scopes, RoutingContext ctx) {
+    if (!scopes.isEmpty()) {
+      return scopes;
+    }
+
+    final Route currentRoute = ctx.currentRoute();
+
+    if (currentRoute == null) {
+      return Collections.emptyList();
+    }
+
+    final Object value = currentRoute
+      .metadata()
+      .get("scopes");
+
+    if (value == null) {
+      return Collections.emptyList();
+    }
+
+    if (value instanceof List) {
+      return (List<String>) value;
+    }
+
+    if (value instanceof String) {
+      return Collections.singletonList((String) value);
+    }
+
+    throw new IllegalStateException("Invalid type for scopes metadata: " + value.getClass().getName());
+  }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/JWTAuthHandlerTest.java
@@ -160,4 +160,50 @@ public class JWTAuthHandlerTest extends WebTestBase {
 
     testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Bearer " + authProvider.generateToken(payloadB)), 200, "OK", null);
   }
+
+  @Test
+  public void testLoginWithScopesFromMetadata() throws Exception {
+
+    router.route()
+      .putMetadata("scopes", Arrays.asList("a", "b"))
+      .handler(JWTAuthHandler.create(authProvider))
+      .handler(RoutingContext::end);
+
+    // Payload as String list
+    final JsonObject payloadA = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", String.join(" ", Arrays.asList("a", "b")));
+
+    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Bearer " + authProvider.generateToken(payloadA)), 200, "OK", null);
+
+    // Payload as Array
+    final JsonObject payloadB = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", new JsonArray().add("a").add("b"));
+
+    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Bearer " + authProvider.generateToken(payloadB)), 200, "OK", null);
+  }
+
+  @Test
+  public void testLoginWithScopesFromMetadataSingle() throws Exception {
+
+    router.route()
+      .putMetadata("scopes", "a")
+      .handler(JWTAuthHandler.create(authProvider))
+      .handler(RoutingContext::end);
+
+    // Payload as String list
+    final JsonObject payloadA = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", "a");
+
+    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Bearer " + authProvider.generateToken(payloadA)), 200, "OK", null);
+
+    // Payload as Array
+    final JsonObject payloadB = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", new JsonArray().add("a"));
+
+    testRequest(HttpMethod.GET, "/", req -> req.putHeader("Authorization", "Bearer " + authProvider.generateToken(payloadB)), 200, "OK", null);
+  }
 }


### PR DESCRIPTION
…etadata as discussed in the issue

Motivation:

The javadoc and annotations were contradictory. the `withScopes` methods are not fluent but rather return a new instance. The implementation has been updated to also allow picking the scopes from the route metadata which reduces the complexity of usage.

```java
app.route("/secure/*)
  .putMetadata("scopes", Arrays.asList("read", "write"))
  .handler(Oauth2AuthHandler.create(...))
```

No need to create double instances.