### PR TITLE
add ServiceRequest constructor for Message Object

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/ServiceRequest.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/ServiceRequest.java
@@ -2,6 +2,7 @@ package io.vertx.ext.web.api.service;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
@@ -49,6 +50,11 @@ public class ServiceRequest {
         headers.set(entry.getKey(), (String)entry.getValue());
       }
     }
+  }
+
+  public ServiceRequest(Message<Object> msg) {
+    JsonObject msgBody = (JsonObject) msg.body();
+    this(msgBody.getJsonObject("context"));
   }
 
   public ServiceRequest(JsonObject params, MultiMap headers, JsonObject user, JsonObject extra) {


### PR DESCRIPTION
Motivation:

Using the [RouteToEBServiceHandler.java](https://github.com/lukasalexanderweber/vertx-web/blob/master/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/RouteToEBServiceHandler.java) I send my OpenAPI operations to the eventbus. For my Handlers I always need to cast the msg body to a JSONObject and create a ServiceRequest for it like 

```
    @Override
    public void handle(Message<Object> msg)
    {
      JsonObject msgBody = (JsonObject) msg.body();
      ServiceRequest serviceRequest = new ServiceRequest(msgBody.getJsonObject("context"));
```

I thought that it might be nice to have a constructor for that. Maybe it's naive, if you think it's a bad idea just close the PR.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
