### PR TITLE
On Windows, HandlebarsTemplateEngine should search for slash and backslash separators

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
@@ -16,25 +16,26 @@
 
 package io.vertx.ext.web.templ.handlebars.impl;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Map;
-
-import io.vertx.ext.web.common.template.CachingTemplateEngine;
-
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.ValueResolver;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.github.jknack.handlebars.io.TemplateSource;
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.common.template.CachingTemplateEngine;
 import io.vertx.ext.web.common.template.impl.TemplateHolder;
 import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+import static io.vertx.core.impl.Utils.isWindows;
 
 /**
  * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
@@ -73,7 +74,7 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
 
       if (template == null) {
         // either it's not cache or cache is disabled
-        int idx = src.lastIndexOf(File.separator);
+        int idx = findLastFileSeparator(src);
         String prefix = "";
         String basename = src;
         if (idx != -1) {
@@ -92,6 +93,13 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
     } catch (Exception ex) {
       return Future.failedFuture(ex);
     }
+  }
+
+  private static int findLastFileSeparator(String src) {
+    if (isWindows()) {
+      return Math.max(src.lastIndexOf('/'), src.lastIndexOf('\\'));
+    }
+    return src.lastIndexOf('/');
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/io/vertx/ext/web/templ/HandlebarsTemplateTest.java
@@ -16,17 +16,16 @@
 
 package io.vertx.ext.web.templ;
 
+import com.github.jknack.handlebars.ValueResolver;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
-
-import com.github.jknack.handlebars.ValueResolver;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +38,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.vertx.core.impl.Utils.isWindows;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -142,6 +143,22 @@ public class HandlebarsTemplateTest {
 
 
     engine.render(context, "src/test/filesystemtemplates/test-handlebars-template3.hbs").onComplete(should.asyncAssertSuccess(render -> {
+      should.assertEquals("Goodbye badger and fox", normalizeCRLF(render.toString()));
+    }));
+  }
+
+  @Test
+  public void testTemplateOnWindowsFileSystem(TestContext should) {
+    assumeTrue(isWindows());
+
+    HandlebarsTemplateEngine engine = HandlebarsTemplateEngine.create(vertx);
+
+    final JsonObject context = new JsonObject()
+      .put("foo", "badger")
+      .put("bar", "fox");
+
+
+    engine.render(context, "src/test/filesystemtemplates\\test-handlebars-template3.hbs").onComplete(should.asyncAssertSuccess(render -> {
       should.assertEquals("Goodbye badger and fox", normalizeCRLF(render.toString()));
     }));
   }


### PR DESCRIPTION
Follows-up on #2449