### PR TITLE
Enable using String::equals fast-path intrinsics for exact matches

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1251,16 +1251,15 @@ final class RouteState {
       if (other.charAt(len -1) == '/') {
         // final slash is not significant, ignore it
         len--;
+        if (base.length() != len) {
+          return false;
+        }
+        // content must match
+        return other.regionMatches(0, base, 0, len);
       }
     }
-
-    // lengths are not the same (fail)
-    if (base.length() != len) {
-      return false;
-    }
-
     // content must match
-    return other.regionMatches(0, base, 0, len);
+    return other.equals(base);
   }
 
   private void addPathParam(RoutingContext context, String name, String value) {


### PR DESCRIPTION
`String::equals` got a special treatment on JDK (it's an intrinsic), while `regionMatches` has only recently received such treatment, via https://bugs.openjdk.org/browse/JDK-8302163

This is introducing a fast-path using `equals` whetever possible.