### PR TITLE
Support MVEL variable resolver again

### DIFF
--- a/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/mvel/impl/MVELTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/main/java/io/vertx/ext/web/templ/mvel/impl/MVELTemplateEngineImpl.java
@@ -22,7 +22,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.common.template.CachingTemplateEngine;
 import io.vertx.ext.web.common.template.impl.TemplateHolder;
 import io.vertx.ext.web.templ.mvel.MVELTemplateEngine;
-import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
 import org.mvel2.templates.CompiledTemplate;
 import org.mvel2.templates.TemplateCompiler;
 import org.mvel2.templates.TemplateRuntime;
@@ -79,7 +79,7 @@ public class MVELTemplateEngineImpl extends CachingTemplateEngine<CompiledTempla
       return Future.succeededFuture(
         Buffer.buffer(
           (String) new TemplateRuntime(mvel.getTemplate(), null, mvel.getRoot(), baseDir)
-            .execute(new StringAppender(), context, new ImmutableDefaultFactory())
+            .execute(new StringAppender(), context, new MapVariableResolverFactory())
         ));
     } catch (Exception ex) {
       return Future.failedFuture(ex);

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/filesystemtemplates/subfolder/include-test2.txt
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/filesystemtemplates/subfolder/include-test2.txt
@@ -1,1 +1,4 @@
 Hello @{foo} and @{bar}
+@if{baz != nil}
+Hi @{baz}!
+@end{}

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/filesystemtemplates/test-mvel-template4.templ
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/filesystemtemplates/test-mvel-template4.templ
@@ -1,2 +1,3 @@
+@code{baz="honey"}
 @include{'subfolder/include-test2.txt'}
 @include{'include-test1.txt'}

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/MVELTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/MVELTemplateTest.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -89,7 +91,9 @@ public class MVELTemplateTest {
 
     String tmplPath = "src/test/filesystemtemplates/test-mvel-template4.templ".replace('/', File.separatorChar);
     engine.render(context, tmplPath).onComplete(should.asyncAssertSuccess(render -> {
-      should.assertEquals("Hello badger and fox\nRequest path is /test-mvel-template4.templ", normalizeCRLF(render.toString()));
+      should.verify(v -> {
+        assertEquals("\nHello badger and fox\n\nHi honey!\n\nRequest path is /test-mvel-template4.templ\n", normalizeCRLF(render.toString()));
+      });
     }));
   }
 


### PR DESCRIPTION
There was a regression introduced in #468. The user-supplied variables were passed to the template engine with a MapVariableResolverFactory and we switched to a context object.

For this reason, it was no longer possible to declare variables in template files.

In this PR, we invoke the template engine with a MapVariableResolverFactory again, instead of the ImmutableDefaultFactory (which prevents from declaring variables).