### PR TITLE
Issue the BridgeEventType.REGISTERED event after registration is comp…

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -257,11 +257,13 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
               }
             }
           };
-          MessageConsumer<?> reg = eb.consumer(address).handler(handler);
-          registrations.put(address, reg);
-          info.handlerCount++;
-          // Notify registration completed
-          checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, rawMsg, sock));
+          // Issue the BridgeEventType.REGISTERED event after registration is complete
+          reg.completionHandler(v -> {
+            registrations.put(address, reg);
+            info.handlerCount++;
+            // Notify registration completed
+            checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, rawMsg, sock));
+          });
         } else {
           // inbound match failed
           if (debug) {


### PR DESCRIPTION
…lete

 use WebSocket in a cluster environment. When I publish a message to this registered address in the 'BridgeEventType. REGISTERED' event, registration may take some time to reach all nodes of the cluster due to registering the processor on the cluster event bus. At this time, if I sends the message to client, it will not receive it. If the sending code is placed in the 'completion processor' after the registration is successful, it will suffice.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
