### PR TITLE
New web client expectation API

### DIFF
--- a/vertx-web-client/src/main/asciidoc/index.adoc
+++ b/vertx-web-client/src/main/asciidoc/index.adoc
@@ -300,7 +300,7 @@ On a success result the callback happens after the response has been received
 ====
 By default, a Vert.x Web Client request ends with an error only if something wrong happens at the network level.
 In other words, a `404 Not Found` response, or a response with the wrong content type, are *not* considered as failures.
-Use <<response-predicates, response predicates>> if you want the Web Client to perform sanity checks automatically.
+Use <<http-response-expectations, http response expectations>> if you want the Web Client to perform sanity checks automatically.
 ====
 
 WARNING: Responses are fully buffered, use {@link io.vertx.ext.web.codec.BodyCodec#pipe(io.vertx.core.streams.WriteStream)}
@@ -371,8 +371,8 @@ that decode the response to a specific type
 
 WARNING: this is only valid for the response decoded as a buffer.
 
-[[response-predicates]]
-=== Response predicates
+[[http-response-expectations]]
+=== Response expectations
 
 By default, a Vert.x Web Client request ends with an error only if something wrong happens at the network level.
 
@@ -383,33 +383,31 @@ In other words, you must perform sanity checks manually after the response is re
 {@link examples.WebClientExamples#manualSanityChecks(io.vertx.ext.web.client.WebClient)}
 ----
 
-You can trade flexibility for clarity and conciseness using _response predicates_.
+You can trade flexibility for clarity and conciseness using _response expectations_.
 
-{@link io.vertx.ext.web.client.predicate.ResponsePredicate Response predicates} can fail a request when the response does
+{@link io.vertx.core.http.HttpResponseExpectation Response expectations} can fail a request when the response does
 not match a criteria.
 
-The Web Client comes with a set of out of the box predicates ready to use:
+The Web Client can reuse the Vert.x HTTP Client predefined expectations:
 
 [source,$lang]
 ----
 {@link examples.WebClientExamples#usingPredefinedPredicates(io.vertx.ext.web.client.WebClient)}
 ----
 
-You can also create custom predicates when existing predicates don't fit your needs:
+You can also create custom expectations when existing expectations don't fit your needs:
 
 [source,$lang]
 ----
 {@link examples.WebClientExamples#usingPredicates(io.vertx.ext.web.client.WebClient)}
 ----
 
-TIP: Response predicates are evaluated _before_ the response body is received. Therefore you can't inspect the response body
-in a predicate test function.
+==== Predefined expectations
 
-==== Predefined predicates
+As a convenience, the Vert.x HTTP Client ships a few expectations for common uses cases that also applies to the
+Web Client.
 
-As a convenience, the Web Client ships a few predicates for common uses cases .
-
-For status codes, e.g {@link io.vertx.ext.web.client.predicate.ResponsePredicate#SC_SUCCESS} to verify that the
+For status codes, e.g. {@link io.vertx.core.http.HttpResponseExpectation#SC_SUCCESS} to verify that the
 response has a `2xx` code, you can also create a custom one:
 
 [source,$lang]
@@ -417,7 +415,7 @@ response has a `2xx` code, you can also create a custom one:
 {@link examples.WebClientExamples#usingSpecificStatus(io.vertx.ext.web.client.WebClient)}
 ----
 
-For content types, e.g {@link io.vertx.ext.web.client.predicate.ResponsePredicate#JSON} to verify that the
+For content types, e.g. {@link io.vertx.core.http.HttpResponseExpectation#JSON} to verify that the
 response body contains JSON data, you can also create a custom one:
 
 [source,$lang]
@@ -425,13 +423,13 @@ response body contains JSON data, you can also create a custom one:
 {@link examples.WebClientExamples#usingSpecificContentType(io.vertx.ext.web.client.WebClient)}
 ----
 
-Please refer to the {@link io.vertx.ext.web.client.predicate.ResponsePredicate} documentation for a full list of predefined predicates.
+Please refer to the {@link io.vertx.core.http.HttpResponseExpectation} documentation for a full list of predefined predicates.
 
 ifeval::["$lang" == "java"]
 ==== Creating custom failures
 
-By default, response predicates (including the predefined ones) use a default error converter which discards
-the body and conveys a simple message. You can customize the exception class by changing the error converter:
+By default, response expectations (including the predefined ones) use a default error converter which discards
+the body and conveys a simple message. You can customize the exception class by mapping the failure:
 
 [source,$lang]
 ----
@@ -449,8 +447,7 @@ For example, the https://developer.marvel.com/docs[Marvel API] uses this JSON ob
 }
 ----
 
-To avoid losing this information, it is possible to wait for the response body to be fully received before the error
-converter is called:
+To avoid losing this information, it is possible to transform response body:
 
 [source,$lang]
 ----
@@ -458,7 +455,7 @@ converter is called:
 ----
 
 WARNING: creating exception in Java can have a performance cost when it captures a stack trace, so you might want
-         to create exceptions that do not capture the stack trace. By default exceptions are reported using the
+         to create exceptions that do not capture the stack trace. By default, exceptions are reported using
          an exception that does not capture the stack trace.
 
 endif::[]

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -424,7 +424,9 @@ public interface HttpRequest<T> {
    *
    * @param predicate the predicate
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link io.vertx.core.http.HttpResponseExpectation} along with {@link Future#expecting(Expectation)}
    */
+  @Deprecated
   @Fluent
   default HttpRequest<T> expect(Function<HttpResponse<Void>, ResponsePredicateResult> predicate) {
     return expect(predicate::apply);
@@ -437,13 +439,16 @@ public interface HttpRequest<T> {
    *
    * @param predicate the predicate
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link io.vertx.core.http.HttpResponseExpectation} along with {@link Future#expecting(Expectation)}
    */
+  @Deprecated
   @Fluent
   HttpRequest<T> expect(ResponsePredicate predicate);
 
   /**
    * @return a read-only list of the response predicate expectations
    */
+  @Deprecated
   List<ResponsePredicate> expectations();
 
   /**

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpResponse.java
@@ -20,7 +20,7 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.HttpResponseHead;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.codec.BodyCodec;
@@ -48,39 +48,7 @@ import java.util.List;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen
-public interface HttpResponse<T> {
-
-  /**
-   * @return the version of the response
-   */
-  @CacheReturn
-  HttpVersion version();
-
-  /**
-   * @return the status code of the response
-   */
-  @CacheReturn
-  int statusCode();
-
-  /**
-   * @return the status message of the response
-   */
-  @CacheReturn
-  String statusMessage();
-
-  /**
-   * @return the headers
-   */
-  @CacheReturn
-  MultiMap headers();
-
-  /**
-   * Return the first header value with the specified name
-   *
-   * @param headerName  the header name
-   * @return the header value
-   */
-  @Nullable String getHeader(String headerName);
+public interface HttpResponse<T> extends HttpResponseHead {
 
   /**
    * @return the trailers
@@ -95,12 +63,6 @@ public interface HttpResponse<T> {
    * @return the trailer value
    */
   @Nullable String getTrailer(String trailerName);
-
-  /**
-   * @return the Set-Cookie headers (including trailers)
-   */
-  @CacheReturn
-  List<String> cookies();
 
   /**
    * @return the response body in the format it was decoded.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpResponseImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpResponseImpl.java
@@ -76,6 +76,11 @@ public class HttpResponseImpl<T> implements HttpResponse<T> {
   }
 
   @Override
+  public String getHeader(CharSequence headerName) {
+    return headers.get(headerName);
+  }
+
+  @Override
   public MultiMap trailers() {
     return trailers;
   }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ErrorConverter.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ErrorConverter.java
@@ -26,7 +26,9 @@ import java.util.function.Function;
  * Converts a {@link ResponsePredicateResult} to a {@code Throwable} describing the error.
  *
  * @author Thomas Segismont
+ * @deprecated instead use {@link io.vertx.core.http.HttpResponseExpectation}
  */
+@Deprecated
 @FunctionalInterface
 @VertxGen
 public interface ErrorConverter {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicate.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicate.java
@@ -46,7 +46,9 @@ import java.util.function.Function;
  * <p>
  * However, you can create a new {@link ResponsePredicate} instance from an existing one using {@link #create(Function)} or
  * {@link #create(Function, ErrorConverter)} when the body is required to build the validation failure.
+ * @deprecated instead use {@link io.vertx.core.http.HttpResponseExpectation}
  */
+@Deprecated
 @VertxGen
 public interface ResponsePredicate extends Function<HttpResponse<Void>, ResponsePredicateResult> {
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicateResult.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/predicate/ResponsePredicateResult.java
@@ -28,7 +28,9 @@ import java.util.function.Function;
  * Represents the outcome of a {@link ResponsePredicate} applied to an {@link HttpResponse}.
  *
  * @author Thomas Segismont
+ * @deprecated instead use {@link io.vertx.core.http.HttpResponseExpectation}
  */
+@Deprecated
 @VertxGen
 public interface ResponsePredicateResult {
 

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/InterceptorTest.java
@@ -332,6 +332,11 @@ public class InterceptorTest extends HttpTestBase {
     }
 
     @Override
+    public String getHeader(CharSequence headerName) {
+      return null;
+    }
+
+    @Override
     public MultiMap trailers() {
       return null;
     }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/WebClientTest.java
@@ -1965,20 +1965,6 @@ public class WebClientTest extends WebClientTestBase {
     });
   }
 
-  private static class CustomException extends Exception {
-
-    UUID tag;
-
-    CustomException(String message) {
-      super(message);
-    }
-
-    CustomException(UUID tag, String message) {
-      super(message);
-      this.tag = tag;
-    }
-  }
-
   private void testExpectation(boolean shouldFail,
                                Consumer<HttpRequest<?>> modifier,
                                Consumer<HttpServerResponse> bilto) throws Exception {
@@ -2004,6 +1990,217 @@ public class WebClientTest extends WebClientTestBase {
       testComplete();
     });
     await();
+  }
+
+  // New expectation API
+
+  @Test
+  public void testExpectFail_2() throws Exception {
+    testExpectation_2(true,
+      value -> false,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectPass_2() throws Exception {
+    testExpectation_2(false,
+      value -> true,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectStatusFail_2() throws Exception {
+    testExpectation_2(true,
+      HttpResponseExpectation.status(200),
+      resp -> resp.setStatusCode(201).end());
+  }
+
+  @Test
+  public void testExpectStatusPass_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.status(200),
+      resp -> resp.setStatusCode(200).end());
+  }
+
+  @Test
+  public void testExpectStatusRangeFail_2() throws Exception {
+    testExpectation_2(true,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(500).end());
+  }
+
+  @Test
+  public void testExpectStatusRangePass1_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(200).end());
+  }
+
+  @Test
+  public void testExpectStatusRangePass2_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(299).end());
+  }
+
+  @Test
+  public void testExpectContentTypeFail_2() throws Exception {
+    testExpectation_2(true,
+      HttpResponseExpectation.JSON,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectOneOfContentTypesFail_2() throws Exception {
+    testExpectation_2(true,
+      HttpResponseExpectation.contentType(Arrays.asList("text/plain", "text/csv")),
+      httpServerResponse -> httpServerResponse.putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaders.TEXT_HTML).end());
+  }
+
+  @Test
+  public void testExpectContentTypePass_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.JSON,
+      resp -> resp.putHeader("content-type", "application/JSON").end());
+  }
+
+  @Test
+  public void testExpectContentTypeWithEncodingPass_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.JSON,
+      resp -> resp.putHeader("content-type", "application/JSON;charset=UTF-8").end());
+  }
+
+  @Test
+  public void testExpectOneOfContentTypesPass_2() throws Exception {
+    testExpectation_2(false,
+      HttpResponseExpectation.contentType(Arrays.asList("text/plain", "text/HTML")),
+      httpServerResponse -> httpServerResponse.putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaders.TEXT_HTML).end());
+  }
+
+  @Test
+  public void testExpectCustomException_2() throws Exception {
+    Expectation<HttpResponseHead> expectation = ((Expectation<HttpResponseHead>) value -> false)
+      .wrappingFailure((head, err) -> new CustomException("boom"));
+    testExpectation_2(true, expectation, HttpServerResponse::end, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals("boom", customException.getMessage());
+    });
+  }
+
+  @Test
+  public void testExpectCustomExceptionWithResponseBody_2() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    Expectation<HttpResponseHead> expectation = HttpResponseExpectation.SC_SUCCESS.wrappingFailure((head, err) -> {
+      JsonObject body = ((HttpResponse<?>) head).bodyAsJsonObject();
+      return new CustomException(UUID.fromString(body.getString("tag")), body.getString("message"));
+    });
+    testExpectation_2(true, expectation, httpServerResponse -> {
+      httpServerResponse
+        .setStatusCode(400)
+        .end(new JsonObject().put("tag", uuid.toString()).put("message", "tilt").toBuffer());
+    }, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals("tilt", customException.getMessage());
+      assertEquals(uuid, customException.tag);
+    });
+  }
+
+  @Test
+  public void testExpectCustomExceptionWithStatusCode_2() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    int statusCode = 400;
+
+    Expectation<HttpResponseHead> expectation = HttpResponseExpectation.SC_SUCCESS
+      .wrappingFailure((head, err) -> new CustomException(uuid, String.valueOf(head.statusCode())));
+
+    testExpectation_2(true, expectation, httpServerResponse -> {
+      httpServerResponse
+        .setStatusCode(statusCode)
+        .end(TestUtils.randomBuffer(2048));
+    }, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals(String.valueOf(statusCode), customException.getMessage());
+      assertEquals(uuid, customException.tag);
+    });
+  }
+
+  @Test
+  public void testExpectFunctionThrowsException_2() throws Exception {
+    Expectation<HttpResponseHead> expectation = value -> {
+      throw new IndexOutOfBoundsException("boom");
+    };
+
+    testExpectation_2(true, expectation, HttpServerResponse::end, ar -> {
+      assertThat(ar.cause(), instanceOf(IndexOutOfBoundsException.class));
+    });
+  }
+
+  @Test
+  public void testErrorConverterThrowsException_2() throws Exception {
+    Expectation<HttpResponseHead> expectation = ((Expectation<HttpResponseHead>) value -> false).wrappingFailure((head, err) -> {
+      throw new IndexOutOfBoundsException();
+    });
+
+    testExpectation_2(true, expectation, HttpServerResponse::end, ar -> {
+      assertThat(ar.cause(), instanceOf(IndexOutOfBoundsException.class));
+    });
+  }
+
+  @Test
+  public void testErrorConverterReturnsNull_2() throws Exception {
+    Expectation<HttpResponseHead> expectation = ((Expectation<HttpResponseHead>) value -> false)
+      .wrappingFailure((head, err) -> null);
+
+    testExpectation_2(true, expectation, HttpServerResponse::end, ar -> {
+      assertThat(ar.cause(), not(instanceOf(NullPointerException.class)));
+    });
+  }
+
+  private void testExpectation_2(boolean shouldFail,
+                                 Expectation<HttpResponseHead> expectation,
+                                 Consumer<HttpServerResponse> bilto) throws Exception {
+    testExpectation_2(shouldFail, expectation, bilto, null);
+  }
+
+  private void testExpectation_2(boolean shouldFail,
+                                 Expectation<HttpResponseHead> expectation,
+                                 Consumer<HttpServerResponse> bilto,
+                                 Consumer<AsyncResult<?>> resultTest) throws Exception {
+    server.requestHandler(request -> bilto.accept(request.response()));
+    startServer();
+    HttpRequest<Buffer> request = webClient
+      .get("/test");
+    request.send().expecting(expectation).onComplete(ar -> {
+      if (ar.succeeded()) {
+        assertFalse("Expected response success", shouldFail);
+      } else {
+        assertTrue("Expected response failure", shouldFail);
+      }
+      if (resultTest != null) resultTest.accept(ar);
+      testComplete();
+    });
+    await();
+  }
+
+  private static class CustomException extends Exception {
+
+    UUID tag;
+
+    CustomException(String message) {
+      super(message);
+    }
+
+    CustomException(UUID tag, String message) {
+      super(message);
+      this.tag = tag;
+    }
   }
 
   @Test


### PR DESCRIPTION
Documentation is updated with the HTTP response expectation API, response predicate API is deprecated.
