### PR TITLE
Intermittent test failures in Healthcheck tests and StaticHandlerTest

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/healthchecks/HealthCheckTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/healthchecks/HealthCheckTest.java
@@ -9,7 +9,6 @@ import io.vertx.ext.healthchecks.Status;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.Router;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -149,7 +148,6 @@ public class HealthCheckTest extends HealthCheckTestBase {
     get("sub2/c/C1/foo", 400).onComplete(tc.asyncAssertSuccess(v -> async.countDown()));
   }
 
-  @Ignore("does not pass reliably in CI")
   @Test
   public void testWithResultHandler(TestContext tc) {
     Function<CheckResult, Future<CheckResult>> resultMapper = cr -> {

--- a/vertx-web/src/test/java/io/vertx/ext/web/healthchecks/HealthCheckTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/healthchecks/HealthCheckTestBase.java
@@ -60,10 +60,21 @@ public abstract class HealthCheckTestBase {
 
   @After
   public void tearDown(TestContext tc) {
-    Future<Void> httpServerClose = httpServer != null ? httpServer.close() : Future.succeededFuture();
-    Future<Void> httpClientClose = httpClient != null ? httpClient.close() : Future.succeededFuture();
-    Future.all(httpServerClose, httpClientClose)
-      .andThen(v -> vertx.close()).onComplete(tc.asyncAssertSuccess());
+    if (httpClient != null) {
+      Async async = tc.async();
+      httpClient.close().onComplete(tc.asyncAssertSuccess(v -> async.complete()));
+      async.awaitSuccess();
+    }
+    if (httpServer != null) {
+      Async async = tc.async();
+      httpServer.close().onComplete(tc.asyncAssertSuccess(v -> async.complete()));
+      async.awaitSuccess();
+    }
+    if (vertx != null) {
+      Async async = tc.async();
+      vertx.close().onComplete(tc.asyncAssertSuccess(v -> async.complete()));
+      async.awaitSuccess();
+    }
   }
 
   Future<JsonObject> getCheckResult(String requestURI, int status) {


### PR DESCRIPTION
Fix #2551

In StaticHandlerTest, some tests create alternative http servers. We must make sure the original and the replacement servers are closed properly. Otherwise, the test results may be affected by the test execution order.

In HealthCheckTestBase, we make sure the client, the server and the Vert.x server are closed properly, and in this order.