### PR TITLE
Fix NPE in ForwardedParser#authority()

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ForwardedParser.java
@@ -129,7 +129,7 @@ class ForwardedParser {
         break;
     }
 
-    if (((scheme.equalsIgnoreCase(HTTP_SCHEME) && port == 80) || (scheme.equalsIgnoreCase(HTTPS_SCHEME) && port == 443))) {
+    if ((scheme == null) || (scheme.equalsIgnoreCase(HTTP_SCHEME) && port == 80) || (scheme.equalsIgnoreCase(HTTPS_SCHEME) && port == 443)) {
       port = -1;
     }
 
@@ -192,8 +192,13 @@ class ForwardedParser {
   }
 
   private void setHostAndPort(HostAndPort authority) {
-    host = authority.host();
-    port = authority.port();
+    if (authority == null) {
+      host = null;
+      port = -1;
+    } else {
+      host = authority.host();
+      port = authority.port();
+    }
   }
 
   private SocketAddress parseFor(String forToParse, int defaultPort) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/impl/HttpServerRequestWrapperTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/impl/HttpServerRequestWrapperTest.java
@@ -1,0 +1,45 @@
+package io.vertx.ext.web.impl;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.ext.web.AllowForwardHeaders;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+public class HttpServerRequestWrapperTest {
+
+	@Test
+	public void test_authority_can_be_null() {
+		HttpServerRequest request = mock(HttpServerRequestInternal.class);
+		HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request, AllowForwardHeaders.NONE);
+		assertNull(request.authority());
+		assertNull(wrapper.authority());
+	}
+
+	@Test
+	public void test_scheme_can_be_null() {
+		HttpServerRequest request = mock(HttpServerRequestInternal.class);
+		HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request, AllowForwardHeaders.NONE);
+		assertNull(request.scheme());
+		assertNull(wrapper.scheme());
+	}
+
+	@Test
+	public void test_path_can_be_null() {
+		HttpServerRequest request = mock(HttpServerRequestInternal.class);
+		HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request, AllowForwardHeaders.NONE);
+		assertNull(request.path());
+		assertNull(wrapper.path());
+	}
+
+	@Test
+	public void test_query_can_be_null() {
+		HttpServerRequest request = mock(HttpServerRequestInternal.class);
+		HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request, AllowForwardHeaders.NONE);
+		assertNull(request.query());
+		assertNull(wrapper.query());
+	}
+}
+


### PR DESCRIPTION
In vertx-core, `HttpServerRequest#authority()` and `HttpServerRequest#scheme()` are marked as `@Nullable`. 

This patch fixes NPEs in vertx-web `HttpServerRequestWrapper#authority()` and `HttpServerRequestWrapper#scheme()` that can be triggered for example when called from within a failure handler on an HTTP/1.0 request.

See also #2629