### PR TITLE
Fixes #2484

### DIFF
--- a/vertx-template-engines/vertx-web-templ-mvel/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-mvel/pom.xml
@@ -16,8 +16,7 @@
     <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
-      <!-- Stack version don't change this -->
-      <version>2.3.1.Final</version>
+      <version>2.5.0.Final</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
Motivation:

Fix issue #2484

We can also remove old @vietj comment "Stack version don't change this" and update it, because vert.x core stack don't use mvel anymore (as far as I know mvel was used by vertx-codegen, but it was refactored).

We already use vertx-web-templ-mvel with excluded and forced new version of mvel in our project on Java 21 without problems.
