### PR TITLE
Draft: Refactor authentication code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
     <module>vertx-web-validation</module>
     <module>vertx-web-openapi-router</module>
     <module>vertx-web-proxy</module>
+    <module>vertx-web-auth-common</module>
+    <module>vertx-web-auth-jwt</module>
   </modules>
 
   <profiles>

--- a/vertx-web-auth-common/pom.xml
+++ b/vertx-web-auth-common/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>vertx-web-parent</artifactId>
+    <groupId>io.vertx</groupId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-web-auth-common</artifactId>
+
+  <properties>
+    <doc.skip>true</doc.skip>
+  </properties>
+
+  <dependencies>
+      <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-auth-common</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AbstractUserContext.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AbstractUserContext.java
@@ -1,0 +1,140 @@
+package io.vertx.ext.auth.common;
+
+import java.util.Objects;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.common.HttpException;
+
+public abstract class AbstractUserContext implements UserContextInternal {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractUserContext.class);
+
+  protected AuthenticationContext ctx;
+  protected User user;
+
+  @Override
+  public void setUser(User user) {
+    this.user = user;
+  }
+
+  @Override
+  public User get() {
+    return user;
+  }
+
+  @Override
+  public Future<Void> refresh() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return refresh(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> refresh(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    // remove user from the context
+    this.user = null;
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public Future<Void> logout() {
+    return logout("/");
+  }
+
+  @Override
+  public Future<Void> impersonate() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return impersonate(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> impersonate(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    // remove the current user from the context to avoid any further access
+    this.user = null;
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public Future<Void> restore() {
+    if (!ctx.request().method().equals(HttpMethod.GET)) {
+      // we can't automate a redirect to a non-GET request
+      return Future.failedFuture(new HttpException(405, "Method not allowed"));
+    }
+    return restore(ctx.request().absoluteURI());
+  }
+
+  @Override
+  public Future<Void> restore(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public Future<Void> logout(String redirectUri) {
+    Objects.requireNonNull(redirectUri, "redirectUri cannot be null");
+
+    // clear the user
+    user = null;
+
+    // we should redirect the UA so this link becomes invalid
+    return ctx.response()
+      // disable all caching
+      .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+      .putHeader("Pragma", "no-cache")
+      .putHeader(HttpHeaders.EXPIRES, "0")
+      // redirect (when there is no state, redirect to home
+      .putHeader(HttpHeaders.LOCATION, redirectUri)
+      .setStatusCode(302)
+      .end("Redirecting to " + redirectUri + ".");
+  }
+
+  @Override
+  public void clear() {
+    user = null;
+  }
+
+}

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AuthenticationContext.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AuthenticationContext.java
@@ -1,0 +1,38 @@
+package io.vertx.ext.auth.common;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+
+/**
+ * Context that is being accepted by various authentication handlers.
+ * <p>
+ * The context allows access to the HTTP request and response to verify provided authentication information 
+ * <p>
+ * The {@link UserContext} provides access to the authenticated user.
+ * 
+ */
+public interface AuthenticationContext {
+
+  /**
+   * @return the HTTP request object
+   */
+  HttpServerRequest request();
+
+  /**
+   * @return the HTTP response object
+   */
+  HttpServerResponse response();
+
+  /**
+   * Control the user associated with this request. The user context allows accessing the security user object as well as perform authentication refreshes,
+   * logout and other operations.
+   * 
+   * @return the user context
+   */
+  UserContext user();
+
+  default void onContinue() {
+    // NOOP
+  }
+
+}

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AuthenticationHandler.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/AuthenticationHandler.java
@@ -14,22 +14,16 @@
  *  You may elect to redistribute this code under either of these licenses.
  */
 
-package io.vertx.ext.web.handler;
+package io.vertx.ext.auth.common;
 
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
-import io.vertx.ext.web.RoutingContext;
 
 /**
  * Base interface for auth handlers.
- * <p>
- * An auth handler allows your application to provide authentication support.
- * <p>
- * An Auth handler may require a {@link SessionHandler} to be on the routing chain before it.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-@VertxGen(concrete = false)
-public interface AuthenticationHandler extends Handler<RoutingContext> {
+public interface AuthenticationHandler<C extends AuthenticationContext> extends Handler<C> {
+
 }

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/UserContext.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/UserContext.java
@@ -13,7 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-package io.vertx.ext.web;
+package io.vertx.ext.auth.common;
 
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
@@ -52,7 +52,9 @@ public interface UserContext {
    * @return fluent self
    */
   @Fluent
-  UserContext loginHint(String loginHint);
+  default UserContext loginHint(String loginHint) {
+    return this;
+  }
 
   /**
    * Forces the current user to re-authenticate. The user will be redirected to the same origin where this call was

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/UserContextInternal.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/UserContextInternal.java
@@ -1,7 +1,6 @@
-package io.vertx.ext.web.impl;
+package io.vertx.ext.auth.common;
 
 import io.vertx.ext.auth.User;
-import io.vertx.ext.web.UserContext;
 
 public interface UserContextInternal extends UserContext {
 

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/handler/AuthenticationHandlerInternal.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/handler/AuthenticationHandlerInternal.java
@@ -1,21 +1,21 @@
-package io.vertx.ext.web.handler.impl;
+package io.vertx.ext.auth.common.handler;
 
 import io.vertx.core.Future;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.AuthenticationHandler;
+import io.vertx.ext.auth.common.AuthenticationContext;
+import io.vertx.ext.auth.common.AuthenticationHandler;
 
-public interface AuthenticationHandlerInternal extends AuthenticationHandler {
+public interface AuthenticationHandlerInternal<C extends AuthenticationContext> extends AuthenticationHandler<C> {
 
   /**
    * Parses the credentials from the request into a JsonObject. The implementation should
    * be able to extract the required info for the auth provider in the format the provider
    * expects.
    *
-   * @param context the routing context
+   * @param context the authentication context
    * @return future user to be called once the information is available.
    */
-  Future<User> authenticate(RoutingContext context);
+  Future<User> authenticate(C context);
 
   /**
    * Applies a {@code WWW-Authenticate} Response Header.
@@ -24,10 +24,10 @@ public interface AuthenticationHandlerInternal extends AuthenticationHandler {
    * acceptable Authorization header is not sent, the server responds with
    * a "401 Unauthorized" status code, and a WWW-Authenticate header.
    *
-   * @param context the routing context
+   * @param context the authentication context
    * @return the {@code true} if a header was added.
    */
-  default boolean setAuthenticateHeader(RoutingContext context) {
+  default boolean setAuthenticateHeader(C context) {
     return false;
   }
 
@@ -36,11 +36,10 @@ public interface AuthenticationHandlerInternal extends AuthenticationHandler {
    * Overrides must call {@link RoutingContext#next()} on success. Implementations must call this handler
    * at the end of the authentication process.
    *
-   * @param ctx the routing context
+   * @param ctx the authentication context
+   * @param authenticated the authenticated user
    */
-  default void postAuthentication(RoutingContext ctx) {
-    ctx.next();
-  }
+  void postAuthentication(C ctx, User authenticated);
 
   /**
    * Signal that this handler can perform an HTTP redirect during the authentication mechanism. In this case

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/handler/impl/HTTPAuthorizationHandler.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/auth/common/handler/impl/HTTPAuthorizationHandler.java
@@ -13,20 +13,22 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-package io.vertx.ext.web.handler.impl;
+package io.vertx.ext.auth.common.handler.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
-import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.auth.common.AuthenticationContext;
+
+import static io.vertx.ext.web.common.HttpException.*;
 
 /**
  * This a common handler for auth handler that use the `Authorization` HTTP header.
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-public abstract class HTTPAuthorizationHandler<T extends AuthenticationProvider> extends AuthenticationHandlerImpl<T> {
+public abstract class HTTPAuthorizationHandler<C extends AuthenticationContext, T extends AuthenticationProvider> extends AuthenticationHandlerImpl<C, T> {
 
   // this should match the IANA registry: https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
   public enum Type {
@@ -73,11 +75,11 @@ public abstract class HTTPAuthorizationHandler<T extends AuthenticationProvider>
     }
   }
 
-  protected final Future<String> parseAuthorization(RoutingContext ctx) {
+  protected final Future<String> parseAuthorization(AuthenticationContext ctx) {
     return parseAuthorization(ctx, false);
   }
 
-  protected final Future<String> parseAuthorization(RoutingContext ctx, boolean optional) {
+  protected final Future<String> parseAuthorization(AuthenticationContext ctx, boolean optional) {
 
     final HttpServerRequest request = ctx.request();
     final String authorization = request.headers().get(HttpHeaders.AUTHORIZATION);
@@ -109,7 +111,7 @@ public abstract class HTTPAuthorizationHandler<T extends AuthenticationProvider>
   }
 
   @Override
-  public boolean setAuthenticateHeader(RoutingContext context) {
+  public boolean setAuthenticateHeader(AuthenticationContext context) {
     if (realm != null && realm.length() > 0) {
       context.response()
         .headers()

--- a/vertx-web-auth-common/src/main/java/io/vertx/ext/web/common/HttpException.java
+++ b/vertx-web-auth-common/src/main/java/io/vertx/ext/web/common/HttpException.java
@@ -13,7 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-package io.vertx.ext.web.handler;
+package io.vertx.ext.web.common;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -30,6 +30,10 @@ import io.netty.handler.codec.http.HttpResponseStatus;
  */
 public final class HttpException extends RuntimeException {
 
+  public static final HttpException UNAUTHORIZED = new HttpException(401);
+  public static final HttpException BAD_REQUEST = new HttpException(400);
+  public static final HttpException BAD_METHOD = new HttpException(405);
+  
   private final int statusCode;
   private final String payload;
 

--- a/vertx-web-auth-common/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-web-auth-common/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Automatic-Module-Name: io.vertx.web.auth-common
+

--- a/vertx-web-auth-jwt/pom.xml
+++ b/vertx-web-auth-jwt/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>vertx-web-parent</artifactId>
+    <groupId>io.vertx</groupId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-web-auth-jwt</artifactId>
+
+  <properties>
+    <doc.skip>true</doc.skip>
+  </properties>
+
+  <dependencies>
+  </dependencies>
+</project>

--- a/vertx-web-auth-jwt/src/main/resources/META-INF/MANIFEST.MF
+++ b/vertx-web-auth-jwt/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Automatic-Module-Name: io.vertx.web.auth-jwt

--- a/vertx-web/pom.xml
+++ b/vertx-web/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-auth-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-bridge-common</artifactId>
     </dependency>
     <!--

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -808,14 +808,14 @@ public class WebExamples {
 
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
 
-    AuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
+    WebAuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
   }
 
   public void example38(Vertx vertx, AuthenticationProvider authProvider, Router router) {
 
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
 
-    AuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
+    WebAuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
 
     // All requests to paths starting with '/private/' will be protected
     router.route("/private/*").handler(basicAuthHandler);
@@ -1102,7 +1102,7 @@ public class WebExamples {
 
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
 
-    AuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
+    WebAuthenticationHandler basicAuthHandler = BasicAuthHandler.create(authProvider);
 
     router.route("/eventbus/*").handler(basicAuthHandler);
 
@@ -1813,7 +1813,7 @@ public class WebExamples {
     router.allowForward(AllowForwardHeaders.NONE);
   }
 
-  public void example78(Router router, AuthenticationHandler authNHandlerA, AuthenticationHandler authNHandlerB, AuthenticationHandler authNHandlerC) {
+  public void example78(Router router, WebAuthenticationHandler authNHandlerA, WebAuthenticationHandler authNHandlerB, WebAuthenticationHandler authNHandlerC) {
 
     // Chain will verify (A Or (B And C))
     ChainAuthHandler chain =

--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -25,7 +25,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 
 import java.util.List;
 import java.util.Map;

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -24,6 +24,8 @@ import io.vertx.core.http.impl.MimeMapping;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
+import io.vertx.ext.auth.common.AuthenticationContext;
+import io.vertx.ext.auth.common.UserContext;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.impl.Utils;
 
@@ -55,7 +57,7 @@ import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface RoutingContext {
+public interface RoutingContext extends AuthenticationContext {
 
   /**
    * @return the HTTP request object

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/APIKeyHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/APIKeyHandler.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  * @author Paulo Lopes
  */
 @VertxGen
-public interface APIKeyHandler extends AuthenticationHandler {
+public interface APIKeyHandler extends WebAuthenticationHandler {
 
   /**
    * Create an API Key authentication handler

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/BasicAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/BasicAuthHandler.java
@@ -26,7 +26,7 @@ import io.vertx.ext.web.handler.impl.BasicAuthHandlerImpl;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface BasicAuthHandler extends AuthenticationHandler {
+public interface BasicAuthHandler extends WebAuthenticationHandler {
 
   /**
    * The default realm to use

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/ChainAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/ChainAuthHandler.java
@@ -25,7 +25,7 @@ import io.vertx.ext.web.handler.impl.ChainAuthHandlerImpl;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-public interface ChainAuthHandler extends AuthenticationHandler {
+public interface ChainAuthHandler extends WebAuthenticationHandler {
 
   /**
    * Create a chain authentication handler that will assert that all handlers pass the verification.
@@ -51,5 +51,5 @@ public interface ChainAuthHandler extends AuthenticationHandler {
    *
    */
   @Fluent
-  ChainAuthHandler add(AuthenticationHandler other);
+  ChainAuthHandler add(WebAuthenticationHandler other);
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/DigestAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/DigestAuthHandler.java
@@ -27,7 +27,7 @@ import io.vertx.ext.web.handler.impl.DigestAuthHandlerImpl;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-public interface DigestAuthHandler extends AuthenticationHandler {
+public interface DigestAuthHandler extends WebAuthenticationHandler {
 
   /**
    * The default nonce expire timeout to use in milliseconds.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/FormLoginHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/FormLoginHandler.java
@@ -29,7 +29,7 @@ import io.vertx.ext.web.handler.impl.FormLoginHandlerImpl;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface FormLoginHandler extends AuthenticationHandler {
+public interface FormLoginHandler extends WebAuthenticationHandler {
 
   /**
    * The default value of the form attribute which will contain the username

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/JWTAuthHandler.java
@@ -29,7 +29,7 @@ import java.util.List;
  * @author Paulo Lopes
  */
 @VertxGen
-public interface JWTAuthHandler extends AuthenticationHandler {
+public interface JWTAuthHandler extends WebAuthenticationHandler {
 
   /**
    * Create a JWT auth handler. When no scopes are explicit declared, the default scopes will be looked up from the

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OAuth2AuthHandler.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @author Paulo Lopes
  */
 @VertxGen
-public interface OAuth2AuthHandler extends AuthenticationHandler {
+public interface OAuth2AuthHandler extends WebAuthenticationHandler {
 
   /**
    * Create a OAuth2 auth handler with host pinning. When no scopes are explicit declared, the default scopes will be

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
@@ -22,7 +22,6 @@ import io.vertx.ext.auth.otp.hotp.HotpAuth;
 import io.vertx.ext.auth.otp.totp.TotpAuth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.UserContext;
 import io.vertx.ext.web.handler.impl.HotpAuthHandlerImpl;
 import io.vertx.ext.web.handler.impl.TotpAuthHandlerImpl;
 
@@ -32,7 +31,7 @@ import io.vertx.ext.web.handler.impl.TotpAuthHandlerImpl;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-public interface OtpAuthHandler extends AuthenticationHandler {
+public interface OtpAuthHandler extends WebAuthenticationHandler {
 
   /**
    * Create a new instance of this handler using a time based one time password authentication provider.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/RedirectAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/RedirectAuthHandler.java
@@ -26,7 +26,7 @@ import io.vertx.ext.web.handler.impl.RedirectAuthHandlerImpl;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface RedirectAuthHandler extends AuthenticationHandler {
+public interface RedirectAuthHandler extends WebAuthenticationHandler {
 
   /**
    * Default path the user will be redirected to

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/SimpleAuthenticationHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/SimpleAuthenticationHandler.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-public interface SimpleAuthenticationHandler extends AuthenticationHandler {
+public interface SimpleAuthenticationHandler extends WebAuthenticationHandler {
 
   /**
    * Creates a new instance of the simple authentication handler.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/WebAuthenticationHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/WebAuthenticationHandler.java
@@ -1,0 +1,20 @@
+package io.vertx.ext.web.handler;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.ext.auth.common.AuthenticationHandler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Base interface for Vert.x Web authentication handlers.
+ * <p>
+ * An auth handler allows your application to provide authentication support.
+ * <p>
+ * An Auth handler may require a {@link SessionHandler} to be on the routing chain before it.
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ */
+@VertxGen(concrete = false)
+public interface WebAuthenticationHandler extends AuthenticationHandler<RoutingContext> {
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/WebAuthnHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/WebAuthnHandler.java
@@ -27,7 +27,7 @@ import io.vertx.ext.web.handler.impl.WebAuthnHandlerImpl;
  * @author Paulo Lopes
  */
 @VertxGen
-public interface WebAuthnHandler extends AuthenticationHandler {
+public interface WebAuthnHandler extends WebAuthenticationHandler {
 
   /**
    * Create a WebAuthN auth handler. This handler expects at least the response callback to be installed.

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/APIKeyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/APIKeyHandlerImpl.java
@@ -25,15 +25,17 @@ import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.auth.authentication.TokenCredentials;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.APIKeyHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import java.util.function.Function;
 
+import static io.vertx.ext.web.common.HttpException.UNAUTHORIZED;
+
 /**
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
-public class APIKeyHandlerImpl extends AuthenticationHandlerImpl<AuthenticationProvider> implements APIKeyHandler {
+public class APIKeyHandlerImpl extends WebAuthenticationHandlerImpl<AuthenticationProvider> implements APIKeyHandler {
 
   enum Type {
     HEADER,

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
@@ -25,7 +25,7 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.AuthorizationHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import java.util.*;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BasicAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BasicAuthHandlerImpl.java
@@ -24,7 +24,7 @@ import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BasicAuthHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import java.nio.charset.StandardCharsets;
@@ -35,7 +35,7 @@ import static io.vertx.ext.auth.impl.Codec.base64Decode;
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class BasicAuthHandlerImpl extends HTTPAuthorizationHandler<AuthenticationProvider> implements BasicAuthHandler {
+public class BasicAuthHandlerImpl extends WebHTTPAuthorizationHandler<AuthenticationProvider> implements BasicAuthHandler {
 
   public BasicAuthHandlerImpl(AuthenticationProvider authProvider, String realm) {
     super(authProvider, Type.BASIC, realm);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSPHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CSPHandlerImpl.java
@@ -2,7 +2,7 @@ package io.vertx.ext.web.handler.impl;
 
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CSPHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 
 import java.util.*;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/DigestAuthHandlerImpl.java
@@ -26,12 +26,13 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.VertxContextPRNG;
 import io.vertx.ext.auth.audit.Marker;
 import io.vertx.ext.auth.audit.SecurityAudit;
+import io.vertx.ext.auth.common.handler.impl.HTTPAuthorizationHandler;
 import io.vertx.ext.auth.htdigest.HtdigestAuth;
 import io.vertx.ext.auth.htdigest.HtdigestCredentials;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.DigestAuthHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import java.security.MessageDigest;
@@ -42,11 +43,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.vertx.ext.auth.impl.Codec.base16Encode;
+import static io.vertx.ext.web.common.HttpException.UNAUTHORIZED;
 
 /**
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-public class DigestAuthHandlerImpl extends HTTPAuthorizationHandler<HtdigestAuth> implements DigestAuthHandler {
+public class DigestAuthHandlerImpl extends WebHTTPAuthorizationHandler<HtdigestAuth> implements DigestAuthHandler {
 
   private final static Logger LOG = LoggerFactory.getLogger(HTTPAuthorizationHandler.class);
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/FormLoginHandlerImpl.java
@@ -29,13 +29,16 @@ import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.FormLoginHandler;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.impl.RoutingContextInternal;
+
+import static io.vertx.ext.web.common.HttpException.BAD_METHOD;
+import static io.vertx.ext.web.common.HttpException.BAD_REQUEST;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class FormLoginHandlerImpl extends AuthenticationHandlerImpl<AuthenticationProvider> implements FormLoginHandler {
+public class FormLoginHandlerImpl extends WebAuthenticationHandlerImpl<AuthenticationProvider> implements FormLoginHandler {
 
   private String usernameParam;
   private String passwordParam;
@@ -104,7 +107,7 @@ public class FormLoginHandlerImpl extends AuthenticationHandlerImpl<Authenticati
   }
 
   @Override
-  public void postAuthentication(RoutingContext ctx) {
+  public void postAuthentication(RoutingContext ctx, User user) {
     HttpServerRequest req = ctx.request();
     Session session = ctx.session();
     if (session != null) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
@@ -28,7 +28,7 @@ import io.vertx.ext.auth.otp.hotp.HotpAuth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.OtpAuthHandler;
 import io.vertx.ext.web.impl.OrderListener;
 import io.vertx.ext.web.impl.RoutingContextInternal;
@@ -36,7 +36,7 @@ import io.vertx.ext.web.impl.RoutingContextInternal;
 /**
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
-public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> implements OtpAuthHandler, OrderListener {
+public class HotpAuthHandlerImpl extends WebAuthenticationHandlerImpl<HotpAuth> implements OtpAuthHandler, OrderListener {
 
   private final OtpKeyGenerator otpKeyGen;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -37,12 +37,12 @@ import io.vertx.ext.auth.oauth2.Oauth2Credentials;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.OAuth2AuthHandler;
 import io.vertx.ext.web.impl.OrderListener;
 import io.vertx.ext.web.impl.Origin;
 import io.vertx.ext.web.impl.RoutingContextInternal;
-import io.vertx.ext.web.impl.UserContextInternal;
+import io.vertx.ext.auth.common.UserContextInternal;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -52,7 +52,7 @@ import java.util.*;
 /**
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
  */
-public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> implements OAuth2AuthHandler, ScopedAuthentication<OAuth2AuthHandler>, OrderListener {
+public class OAuth2AuthHandlerImpl extends WebHTTPAuthorizationHandler<OAuth2Auth> implements OAuth2AuthHandler, ScopedAuthentication<RoutingContext, OAuth2AuthHandler>, OrderListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuth2AuthHandlerImpl.class);
 
@@ -334,7 +334,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
    * The default behavior for post-authentication
    */
   @Override
-  public void postAuthentication(RoutingContext ctx) {
+  public void postAuthentication(RoutingContext ctx, User authenticatedUser) {
     // the user is authenticated, however the user may not have all the required scopes
     final List<String> scopes = getScopesOrSearchMetadata(this.scopes, ctx);
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/RedirectAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/RedirectAuthHandlerImpl.java
@@ -21,14 +21,14 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.RedirectAuthHandler;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
-public class RedirectAuthHandlerImpl extends AuthenticationHandlerImpl<AuthenticationProvider> implements RedirectAuthHandler {
+public class RedirectAuthHandlerImpl extends WebAuthenticationHandlerImpl<AuthenticationProvider> implements RedirectAuthHandler {
 
   private final String loginRedirectURL;
   private final String returnURLParam;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ScopedAuthentication.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ScopedAuthentication.java
@@ -2,11 +2,11 @@ package io.vertx.ext.web.handler.impl;
 
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.AuthenticationHandler;
+import io.vertx.ext.auth.common.AuthenticationContext;
+import io.vertx.ext.auth.common.AuthenticationHandler;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Internal interface for scope aware Authentication handlers.
@@ -14,7 +14,7 @@ import java.util.Map;
  * @param <SELF>
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
-public interface ScopedAuthentication<SELF extends AuthenticationHandler> {
+public interface ScopedAuthentication<C extends AuthenticationContext, SELF extends AuthenticationHandler<C>> {
 
   /**
    * Return a new instance with the internal state copied from the caller but the scopes to be requested during a token

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -29,7 +29,7 @@ import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 import io.vertx.ext.web.impl.Signature;
-import io.vertx.ext.web.impl.UserContextInternal;
+import io.vertx.ext.auth.common.UserContextInternal;
 import io.vertx.ext.web.sstore.SessionStore;
 import io.vertx.ext.web.sstore.impl.SessionInternal;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SimpleAuthenticationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SimpleAuthenticationHandlerImpl.java
@@ -5,13 +5,13 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.audit.Marker;
 import io.vertx.ext.auth.audit.SecurityAudit;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.SimpleAuthenticationHandler;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
 import java.util.function.Function;
 
-public class SimpleAuthenticationHandlerImpl extends AuthenticationHandlerImpl<NOOPAuthenticationProvider> implements SimpleAuthenticationHandler {
+public class SimpleAuthenticationHandlerImpl extends WebAuthenticationHandlerImpl<NOOPAuthenticationProvider> implements SimpleAuthenticationHandler {
 
   private Function<RoutingContext, Future<User>> authn;
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
@@ -28,15 +28,17 @@ import io.vertx.ext.auth.otp.totp.TotpAuth;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.OtpAuthHandler;
 import io.vertx.ext.web.impl.OrderListener;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
+import static io.vertx.ext.web.common.HttpException.UNAUTHORIZED;
+
 /**
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
-public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> implements OtpAuthHandler, OrderListener {
+public class TotpAuthHandlerImpl extends WebAuthenticationHandlerImpl<TotpAuth> implements OtpAuthHandler, OrderListener {
 
   private final OtpKeyGenerator otpKeyGen;
 
@@ -63,7 +65,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
     final User user = ctx.user().get();
 
     if (user == null) {
-      return Future.failedFuture(new HttpException(401));
+      return Future.failedFuture(UNAUTHORIZED);
     } else {
       Boolean userOtp = user.get("mfa");
       // user hasn't 2fa yet?

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
@@ -21,7 +21,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.UserContextInternal;
+import io.vertx.ext.auth.common.UserContextInternal;
 import io.vertx.ext.web.impl.Utils;
 
 import java.nio.charset.StandardCharsets;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthenticationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthenticationHandlerImpl.java
@@ -1,0 +1,58 @@
+package io.vertx.ext.web.handler.impl;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.common.handler.impl.AuthenticationHandlerImpl;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.HttpException;
+
+public abstract class WebAuthenticationHandlerImpl<T extends AuthenticationProvider> extends AuthenticationHandlerImpl<RoutingContext, T> {
+
+  public WebAuthenticationHandlerImpl(T authProvider) {
+    super(authProvider, null);
+  }
+
+  public WebAuthenticationHandlerImpl(T authProvider, String mfa) {
+    super(authProvider, mfa);
+  }
+
+  public void postAuthentication(RoutingContext ctx, User user) {
+    ctx.next();
+  }
+
+  // TODO remove duplicated code from WebAuthenticationHandlerImpl
+  /**
+   * This method is protected so custom auth handlers can override the default error handling
+   */
+  protected void processException(RoutingContext ctx, Throwable exception) {
+    if (exception != null) {
+      if (exception instanceof HttpException) {
+        final int statusCode = ((HttpException) exception).getStatusCode();
+        final String payload = ((HttpException) exception).getPayload();
+
+        switch (statusCode) {
+        case 302:
+          ctx.response()
+            .putHeader(HttpHeaders.LOCATION, payload)
+            .setStatusCode(302)
+            .end("Redirecting to " + payload + ".");
+          return;
+        case 401:
+          if (!"XMLHttpRequest".equals(ctx.request().getHeader("X-Requested-With"))) {
+            setAuthenticateHeader(ctx);
+          }
+          ctx.fail(401, exception);
+          return;
+        default:
+          ctx.fail(statusCode, exception);
+          return;
+        }
+      }
+    }
+
+    // fallback 500
+    ctx.fail(exception);
+  }
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthnHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthnHandlerImpl.java
@@ -27,14 +27,14 @@ import io.vertx.ext.auth.webauthn.impl.attestation.AttestationException;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.WebAuthnHandler;
 import io.vertx.ext.web.impl.OrderListener;
 import io.vertx.ext.web.impl.Origin;
-import io.vertx.ext.web.impl.UserContextInternal;
+import io.vertx.ext.auth.common.UserContextInternal;
 import io.vertx.ext.web.impl.RoutingContextInternal;
 
-public class WebAuthnHandlerImpl extends AuthenticationHandlerImpl<WebAuthn> implements WebAuthnHandler, OrderListener {
+public class WebAuthnHandlerImpl extends WebAuthenticationHandlerImpl<WebAuthn> implements WebAuthnHandler, OrderListener {
 
   private static final boolean CONFORMANCE = Boolean.getBoolean("io.vertx.ext.web.fido2.conformance.tests");
 

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebHTTPAuthorizationHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebHTTPAuthorizationHandler.java
@@ -1,0 +1,56 @@
+package io.vertx.ext.web.handler.impl;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.common.handler.impl.HTTPAuthorizationHandler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.HttpException;
+
+public abstract class WebHTTPAuthorizationHandler<T extends AuthenticationProvider> extends HTTPAuthorizationHandler<RoutingContext, T> {
+
+  public WebHTTPAuthorizationHandler(T authProvider, Type type, String realm) {
+    super(authProvider, type, realm);
+  }
+
+  public void postAuthentication(RoutingContext ctx, User authenticatedUser) {
+    ctx.next();
+  }
+  
+  
+  // TODO remove duplicated code from WebAuthenticationHandlerImpl
+  /**
+   * This method is protected so custom auth handlers can override the default error handling
+   */
+  protected void processException(RoutingContext ctx, Throwable exception) {
+    if (exception != null) {
+      if (exception instanceof HttpException) {
+        final int statusCode = ((HttpException) exception).getStatusCode();
+        final String payload = ((HttpException) exception).getPayload();
+
+        switch (statusCode) {
+        case 302:
+          ctx.response()
+            .putHeader(HttpHeaders.LOCATION, payload)
+            .setStatusCode(302)
+            .end("Redirecting to " + payload + ".");
+          return;
+        case 401:
+          if (!"XMLHttpRequest".equals(ctx.request().getHeader("X-Requested-With"))) {
+            setAuthenticateHeader(ctx);
+          }
+          ctx.fail(401, exception);
+          return;
+        default:
+          ctx.fail(statusCode, exception);
+          return;
+        }
+      }
+    }
+
+    // fallback 500
+    ctx.fail(exception);
+  }
+
+
+}

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -22,6 +22,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.impl.URIDecoder;
 import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.auth.common.AuthenticationHandler;
 import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.*;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.web.impl;
 
 import io.vertx.codegen.annotations.Nullable;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -11,6 +12,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.audit.SecurityAudit;
+import io.vertx.ext.auth.common.UserContext;
 import io.vertx.ext.web.*;
 
 import java.nio.charset.Charset;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -21,12 +21,12 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.ext.auth.common.UserContext;
 import io.vertx.ext.web.*;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.handler.impl.UserHolder;
 
 import java.nio.charset.Charset;
@@ -140,6 +140,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     if (!iterateNext()) {
       checkHandleNoMatch();
     }
+  }
+
+  @Override
+  public void onContinue() {
+    next();
   }
 
   private void checkHandleNoMatch() {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImplBase.java
@@ -26,7 +26,7 @@ import io.vertx.ext.auth.audit.impl.SecurityAuditNOOP;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.common.HttpException;
 
 import java.util.HashSet;
 import java.util.Iterator;

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -25,6 +25,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.auth.common.UserContext;
 import io.vertx.ext.web.*;
 
 import java.nio.charset.Charset;

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthHandlerTestBase.java
@@ -25,7 +25,7 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.auth.properties.PropertyFileAuthorization;
 import io.vertx.ext.web.WebTestBase;
-import io.vertx.ext.web.impl.UserContextInternal;
+import io.vertx.ext.auth.common.UserContextInternal;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.AfterClass;
@@ -53,7 +53,7 @@ public abstract class AuthHandlerTestBase extends WebTestBase {
     testAuthorization("tim", true, PermissionBasedAuthorization.create("knitter"));
   }
 
-  protected abstract AuthenticationHandler createAuthHandler(AuthenticationProvider authProvider);
+  protected abstract WebAuthenticationHandler createAuthHandler(AuthenticationProvider authProvider);
 
   protected boolean requiresSession() {
     return false;
@@ -72,7 +72,7 @@ public abstract class AuthHandlerTestBase extends WebTestBase {
     AuthenticationProvider authNProvider = PropertyFileAuthentication.create(vertx, "login/loginusers.properties");
     AuthorizationProvider authZProvider = PropertyFileAuthorization.create(vertx, "login/loginusers.properties");
 
-    AuthenticationHandler authNHandler = createAuthHandler(authNProvider);
+    WebAuthenticationHandler authNHandler = createAuthHandler(authNProvider);
     router.route().handler(rc -> {
       // we need to be logged in
       if (!rc.user().authenticated()) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthXRequestedWithTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/AuthXRequestedWithTest.java
@@ -59,7 +59,7 @@ public class AuthXRequestedWithTest extends AuthHandlerTestBase {
   }
 
   @Override
-  protected AuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
+  protected WebAuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
     return BasicAuthHandler.create(authProvider);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthHandlerTest.java
@@ -25,6 +25,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.ext.auth.VertxContextPRNG;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.common.AuthenticationHandler;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
@@ -214,7 +215,7 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
   }
 
   @Override
-  protected AuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
+  protected WebAuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
     return BasicAuthHandler.create(authProvider);
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BasicAuthImpersonationTest.java
@@ -9,6 +9,7 @@ import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.auth.properties.PropertyFileAuthorization;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.Test;
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerAndTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerAndTest.java
@@ -17,7 +17,7 @@ public class ChainAuthHandlerAndTest extends WebTestBase {
     super.setUp();
 
     authProvider = PropertyFileAuthentication.create(vertx, "login/loginusers.properties");
-    AuthenticationHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
+    WebAuthenticationHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
 
     // create a chain
     chain = ChainAuthHandler.all()

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthHandlerTest.java
@@ -20,7 +20,7 @@ public class ChainAuthHandlerTest extends WebTestBase {
     super.setUp();
 
     authProvider = PropertyFileAuthentication.create(vertx, "login/loginusers.properties");
-    AuthenticationHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
+    WebAuthenticationHandler redirectAuthHandler = RedirectAuthHandler.create(authProvider);
 
     // create a chain
     chain = ChainAuthHandler.any()

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthMixHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/ChainAuthMixHandlerTest.java
@@ -8,6 +8,7 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import org.junit.Test;
 
@@ -17,11 +18,11 @@ public class ChainAuthMixHandlerTest extends WebTestBase {
 
   private static final User USER = User.create(new JsonObject().put("id", "paulo"));
 
-  private final AuthenticationHandler success = SimpleAuthenticationHandler.create()
+  private final WebAuthenticationHandler success = SimpleAuthenticationHandler.create()
     .authenticate(ctx -> Future.succeededFuture(USER));
 
 
-  private final AuthenticationHandler failure = SimpleAuthenticationHandler.create()
+  private final WebAuthenticationHandler failure = SimpleAuthenticationHandler.create()
     .authenticate(ctx -> Future.failedFuture(new HttpException(401)));
 
   @Test

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/CustomAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/CustomAuthHandlerTest.java
@@ -24,18 +24,20 @@ import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.HttpException;
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class CustomAuthHandlerTest extends AuthHandlerTestBase {
 
   @Override
-  protected AuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
+  protected WebAuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
     return newAuthHandler(authProvider, null);
   }
 
-  private AuthenticationHandler newAuthHandler(AuthenticationProvider authProvider, Handler<Throwable> exceptionProcessor) {
+  private WebAuthenticationHandler newAuthHandler(AuthenticationProvider authProvider, Handler<Throwable> exceptionProcessor) {
 
     return SimpleAuthenticationHandler.create()
       .authenticate(ctx -> {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/EventbusBridgeTest.java
@@ -1166,7 +1166,7 @@ public class EventbusBridgeTest extends WebTestBase {
     testError(new JsonObject().put("type", "send").put("address", addr).put("body", "foo"), "access_denied");
   }
 
-  private AuthenticationHandler addLoginHandler(AuthenticationProvider authProvider) {
+  private WebAuthenticationHandler addLoginHandler(AuthenticationProvider authProvider) {
     return SimpleAuthenticationHandler.create()
       .authenticate(ctx -> {
         if (ctx.user().get() == null) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2AuthHandlerTest.java
@@ -677,7 +677,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
 
     latch.await();
 
-    AuthenticationHandler oauth2Handler = BasicAuthHandler.create(oauth2);
+    WebAuthenticationHandler oauth2Handler = BasicAuthHandler.create(oauth2);
 
     // protect everything under /protected
     router.route("/protected/*").handler(oauth2Handler);

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/OAuth2ImpersonationTest.java
@@ -26,6 +26,7 @@ import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.auth.oauth2.authorization.ScopeAuthorization;
 import io.vertx.ext.web.WebTestBase;
+import io.vertx.ext.web.common.HttpException;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.Test;
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/RedirectAuthHandlerTest.java
@@ -21,6 +21,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.common.AuthenticationHandler;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
@@ -229,7 +230,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
   }
 
   @Override
-  protected AuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
+  protected WebAuthenticationHandler createAuthHandler(AuthenticationProvider authProvider) {
     return RedirectAuthHandler.create(authProvider);
   }
 


### PR DESCRIPTION
Motivation:

The refactor enables re-use of authentication implementation details in non vertx-web projects. (e.g. Vert.x gRPC)
There will be a matching PR for `vertx-auth` + `vertx-grpc` to incorporate and make use of the refactored codebase.

Draft:

This PR introduces  two maven modules. These modules have been added as discussed in the discord meeting to limit the diff and make it easier to review the changes since classes eventually have to be moved to `vertx-auth`.

Changes:

* Creation of a UserContext abstraction
* Move of various interfaces to common modules
* Introduction of `AuthenticationContext` interface
* `AuthenticationHandler` is now generic to accept implementation specific context objects
* `JWTAuthHandlerImpl`, `HTTPAuthorizationHandler`, `AuthenticationHandlerImpl` have been refactored to be `RoutingContext` agnostic and use `AuthenticationContext` instead.
* `UserContextImpl` split into `AbstractUserContext` to enable re-use of code
* `RoutingContext` now extends `AuthenticationContext`

Tasks:

* [ ] Solve TODO in `WebHTTPAuthorizationHandler`, `WebAuthenticationHandlerImpl` - currently code is duplicated
* [ ] Check Javadoc for needed changes (`RoutingContext` -> `AuthenticationContext`)
* [ ] Run all tests
* [ ] Verify codegen still works properly
* [ ] Rename `UserContextImpl` into `UserWebContextImpl` ?
* [ ] Check whether `AuthenticationContext#onContinue` can be added
