### PR TITLE
Fix NPE in ForwardedParser when host header is missing for HTTP/1.1

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -128,9 +128,11 @@ class ForwardedParser {
       port = -1;
     }
 
-    authority = HostAndPort.create(host, port);
-    host = host + (port >= 0 ? ":" + port : "");
-    absoluteURI = scheme + "://" + host + delegate.uri();
+    if (host != null) {
+      authority = HostAndPort.create(host, port);
+      host = host + (port >= 0 ? ":" + port : "");
+      absoluteURI = scheme + "://" + host + delegate.uri();
+    }
   }
 
   private void calculateForward() {


### PR DESCRIPTION
The ForwardedParser fails when the host header is missing for HTTP/1.x with an NPE.
