### PR TITLE
EventBusBridge must save registration locally before completion

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventBusBridgeImpl.java
@@ -239,10 +239,10 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
             }
           };
           MessageConsumer<?> reg = eb.consumer(address).handler(handler);
+          registrations.put(address, reg);
+          info.handlerCount++;
           reg.completion().onComplete(ar -> {
             if (ar.succeeded()) {
-              registrations.put(address, reg);
-              info.handlerCount++;
               // Notify registration completed
               checkCallHook(() -> new BridgeEventImpl(BridgeEventType.REGISTERED, rawMsg, sock));
             } else {
@@ -273,7 +273,7 @@ public class EventBusBridgeImpl implements Handler<SockJSSocket> {
           MessageConsumer<?> registration = registrations.remove(address);
           if (registration != null) {
             SockInfo info = sockInfos.get(sock);
-            registration.unregister();
+            registration.completion().onSuccess(v -> registration.unregister());
             info.handlerCount--;
           }
         } else {


### PR DESCRIPTION
See #2423

Otherwise, if the user unregisters immediately after registration, and the cluster registration is slow, there might be orphan registration.