### PR TITLE
EventBusBridge should fire REGISTERED event after registration completion

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -1,33 +1,12 @@
 /*
- * Copyright 2014 Red Hat, Inc.
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  The Eclipse Public License is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *
- *  The Apache License v2.0 is available at
- *  http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
- */
-
-/*
- * Copyright (c) 2011-2013 The original author or authors
- * ------------------------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
- *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.ext.web.handler.sockjs.impl;
@@ -36,10 +15,10 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.*;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.auth.authorization.AuthorizationProvider;
@@ -47,7 +26,9 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.bridge.BridgeEventType;
 import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.sockjs.*;
+import io.vertx.ext.web.handler.sockjs.BridgeEvent;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSSocket;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -260,10 +241,17 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
             }
           };
           MessageConsumer<?> reg = eb.consumer(address).handler(handler);
-          registrations.put(address, reg);
-          info.handlerCount++;
-          // Notify registration completed
-          checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, rawMsg, sock));
+          reg.completionHandler(ar -> {
+            if (ar.succeeded()) {
+              registrations.put(address, reg);
+              info.handlerCount++;
+              // Notify registration completed
+              checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, rawMsg, sock));
+            } else {
+              LOG.warn("Cannot register handler for address " + address, ar.cause());
+              replyError(sock, "registration_failure");
+            }
+          });
         } else {
           // inbound match failed
           if (debug) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -33,13 +33,14 @@ import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.auth.properties.PropertyFileAuthorization;
 import io.vertx.ext.bridge.BridgeEventType;
+import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.WebTestBase;
-import io.vertx.ext.web.handler.sockjs.*;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 import io.vertx.ext.web.handler.sockjs.impl.JsonCodec;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
-import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,7 +120,7 @@ public class EventbusBridgeTest extends WebTestBase {
         }
       }));
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client
       .connect(websocketURI).compose(v -> client.send(addr, "foobar"))
       .onComplete(onSuccess(v -> latch.countDown()));
@@ -142,7 +143,7 @@ public class EventbusBridgeTest extends WebTestBase {
         }
       }));
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client.connect(websocketURI).onComplete(onSuccess(v -> client.close()));
 
     await();
@@ -163,7 +164,7 @@ public class EventbusBridgeTest extends WebTestBase {
         }
       }));
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client.connect(websocketURI).onComplete(onSuccess(v -> client.transportClient.result().abruptClose()));
 
     await();
@@ -392,7 +393,7 @@ public class EventbusBridgeTest extends WebTestBase {
         be.complete(true);
       }));
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.handler((address, received) -> {
       assertEquals(addr, address);
@@ -862,7 +863,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     CountDownLatch latch = new CountDownLatch(1);
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -898,7 +899,7 @@ public class EventbusBridgeTest extends WebTestBase {
       sockJS.bridge(defaultOptions.addInboundPermitted(new PermittedOptions().setAddress(addr))));
 
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -939,7 +940,7 @@ public class EventbusBridgeTest extends WebTestBase {
       sockJS.bridge(defaultOptions.addOutboundPermitted(new PermittedOptions().setAddress(addr))));
 
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -971,7 +972,7 @@ public class EventbusBridgeTest extends WebTestBase {
       sockJS.bridge(allAccessOptions.setReplyTimeout(200)));
 
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -1006,7 +1007,7 @@ public class EventbusBridgeTest extends WebTestBase {
       sockJS.bridge(allAccessOptions.setReplyTimeout(200)));
 
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -1073,7 +1074,7 @@ public class EventbusBridgeTest extends WebTestBase {
     router.route("/eventbus/*").subRouter(
       sockJS.bridge(new SockJSBridgeOptions(allAccessOptions).setMaxHandlersPerSocket(maxHandlers)));
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -1126,7 +1127,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     router.route("/eventbus/*").subRouter(
       sockJS.bridge(new SockJSBridgeOptions(allAccessOptions).setMaxAddressLength(10)));
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(v -> {
 
@@ -1200,7 +1201,7 @@ public class EventbusBridgeTest extends WebTestBase {
       sockJS.bridge(allAccessOptions.setPingTimeout(1000)));
     CountDownLatch latch = new CountDownLatch(1);
     long start = System.currentTimeMillis();
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI)
       .onComplete(v -> client.closeHandler(v2 -> latch.countDown()));
@@ -1270,7 +1271,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     CountDownLatch latch = new CountDownLatch(1);
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client.errorHandler(received -> {
       assertEquals(expectedErr, received.getString("body"));
       latch.countDown();
@@ -1293,7 +1294,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
     CountDownLatch latch = new CountDownLatch(1);
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client.connect(websocketURI).onComplete(onSuccess(v1 -> {
       MessageConsumer<Object> consumer = vertx.eventBus().consumer(address);
       consumer.handler(msg -> {
@@ -1327,7 +1328,7 @@ public class EventbusBridgeTest extends WebTestBase {
   private void testPublish(String address, Object body, boolean headers) throws Exception {
     CountDownLatch latch = new CountDownLatch(2);
 
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v1 -> {
       vertx.eventBus().consumer(address, msg -> {
@@ -1360,7 +1361,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
   private void testReceive(String address, Object body) throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
     client.handler((addr, received) -> {
       assertEquals(address, addr);
       assertEquals(body, received.getValue("body"));
@@ -1377,7 +1378,7 @@ public class EventbusBridgeTest extends WebTestBase {
 
   private void testReceiveFail(String address, Object body) throws Exception {
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -1398,7 +1399,7 @@ public class EventbusBridgeTest extends WebTestBase {
   private void testUnregister(String address) throws Exception {
 
     CountDownLatch latch = new CountDownLatch(1);
-    BridgeClient client = new BridgeClient();
+    BridgeClient client = new BridgeClient(super.client, transport);
 
     client.connect(websocketURI).onComplete(onSuccess(v -> {
 
@@ -1562,12 +1563,19 @@ public class EventbusBridgeTest extends WebTestBase {
     void abruptClose();
   }
 
-  class BridgeClient {
+  static class BridgeClient {
 
+    private final HttpClient client;
+    private final Transport transport;
     private Future<TransportClient> transportClient;
     private BiConsumer<String, JsonObject> handler;
     private Handler<JsonObject> errorHandler;
     private Handler<Void> closeHandler;
+
+    public BridgeClient(HttpClient client, Transport transport) {
+      this.client = client;
+      this.transport = transport;
+    }
 
     public Future<Void> connect(String websocketURI) {
       if (transportClient != null) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/SlowClusterEventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/SlowClusterEventbusBridgeTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.ext.web.handler;
+
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.cluster.RegistrationInfo;
+import io.vertx.core.spi.cluster.WrappedClusterManager;
+import io.vertx.ext.bridge.BridgeEventType;
+import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.EventbusBridgeTest.BridgeClient;
+import io.vertx.ext.web.handler.EventbusBridgeTest.Transport;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.fakecluster.FakeClusterManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(Parameterized.class)
+public class SlowClusterEventbusBridgeTest extends VertxTestBase {
+
+  @Parameterized.Parameters(name = "{index}: transport = {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {Transport.RAW_WS}, {Transport.WS}
+    });
+  }
+
+  private final Transport transport;
+
+  private Vertx node1;
+  private Vertx node2;
+  private Router router;
+  private HttpServer server;
+  private HttpClient client;
+  protected SockJSHandler sockJS;
+
+  public SlowClusterEventbusBridgeTest(Transport transport) {
+    this.transport = transport;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    startNodes(2);
+    node1 = vertices[0];
+    node2 = vertices[1];
+    router = Router.router(node1);
+    server = node1.createHttpServer();
+    CountDownLatch latch = new CountDownLatch(1);
+    server.requestHandler(router).listen(0).onComplete(onSuccess(res -> latch.countDown()));
+    awaitLatch(latch);
+    client = node1.createHttpClient(new HttpClientOptions().setDefaultPort(server.actualPort()));
+    sockJS = SockJSHandler.create(node1);
+  }
+
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new SlowClusterManager(vertx);
+  }
+
+  @Test
+  public void testRegistration() throws Exception {
+    String payload = "hello slinkydeveloper!";
+    String addr = "someaddress";
+    String websocketURI = "/eventbus/websocket";
+
+    CountDownLatch registerLatch = new CountDownLatch(1);
+    CountDownLatch registeredLatch = new CountDownLatch(1);
+    CountDownLatch requestLatch = new CountDownLatch(1);
+
+    SockJSBridgeOptions allAccessOptions = new SockJSBridgeOptions()
+      .addInboundPermitted(new PermittedOptions())
+      .addOutboundPermitted(new PermittedOptions());
+
+    // 1. Check if REGISTER hook is called
+    // 2. Check if REGISTERED hook is called
+    // 3. Try to send a message while managing REGISTERED event
+    // 4. Check if bridgeClient receives the message
+    router.route("/eventbus/*").subRouter(
+      sockJS.bridge(allAccessOptions, be -> {
+        if (be.type() == BridgeEventType.REGISTER) {
+          assertNotNull(be.socket());
+          JsonObject raw = be.getRawMessage();
+          assertEquals(addr, raw.getString("address"));
+          registerLatch.countDown();
+        } else if (be.type() == BridgeEventType.REGISTERED) {
+          assertNotNull(be.socket());
+          JsonObject raw = be.getRawMessage();
+          assertEquals(addr, raw.getString("address"));
+
+          // The bridgeClient should be able to receive this message
+          node2.eventBus().send(addr, payload);
+
+          registeredLatch.countDown();
+        }
+        be.complete(true);
+      }));
+
+    BridgeClient bridgeClient = new BridgeClient(client, transport);
+
+    bridgeClient.handler((address, received) -> {
+      assertEquals(addr, address);
+      assertEquals(payload, received.getString("body"));
+      bridgeClient.close().onComplete(v2 -> requestLatch.countDown());
+    });
+
+    bridgeClient
+      .connect(websocketURI)
+      .compose(v -> bridgeClient.register(addr))
+      .onComplete(onSuccess(v -> {
+      }));
+
+    awaitLatch(registerLatch);
+    awaitLatch(registeredLatch);
+    awaitLatch(requestLatch);
+  }
+
+  private static class SlowClusterManager extends WrappedClusterManager {
+
+    final Vertx vertx;
+
+    SlowClusterManager(Vertx vertx) {
+      super(new FakeClusterManager());
+      this.vertx = vertx;
+    }
+
+    @Override
+    public void addRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+      vertx.setTimer(1000, l -> {
+        super.addRegistration(address, registrationInfo, promise);
+      });
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2407

Otherwise, when Vert.x is clustered and registration is slow, the consumer may miss some messages.