### PR TITLE
Fix NPE in ForwardedParser when host header is missing for HTTP/1.1

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -134,9 +134,11 @@ class ForwardedParser {
       port = -1;
     }
 
-    authority = HostAndPort.create(host, port);
-    host = host + (port >= 0 ? ":" + port : "");
-    absoluteURI = scheme + "://" + host + delegate.uri();
+    if (host != null) {
+      authority = HostAndPort.create(host, port);
+      host = host + (port >= 0 ? ":" + port : "");
+      absoluteURI = scheme + "://" + host + delegate.uri();
+    }
   }
 
   private void calculateForward() {

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -17,6 +17,8 @@
 package io.vertx.ext.web;
 
 import io.vertx.core.http.*;
+import io.vertx.core.net.NetClient;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -352,6 +354,53 @@ public class ForwardedTest extends WebTestBase {
     });
 
     testRequest("Forwarded", "for=\"" + host + ":" + port + "\"");
+  }
+
+  @Test
+  public void testNoneMissingHostHeader() throws Exception {
+    testMissingHostHeader(router.allowForward(NONE).route("/"));
+  }
+
+  @Test
+  public void testAllMissingHostHeader() throws Exception {
+    testMissingHostHeader(router.allowForward(ALL).route("/"));
+  }
+
+  @Test
+  public void testForwardMissingHostHeader() throws Exception {
+    testMissingHostHeader(router.allowForward(FORWARD).route("/"));
+  }
+
+  @Test
+  public void testXForwardMissingHostHeader() throws Exception {
+    testMissingHostHeader(router.allowForward(X_FORWARD).route("/"));
+  }
+
+  @Test
+  public void testMissingHostHeader() throws Exception {
+    testMissingHostHeader(router.allowForward(ALL).route("/"));
+  }
+
+  private void testMissingHostHeader(Route route) throws Exception {
+
+    route.handler(rc -> {
+      assertNull(rc.request().authority());
+      assertNull(rc.request().host());
+      rc.end();
+    });
+
+    NetClient tcpClient = vertx.createNetClient();
+    try {
+      tcpClient.connect(8080, "localhost").onComplete(onSuccess(so -> {
+        so.write("GET / HTTP/1.1\r\n\r\n");
+        so.handler(buff -> {
+          testComplete();
+        });
+      }));
+      await();
+    } finally {
+      tcpClient.close();
+    }
   }
 
   @Test


### PR DESCRIPTION
The ForwardedParser fails when the host header is missing for HTTP/1.x with an NPE.