### PR TITLE
fix: report client closure to request promise

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -490,15 +490,19 @@ public class HttpContext<T> {
         request.end();
       });
     }
-    client.request(requestOptions)
-      .onComplete(ar1 -> {
-        if (ar1.succeeded()) {
-          sendRequest(ar1.result());
-        } else {
-          fail(ar1.cause());
-          requestPromise.fail(ar1.cause());
-        }
-      });
+    try {
+      client.request(requestOptions)
+        .onComplete(ar1 -> {
+          if (ar1.succeeded()) {
+            sendRequest(ar1.result());
+          } else {
+            fail(ar1.cause());
+            requestPromise.fail(ar1.cause());
+          }
+        });
+    } catch (Exception e) {
+      fail(e);
+    }
   }
 
   private void handleReceiveResponse() {


### PR DESCRIPTION
Motivation:

If the client is closed (or other exception is thrown), it wont be handled and instead will be thrown on the context exception handler.

Normally this is fine, but in `VIRTUAL_THREAD` threading mode it causes threads to never be awaken.

Note: this technically can be solved by also changing how the `client.request` throws its exceptions and to fail the request promise too, but here it seems more appropriate in my eyes.