### PR TITLE
WebClient should use the Address specified in RequestOptions

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -25,6 +25,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.Address;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
@@ -90,7 +91,9 @@ public class WebClientBase implements WebClientInternal {
     if (host == null) {
       host = options.getDefaultHost();
     }
-    HttpRequestImpl<Buffer> request = request(method, serverAddress, port, host, requestOptions.getURI());
+    Address address = serverAddress != null ? serverAddress : requestOptions.getServer();
+    HttpRequestImpl<Buffer> request = new HttpRequestImpl<>(this, method, address, options.isSsl(), port, host,
+      requestOptions.getURI(), BodyCodecImpl.BUFFER, options.isFollowRedirects(), buildProxyOptions(options), buildHeaders(options));
     request.ssl(requestOptions.isSsl());
     if (requestOptions.getTimeout() >= 0L) {
       request.timeout(requestOptions.getTimeout());

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -2118,7 +2118,7 @@ public class WebClientTest extends WebClientTestBase {
 
   @Test
   public void testCannotResolveAddress() throws Exception {
-    client.close();
+    awaitFuture(client.close());
     FakeAddressResolver<?> resolver = new FakeAddressResolver<>();
     client = vertx.httpClientBuilder().with(createBaseClientOptions()).withAddressResolver(resolver).build();
     webClient = WebClient.wrap(client);
@@ -2131,7 +2131,7 @@ public class WebClientTest extends WebClientTestBase {
 
   @Test
   public void testUseResolvedAddress() throws Exception {
-    client.close();
+    awaitFuture(client.close());
     FakeAddressResolver<?> resolver = new FakeAddressResolver<>();
     resolver.registerAddress("mars", Collections.singletonList(testAddress));
     client = vertx.httpClientBuilder().with(createBaseClientOptions()).withAddressResolver(resolver).build();


### PR DESCRIPTION
Fixes #2571

Without this fix, we can't integrate the Vert.x Web Client and the Vert.x Service Resolver.