### PR TITLE
fix: When reroute() is called, timeout is always (#2617)

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TimeoutHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TimeoutHandlerImpl.java
@@ -41,8 +41,8 @@ public class TimeoutHandlerImpl implements TimeoutHandler {
     long tid = ctx.vertx().setTimer(timeout, t -> {
       if (!ctx.request().isEnded()) {
         ctx.request().resume();
+        ctx.fail(errorCode);
       }
-      ctx.fail(errorCode);
     });
 
     ctx.addBodyEndHandler(v -> ctx.vertx().cancelTimer(tid));


### PR DESCRIPTION
See #2617