### PR TITLE
Let the body handler correctly log the decoder exception

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java
@@ -262,13 +262,17 @@ public class BodyHandlerImpl implements BodyHandler {
       }
 
       context.request().exceptionHandler(t -> {
+        System.out.println("failure!");
         context.cancelAndCleanupFileUploads();
+        int sc = 200;
         if (t instanceof DecoderException) {
           // bad request
-          context.fail(400, t.getCause());
-        } else {
-          context.fail(t);
+          sc = 400;
+          if (t.getCause() != null) {
+            t = t.getCause();
+          }
         }
+        context.fail(sc, t);
       });
     }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/BodyHandlerTest.java
@@ -1045,4 +1045,31 @@ public class BodyHandlerTest extends WebTestBase {
 
     assertWaitUntil(() -> vertx.fileSystem().readDirBlocking(uploadsDirectory).isEmpty());
   }
+
+
+  @Test
+  public void testMaxFormFieldsLimit() throws Exception {
+    router.clear();
+    router.route().handler(BodyHandler.create());
+    router.route().handler(ctx -> {
+      fail();
+    });
+
+    int len = 1025;
+
+    testRequest(HttpMethod.POST, "/", req -> {
+      req.setChunked(true);
+      req.putHeader("content-type", "application/x-www-form-urlencoded");
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0;i < len;i++) {
+        sb.append("a");
+      }
+
+      req.write(sb.toString());
+
+      vertx.setTimer(10, id -> {
+        req.end("=b");
+      });
+    }, 400, "Bad Request", "Bad Request");
+  }
 }


### PR DESCRIPTION
The `BodyHandler` does not correctly handler max form limits and does not log correctly the decoder exception, assuming incorrectly that the decoder exception always contains a cause.

Change: only unwrap the cause to log when there is actually one.
