### PR TITLE
build(deps): bump com.graphql-java:graphql-java from 21.1 to 21.2

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>vertx-web-graphql</artifactId>
 
   <properties>
-    <graphql.java.version>21.1</graphql.java.version>
+    <graphql.java.version>21.2</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
Summary : 

This is a release with new features and bugfixes. There are no breaking changes.

Full release notes : 

https://github.com/graphql-java/graphql-java/releases/tag/v21.2

> @oneOf directive
> We've implemented the @oneOf directive for input objects. From the https://github.com/graphql/graphql-spec/pull/825:
> 
> OneOf Input Objects are a special variant of Input Objects where the type system asserts that exactly one of the fields must be set and non-null, all others being omitted
> 
> This will soon be a new built-in directive in the GraphQL specification.
> 
> The directive is currently labelled as experimental inside graphql-java while we wait for the RFC to be formally approved. The final step before the RFC is approved is your feedback! If you're using @oneOf, please share your thoughts on the https://github.com/graphql/graphql-spec/pull/825 on the GraphQL Working Group repository.
> 
> DataLoader version 3.2.1 released
> We've released a new version of [java-dataloader](https://github.com/graphql-java/java-dataloader) including a new ticker mode and predicates per dataloader. See the [release notes](https://github.com/graphql-java/java-dataloader/releases/tag/v3.2.1) for more details.
> 
> What's Changed
> Add max depth option to ExecutableNormalizedOperationFactory by @gnawf in https://github.com/graphql-java/graphql-java/pull/3268
> Handle repeated query directives by @gnawf in https://github.com/graphql-java/graphql-java/pull/3270
> Update readme by @dondonz in https://github.com/graphql-java/graphql-java/pull/3273
> Wrap NumberFormatException by @arthurscchan in https://github.com/graphql-java/graphql-java/pull/3282
> Bump org.openjdk.jmh:jmh-core from 1.36 to 1.37 by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3289
> Bump com.google.guava:guava from 32.1.1-jre to 32.1.2-jre by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3284
> Bump org.openjdk.jmh:jmh-generator-annprocess from 1.36 to 1.37 by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3290
> deprecated default value method produces bad results by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3286
> write query directives from ENF to AST by @russellyou in https://github.com/graphql-java/graphql-java/pull/3295
> Add SchemaPrinter AST comments support by @vadimofd in https://github.com/graphql-java/graphql-java/pull/3287
> Bug 3276 - default values not being used correctly during validation by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3278
> Experimental - oneOf directive support by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3275
> add directiveName as property to AppliedDirectiveLocationDetail by @faizan-siddiqui in https://github.com/graphql-java/graphql-java/pull/3297
> Schema Printer - add deprecation reason printing and fix missing deprecated directive on argument by @vadimofd in https://github.com/graphql-java/graphql-java/pull/3298
> Added support for async create state in instrumentmentations by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3302
> The last Java unit test by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3305
> Permit parent restricted nodes to map to isolated nodes by @gnawf in https://github.com/graphql-java/graphql-java/pull/3304
> Bump org.codehaus.groovy:groovy from 3.0.18 to 3.0.19 by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3307
> Use the non deprecated method in InstrumentationExamples.java by @appreciated in https://github.com/graphql-java/graphql-java/pull/3265
> Update security policy by @dondonz in https://github.com/graphql-java/graphql-java/pull/3316
> guava version fix for master by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3321
> Bump actions/checkout from 3 to 4 by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3325
> ES errors test to lock in current behavior by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3327
> Fix OSGi bundle manifest by @geichelberger in https://github.com/graphql-java/graphql-java/pull/3313
> Allow schema diff to use SDL document to enforce directives by @ndejaco2 in https://github.com/graphql-java/graphql-java/pull/3344
> The ability to get the source location of a schema element by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3340
> Bump com.fasterxml.jackson.core:jackson-databind from 2.15.2 to 2.15.3 by https://github.com/dependabot in https://github.com/graphql-java/graphql-java/pull/3350
> Build cache fixes by @Duhemm in https://github.com/graphql-java/graphql-java/pull/3335
> Issue 3332 - overlapping aliases should be prevented by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3334
> https://github.com/graphql-java/graphql-java/issues/3267 clear directives schema usage bug fix by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3272
> removed synchronised from code base as much as possible for VT by @bbakerman in https://github.com/graphql-java/graphql-java/pull/3317
> Update DataLoader to 3.2.1 by @dondonz in https://github.com/graphql-java/graphql-java/pull/3351