### PR TITLE
Fix potential concurrent exception when resolving recursive ref

### DIFF
--- a/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
+++ b/vertx-web-openapi/src/main/java/io/vertx/ext/web/openapi/impl/OpenAPIHolderImpl.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 
 public class OpenAPIHolderImpl implements OpenAPIHolder {
@@ -52,7 +53,7 @@ public class OpenAPIHolderImpl implements OpenAPIHolder {
   public OpenAPIHolderImpl(Vertx vertx, HttpClient client, FileSystem fs, OpenAPILoaderOptions options) {
     this.vertx = vertx;
     absolutePaths = new ConcurrentHashMap<>();
-    externalSolvingRefs = new ConcurrentHashMap<>();
+    externalSolvingRefs = new ConcurrentSkipListMap<>();;
     this.client = client;
     this.fs = fs;
     this.options = options;


### PR DESCRIPTION
This PR addresses a potential issue where concurrent exceptions could occur during the resolution of recursive references. Although these exceptions are challenging to reproduce reliably due to their time-sensitive nature, this fix mitigates the risk by replacing the concurrent hash map with a concurrent skip list map.
