### PR TITLE
ForwardedParser improvements

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -20,6 +20,7 @@
 package io.vertx.ext.web.impl;
 
 import io.netty.util.AsciiString;
+import io.netty.util.NetUtil;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -204,12 +205,24 @@ class ForwardedParser {
   private SocketAddress parseFor(String forToParse, int defaultPort) {
     String host = forToParse;
     int port = defaultPort;
-    int portSeparatorIdx = forToParse.lastIndexOf(':');
-    if (portSeparatorIdx > forToParse.lastIndexOf(']')) {
-      host = forToParse.substring(0, portSeparatorIdx);
-      port = parsePort(forToParse.substring(portSeparatorIdx + 1), defaultPort);
+    if (forToParse.length() > 0 && forToParse.charAt(0) == '[') {
+      int idx = forToParse.lastIndexOf("]");
+      if (idx > 0) {
+        int portSeparatorIdx = forToParse.indexOf(':', idx + 1);
+        if (portSeparatorIdx > 0) {
+          host = forToParse.substring(0, idx + 1);
+          port = parsePort(forToParse.substring(idx + 2), defaultPort);
+        }
+      }
+    } else {
+      if (!NetUtil.isValidIpV6Address(forToParse)) {
+        int portSeparatorIdx = forToParse.lastIndexOf(':');
+        if (portSeparatorIdx > 0) {
+          host = forToParse.substring(0, portSeparatorIdx);
+          port = parsePort(forToParse.substring(portSeparatorIdx + 1), defaultPort);
+        }
+      }
     }
-
     return new SocketAddressImpl(port, host);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -62,6 +62,45 @@ public class ForwardedTest extends WebTestBase {
   }
 
   @Test
+  public void testXForwardedForIpv6() throws Exception {
+    String host = "[2001:db8:cafe::17]";
+    int port = 4711;
+
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      assertTrue(rc.request().remoteAddress().port() == port);
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-For", host + ":" + port);
+  }
+
+  @Test
+  public void testXForwardedForIpv6NoPort() throws Exception {
+    String host = "[2001:db8:cafe::17]";
+
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-For", host);
+  }
+
+  @Test
+  public void testXForwardedForRawIpv6NoPort() throws Exception {
+    // Make sure this is not seen as a host:port
+    String host = "2001:db8:85a3:8d3:1319:8a2e:370:9c82";
+
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      rc.end();
+    });
+
+    testRequest("X-Forwarded-For", host);
+  }
+
+  @Test
   public void testForwardedProto() throws Exception {
     router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());


### PR DESCRIPTION
The x-forwarded-XXX parser does not handle correctly raw IPV6 address… (not enclosed within square brackets) that some intermedaries can send, the parser will try to parse the port part of the actual IPV6 address.

This fixes the parser to handle IPV6 addresses when they are not enclosed within square brackets.
