### PR TITLE
When detecting request ended, make sure processing stops with an error

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -132,6 +132,10 @@ public class BodyHandlerImpl implements BodyHandler {
           .handler(handler)
           .endHandler(handler::end)
           .resume();
+      } else {
+        LOG.error("Cannot register body handler after request has ended! " +
+          "Pause the request to make sure the BodyHandler can process the request body.");
+        context.fail(new Exception("BodyHandler started too late"));
       }
     } else {
       // on reroute we need to re-merge the form params if that was desired


### PR DESCRIPTION
A suggested fix for issue #2438 - if the `BodyHandler` was started too late,  make sure the developer knows they made a mistake by logging the problem, making a suggestion for a fix, and failing the request.