### PR TITLE
Make the Forwarded Parser syntax parsing case-insensitive

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -44,9 +44,9 @@ class ForwardedParser {
   private static final AsciiString X_FORWARDED_PORT = AsciiString.cached("X-Forwarded-Port");
   private static final AsciiString X_FORWARDED_FOR = AsciiString.cached("X-Forwarded-For");
 
-  private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?");
-  private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
-  private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
+  private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+  private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+  private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
 
   private final HttpServerRequest delegate;
   private final AllowForwardHeaders allowForward;

--- a/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/ForwardedTest.java
@@ -127,6 +127,19 @@ public class ForwardedTest extends WebTestBase {
   }
 
   @Test
+  public void testForwardedHostAlongWithXForwardSSLWithUppercase() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertEquals(rc.request().authority().toString(), host);
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "Host=" + host, "X-Forwarded-Ssl", "On");
+  }
+
+  @Test
   public void testMultipleForwarded() throws Exception {
     router.allowForward(ALL).route("/").handler(rc -> {
       assertTrue(rc.request().isSSL());
@@ -135,6 +148,17 @@ public class ForwardedTest extends WebTestBase {
     });
 
     testRequest("Forwarded", "proto=https,proto=http");
+  }
+
+  @Test
+  public void testMultipleForwardedWithUppercase() throws Exception {
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "Proto=https,Proto=http");
   }
 
   @Test
@@ -160,6 +184,17 @@ public class ForwardedTest extends WebTestBase {
   }
 
   @Test
+  public void testForwardedHostWithUppercase() throws Exception {
+    String host = "vertx.io";
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertEquals(rc.request().authority().host(), host);
+      rc.end();
+    });
+
+    testRequest("Forwarded", "Host=" + host);
+  }
+
+  @Test
   public void testForwardedHostAndPort() throws Exception {
     String host = "vertx.io:1234";
     router.allowForward(ALL).route("/").handler(rc -> {
@@ -181,6 +216,19 @@ public class ForwardedTest extends WebTestBase {
     });
 
     testRequest("Forwarded", "host=" + host + ";proto=https");
+  }
+
+  @Test
+  public void testForwardedHostAndPortAndProtoWithUppercase() throws Exception {
+    String host = "vertx.io:1234";
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertEquals(rc.request().authority().toString(), host);
+      assertTrue(rc.request().isSSL());
+      assertEquals(rc.request().scheme(), "https");
+      rc.end();
+    });
+
+    testRequest("Forwarded", "Host=" + host + ";Proto=https");
   }
 
   @Test
@@ -331,6 +379,17 @@ public class ForwardedTest extends WebTestBase {
   }
 
   @Test
+  public void testForwardedForWithUpperCase() throws Exception {
+    String host = "1.2.3.4";
+    router.allowForward(ALL).route("/").handler(rc -> {
+      assertTrue(rc.request().remoteAddress().host().equals(host));
+      rc.end();
+    });
+
+    testRequest("Forwarded", "For=" + host);
+  }
+
+  @Test
   public void testForwardedForIpv6() throws Exception {
     String host = "[2001:db8:cafe::17]";
     int port = 4711;
@@ -446,6 +505,34 @@ public class ForwardedTest extends WebTestBase {
     wsClient.connect(new WebSocketConnectOptions().setURI("/ws").addHeader("Forwarded", "host=" + host + ";proto=https" + ";for=" + address)).onComplete(onSuccess(e -> {
       latch.countDown();
     }));
+    awaitLatch(latch);
+  }
+
+  @Test
+  public void testForwardedForAndWebSocketWithUppercase() throws Exception {
+    CountDownLatch latch = new CountDownLatch(2);
+    String host = "vertx.io:1234";
+    String address = "1.2.3.4";
+    router.allowForward(ALL).route("/ws").handler(rc -> {
+      HttpServerRequest request = rc.request();
+      if (canUpgradeToWebsocket(request)) {
+        request
+          .toWebSocket()
+          .onComplete(onSuccess(socket -> {
+            assertTrue(socket.authority().toString().equals(host));
+            assertTrue(socket.isSsl());
+            assertTrue(socket.remoteAddress().host().equals(address));
+            latch.countDown();
+          }));
+      } else {
+        fail("Expected websocket connection");
+      }
+    });
+
+    wsClient.connect(new WebSocketConnectOptions().setURI("/ws").addHeader("Forwarded", "Host=" + host + ";Proto=https" + ";For=" + address))
+      .onComplete(onSuccess(e -> {
+        latch.countDown();
+      }));
     awaitLatch(latch);
   }
 


### PR DESCRIPTION
As described on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded, the forwarded header syntax parsing should be case-insensitive. It's not a real spec, but Kong is using Proto instead of proto and For instead of for...
