### PR TITLE
GraphQLWS: store the RoutingContext in GraphQLContext

### DIFF
--- a/vertx-web-graphql/src/main/asciidoc/index.adoc
+++ b/vertx-web-graphql/src/main/asciidoc/index.adoc
@@ -179,13 +179,12 @@ Then you can return Vert.x futures directly.
 
 === Providing data fetchers with some context
 
-Very often, the {@link io.vertx.ext.web.handler.graphql.GraphQLHandler} will be declared after other route handlers.
+Very often, the {@link io.vertx.ext.web.handler.graphql.GraphQLHandler}, or the {@link io.vertx.ext.web.handler.graphql.ws.GraphQLWSHandler}, will be declared after other route handlers.
 For example, you could protect your application with authentication.
 
-In this case, it is likely that your data fetchers will need to know which user is logged-in to narrow down the results.
-Let's say your authentication layer stores a `User` object in the {@link io.vertx.ext.web.RoutingContext}.
+In this case, it is likely that your data fetchers will need to know which user is logged-in, to narrow down the results.
 
-You may retrieve this object by inspecting the `DataFetchingEnvironment`:
+For this, you may retrieve the {@link io.vertx.ext.web.RoutingContext} object by inspecting the `DataFetchingEnvironment`:
 
 [source,$lang]
 ----

--- a/vertx-web-graphql/src/main/java/examples/GraphQLExamples.java
+++ b/vertx-web-graphql/src/main/java/examples/GraphQLExamples.java
@@ -29,6 +29,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.UserContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.graphql.*;
 import io.vertx.ext.web.handler.graphql.instrumentation.JsonObjectAdapter;
@@ -143,9 +144,9 @@ public class GraphQLExamples {
   public void routingContextInDataFetchingEnvironment() {
     DataFetcher<CompletionStage<List<Link>>> dataFetcher = environment -> {
 
-      RoutingContext routingContext = GraphQLHandler.getRoutingContext(environment.getGraphQlContext());
+      RoutingContext routingContext = environment.getGraphQlContext().get(RoutingContext.class);
 
-      User user = routingContext.get("user");
+      UserContext user = routingContext.user();
 
       Future<List<Link>> future = retrieveLinksPostedBy(user);
       return future.toCompletionStage();
@@ -153,7 +154,7 @@ public class GraphQLExamples {
     };
   }
 
-  private Future<List<Link>> retrieveLinksPostedBy(User user) {
+  private Future<List<Link>> retrieveLinksPostedBy(UserContext user) {
     return null;
   }
 

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/ConnectionHandler.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/ConnectionHandler.java
@@ -29,6 +29,7 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.ExecutionInputBuilderWithContext;
 import io.vertx.ext.web.handler.graphql.impl.GraphQLQuery;
 import io.vertx.ext.web.handler.graphql.ws.ConnectionInitEvent;
@@ -37,12 +38,13 @@ import io.vertx.ext.web.handler.graphql.ws.MessageType;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
-import static io.vertx.ext.web.handler.graphql.impl.ErrorUtil.*;
+import static io.vertx.ext.web.handler.graphql.impl.ErrorUtil.toJsonObject;
 import static io.vertx.ext.web.handler.graphql.ws.MessageType.*;
 
 public class ConnectionHandler {
@@ -52,13 +54,15 @@ public class ConnectionHandler {
   private final GraphQLWSHandlerImpl graphQLWSHandler;
   private final ContextInternal context;
   private final ServerWebSocket socket;
+  private final RoutingContext routingContext;
 
   private ConnectionState state;
 
-  public ConnectionHandler(GraphQLWSHandlerImpl graphQLWSHandler, ContextInternal context, ServerWebSocket socket) {
+  public ConnectionHandler(GraphQLWSHandlerImpl graphQLWSHandler, ContextInternal context, ServerWebSocket socket, RoutingContext routingContext) {
     this.graphQLWSHandler = graphQLWSHandler;
     this.context = context;
     this.socket = socket;
+    this.routingContext = routingContext;
     state = new InitialState();
   }
 
@@ -349,6 +353,8 @@ public class ConnectionHandler {
       } else if (extensions != null && extensions.containsKey("persistedQuery")) {
         builder.query(PersistedQuerySupport.PERSISTED_QUERY_MARKER);
       }
+
+      builder.graphQLContext(Collections.singletonMap(RoutingContext.class, routingContext));
 
       Handler<ExecutionInputBuilderWithContext<Message>> beforeExecute = graphQLWSHandler.getBeforeExecute();
       if (beforeExecute != null) {

--- a/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/GraphQLWSHandlerImpl.java
+++ b/vertx-web-graphql/src/main/java/io/vertx/ext/web/handler/graphql/impl/ws/GraphQLWSHandlerImpl.java
@@ -91,7 +91,7 @@ public class GraphQLWSHandlerImpl implements GraphQLWSHandler {
         .toWebSocket()
         .onFailure(rc::fail)
         .onSuccess(socket -> {
-          ConnectionHandler handler = new ConnectionHandler(this, context, socket);
+          ConnectionHandler handler = new ConnectionHandler(this, context, socket, rc);
           handler.handleConnection();
         });
     } else {


### PR DESCRIPTION
This can be useful when, e.g. the webapp is protected with authentication.

This was already possible with the GraphQL handler