### PR TITLE
Fixed docs of vertx-web

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -247,8 +247,8 @@ Note, if you need to process multipart form data from a blocking handler, you MU
 A route can be set-up to match the path from the request URI. In this case it will match any request which has a path
 that's the same as the specified path.
 
-In the following example the handler will be called for a request `/some/path/`. We also ignore trailing slashes
-so it will be called for paths `/some/path` and `/some/path//` too:
+In the following example the handler will be called for a request `/some/path`. We also ignore trailing slashes
+so it will be called for paths `/some/path/` and `/some/path//` too:
 
 [source,$lang]
 ----


### PR DESCRIPTION
Changes in vertx-web/src/main/asciidoc/index.adoc @line-250,251

Motivation:
There was a contradictory statement in vertx-web docs at #routing-by-exact-path.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
