### PR TITLE
WebClientTestBase#setup should not recreate the Http Client

### DIFF
--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTestBase.java
@@ -65,7 +65,6 @@ public class WebClientTestBase extends HttpTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    client = vertx.createHttpClient(createBaseClientOptions());
     webClient = WebClient.wrap(client);
     server.close();
     server = vertx.createHttpServer(createBaseServerOptions());


### PR DESCRIPTION
It's already setup in the setup method of the parent test class. And when this is called by a shared client test, Vert.x counts 2 shared client instances.

Consequently, some tests which rely on closing the original http client before creating another one may not work.