### PR TITLE
Extends HttpServerRequestWrapper to access the routing context associated with the request

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/WebServerRequest.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/WebServerRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.web;
+
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * Extends to access the routing context associated with the request.
+ *
+ * @author Florian Bütler
+ */
+public interface WebServerRequest extends HttpServerRequest {
+
+  /**
+   * @return the Vert.x context associated with this server request
+   */
+  public abstract RoutingContext routingContext();
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -8,7 +8,8 @@ import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.AllowForwardHeaders;
-
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.WebServerRequest;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,7 @@ import java.util.Map;
  * Wraps the source {@link HttpServerRequestInternal}. It updates the method, path and query of the original request and
  * resumes the request if a caller explicitly sets a handler to any callback that processes the request body.
  */
-class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequestWrapper {
+class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequestWrapper implements WebServerRequest {
 
   private final ForwardedParser forwardedParser;
 
@@ -29,10 +30,16 @@ class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequest
   private String uri;
   private String absoluteURI;
   private MultiMap params;
+  private RoutingContext ctx;
 
   HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward) {
+    this(request, allowForward, null);
+  }
+
+  HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward, RoutingContext ctx) {
     super((HttpServerRequestInternal) request);
     forwardedParser = new ForwardedParser(request, allowForward);
+    this.ctx = ctx;
   }
 
   void changeTo(HttpMethod method, String uri) {
@@ -204,6 +211,11 @@ class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequest
   @Override
   public boolean isSSL() {
     return forwardedParser.isSSL();
+  }
+
+  @Override
+  public RoutingContext routingContext() {
+    return ctx;
   }
 
 }


### PR DESCRIPTION
Related to https://github.com/eclipse-vertx/vertx-http-proxy/issues/50

(Also https://github.com/vert-x3/vertx-web/pull/2461)