### PR TITLE
fix: NPE on misformatted Date or Expires header

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheControl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheControl.java
@@ -21,6 +21,7 @@ import io.vertx.core.http.HttpHeaders;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -53,13 +54,15 @@ public class CacheControl {
     this.vary = headers.get(HttpHeaders.VARY);
 
     if (headers.contains(HttpHeaders.DATE)) {
-      this.date = DateFormatter.parseHttpDate(headers.get(HttpHeaders.DATE)).toInstant();
+      Date date = DateFormatter.parseHttpDate(headers.get(HttpHeaders.DATE));
+      this.date = date == null ? null : date.toInstant();
     } else {
       this.date = Instant.now();
     }
 
     if (headers.contains(HttpHeaders.EXPIRES)) {
-      this.expires = DateFormatter.parseHttpDate(headers.get(HttpHeaders.EXPIRES)).toInstant();
+      Date expiresDate = DateFormatter.parseHttpDate(headers.get(HttpHeaders.EXPIRES));
+      this.expires = expiresDate == null ? null : expiresDate.toInstant();
     } else {
       this.expires = null;
     }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheControl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheControl.java
@@ -153,7 +153,7 @@ public class CacheControl {
       return timeDirectives.get(CacheControlDirective.SHARED_MAX_AGE);
     } else if (timeDirectives.containsKey(CacheControlDirective.MAX_AGE)) {
       return timeDirectives.get(CacheControlDirective.MAX_AGE);
-    } else if (expires != null) {
+    } else if (date != null && expires != null) {
       return Duration.between(date, expires).getSeconds();
     } else {
       return Long.MAX_VALUE;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheControlTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheControlTest.java
@@ -1,0 +1,39 @@
+package io.vertx.ext.web.client.impl.cache;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.client.WebClientTestBase;
+
+public class CacheControlTest extends WebClientTestBase {
+  @Test
+  public void testMaxAge() {
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Date", "Tue, 09 Apr 2024 19:10:51 GMT");
+    headers.add("Expires", "Thu, 09 May 2024 19:10:51 GMT");
+
+    CacheControl cc = CacheControl.parse(headers);
+    assertEquals(Duration.ofDays(30).getSeconds(), cc.getMaxAge());
+  }
+
+  @Test
+  public void testInvalidHeaders() {
+    // invalid Date
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Date", "this header doesn't make sense");
+    headers.add("Expires", "Thu, 09 May 2024 19:10:51 GMT");
+
+    CacheControl cc = CacheControl.parse(headers);
+    assertEquals(Long.MAX_VALUE, cc.getMaxAge());
+
+    // invalid Expires
+    headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Date", "Tue, 09 Apr 2024 19:10:51 GMT");
+    headers.add("Expires", "this header doesn't make sense");
+
+    cc = CacheControl.parse(headers);
+    assertEquals(Long.MAX_VALUE, cc.getMaxAge());
+  }
+}

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheControlTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/impl/cache/CacheControlTest.java
@@ -1,13 +1,14 @@
 package io.vertx.ext.web.client.impl.cache;
 
+import static org.junit.Assert.*;
+
 import java.time.Duration;
 
 import org.junit.Test;
 
 import io.vertx.core.MultiMap;
-import io.vertx.ext.web.client.WebClientTestBase;
 
-public class CacheControlTest extends WebClientTestBase {
+public class CacheControlTest {
   @Test
   public void testMaxAge() {
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();


### PR DESCRIPTION
Netty's date parse function returns `null` on a misformatted date. This wasn't handled properly in the cache control.

