### PR TITLE
Move blocking error logging to executor thread

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -32,6 +32,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -45,6 +47,7 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
     AtomicIntegerFieldUpdater.newUpdater(RoutingContextImplBase.class, "currentRouteNextFailureHandlerIndex");
 
   protected static final Logger LOG = LoggerFactory.getLogger(RoutingContext.class);
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   private final Set<RouteImpl> routes;
 
@@ -255,7 +258,9 @@ public abstract class RoutingContextImplBase implements RoutingContextInternal {
       }
     } else {
       // if there are no user defined handlers, we will log the exception
-      LOG.error("Unhandled exception in router", failure);
+      executor.execute(() -> {
+        LOG.error("Unhandled exception in router", failure);
+      });
     }
 
     if (!response().ended() && !response().closed()) {


### PR DESCRIPTION
Hi! :)

Thank you for this project.

This PR fixes a blocking call that happens when logging error as detected by BlockHound:
<img width="939" alt="Screen Shot 2023-07-27 at 7 43 38 AM" src="https://github.com/vert-x3/vertx-web/assets/56495631/8d243720-4892-4a48-8ba4-ff11f30d8035">


We re-ran the tests to ensure the fix is non-intrusive.
