### PR TITLE
build(deps): bump com.graphql-java:graphql-java from 21.3 to 21.4

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>vertx-web-graphql</artifactId>
 
   <properties>
-    <graphql.java.version>21.3</graphql.java.version>
+    <graphql.java.version>21.4</graphql.java.version>
     <doc.skip>false</doc.skip>
   </properties>
 


### PR DESCRIPTION
Release notes https://github.com/graphql-java/graphql-java/releases/tag/v21.4

> 
> This is a special release to help control introspection queries.
> 
> This release adds a default check for introspection queries, to check that they are sensible. This feature is a backport of https://github.com/graphql-java/graphql-java/pull/3526 and https://github.com/graphql-java/graphql-java/pull/3527.
> 
> This release also adds an optional maximum result nodes limit, which is a backport of https://github.com/graphql-java/graphql-java/pull/3525.