### PR TITLE
TimeoutHandler shouldn't fail the request if the router has been restarted

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HandlersList.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HandlersList.java
@@ -51,7 +51,10 @@ class HandlersList<E> {
   }
 
   void clear() {
-    list.clear();
+    // Fill with nulls to keep generating unique handlers IDs
+    for (int i = 0; i < list.size(); i++) {
+      list.set(i, null);
+    }
   }
 
   void invokeInReverseOrder(E event) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/handler/TimeoutHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/handler/TimeoutHandlerTest.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.handler;
 
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebTestBase;
 import org.junit.Test;
 
@@ -66,5 +67,13 @@ public class TimeoutHandlerTest extends WebTestBase {
     Thread.sleep(1000); // Let timer kick in, if it's going to
   }
 
-
+  @Test
+  public void testTimeoutWithReroute() throws Exception {
+    router.route().handler(TimeoutHandler.create(500));
+    router.get("/a").handler(rc -> rc.reroute("/b"));
+    router.get("/b").handler(RoutingContext::end);
+    router.errorHandler(TimeoutHandler.DEFAULT_ERRORCODE, rc -> fail());
+    testRequest(HttpMethod.GET, "/a", 200, "OK");
+    Thread.sleep(1000);
+  }
 }


### PR DESCRIPTION
See #2617

After reroute, the bodyEndHandler was removed, so the timer couldn't be canceled. Now we check if the bodyEndHandler is still present before failing the request.

Note: we need unique ids for the lifetime of the RoutingContext, this is why HandlersList has to be modified.