### PR TITLE
HTTP/1.1 requests without a host header must send a 400 response

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -186,15 +186,8 @@ class ForwardedParser {
   }
 
   private void setHostAndPort(HostAndPort authority) {
-    if (authority == null) {
-      // no header is provided
-      host = null;
-      port = -1;
-    } else {
-      String h = authority.host();
-      host = h;
-      port = authority.port();
-    }
+    host = authority.host();
+    port = authority.port();
   }
 
   private SocketAddress parseFor(String forToParse, int defaultPort) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -27,6 +27,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.ext.web.*;
 import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.handler.impl.UserHolder;
@@ -75,9 +76,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     this.request = new HttpServerRequestWrapper(request, router.getAllowForward());
     this.body = new RequestBodyImpl(this);
 
-    final String path = request.path();
+    String path = request.path();
+    HostAndPort authority = request.authority();
 
-    if (path == null || path.isEmpty()) {
+    if (authority == null || path == null || path.isEmpty()) {
+      // Authority must be present (HTTP/1.x host header // HTTP/2 :authority pseudo header)
       // HTTP paths must start with a '/'
       fail(400);
     } else if (path.charAt(0) != '/') {


### PR DESCRIPTION
Update the routing context implementation to perform this check along with the other request related checks. The section of ForwardedParser which could expect a null authority is removed since we should not anymore fall in this case.
