### PR TITLE
fix: don't update session on GET with token already set

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSRFHandlerImpl.java
@@ -126,6 +126,11 @@ public class CSRFHandlerImpl implements CSRFHandler {
           // it's not an option to change the same site policy
           .setSameSite(CookieSameSite.STRICT));
 
+    // only add the token to the session when the request ends successfully, doing this avoids storing a token that
+    // may due to error not make it to the browser. It is assumed that the token placed onto the context directly
+    // would only be returned to the user if the request completed successfully, thus they will remain in sync
+    ctx.addEndHandler(sessionTokenEndHandler(ctx, token));
+
     return token;
   }
 
@@ -340,10 +345,6 @@ public class CSRFHandlerImpl implements CSRFHandler {
             }
           }
         }
-        // only add the token to the session when the request ends successfully, doing this avoids storing a token that
-        // may due to error not make it to the browser. It is assumed that the token placed onto the context directly
-        // would only be returned to the user if the request completed successfully, thus they will remain in sync
-        ctx.addEndHandler(sessionTokenEndHandler(ctx, token));
         // put the token in the context for users who prefer to render the token directly on the HTML
         ctx.put(headerName, token);
         ctx.next();
@@ -355,10 +356,6 @@ public class CSRFHandlerImpl implements CSRFHandler {
         if (isValidRequest(ctx)) {
           // it matches, so refresh the token to avoid replay attacks
           token = generateToken(ctx);
-          // only add the token to the session when the request ends successfully, doing this avoids updating a token
-          // for a request that times out. It is assumed that the token placed onto the context directly would only
-          // be returned to the user if the request completed successfully, thus they will remain in sync
-          ctx.addEndHandler(sessionTokenEndHandler(ctx, token));
           // put the token in the context for users who prefer to
           // render the token directly on the HTML
           ctx.put(headerName, token);


### PR DESCRIPTION
Motivation:

The updated CSRF handler would attempt to set the token into the session even when a new one was
not generated, this opened a timing issue where a GET request that started during / before a POST
but ended after would revert the changed token, leaving the user stuck

Contributes To: https://github.com/vert-x3/vertx-web/issues/2447
