### PR TITLE
Fix handlebars partial template resolution for windows

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.templ.handlebars.impl;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -71,7 +72,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
       if (template == null) {
         // either it's not cache or cache is disabled
-        int idx = src.lastIndexOf('/');
+        int idx = src.lastIndexOf(File.separator);
         String prefix = "";
         String basename = src;
         if (idx != -1) {


### PR DESCRIPTION
Motivation:

When developing locally on a Windows Machine while using Handlebars, it's often the use case to use partials.
The current implementation does not use Java's File Implementations/Path resolutions, and uses it's own way to handle this.
While it works on Unix based File-Systems, on Windows based ones this doesn't work, as it's checking for `/` characters explicitly, which is not the separator character for Windows.

Using Java's `File.separator` constant which is platform agnostic, this can be easily fixed.