### PR TITLE
Make the Forwarded Parser syntax parsing case-insensitive

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -44,9 +44,9 @@ class ForwardedParser {
   private static final AsciiString X_FORWARDED_PORT = AsciiString.cached("X-Forwarded-Port");
   private static final AsciiString X_FORWARDED_FOR = AsciiString.cached("X-Forwarded-For");
 
-  private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?");
-  private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
-  private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
+  private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+  private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+  private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
 
   private final HttpServerRequest delegate;
   private final AllowForwardHeaders allowForward;


### PR DESCRIPTION
As described on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded, the forwarded header syntax parsing should be case-insensitive. It's not a real spec, but Kong is using Proto instead of proto and For instead of for...