### PR TITLE
Always set the routing context in HttpServerRequestWrapper

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/WebServerRequest.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/WebServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc.
+ * Copyright 2024 Red Hat, Inc.
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,6 @@ public interface WebServerRequest extends HttpServerRequest {
   /**
    * @return the Vert.x context associated with this server request
    */
-  public abstract RoutingContext routingContext();
+  RoutingContext routingContext();
 
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/HttpServerRequestWrapper.java
@@ -2,14 +2,20 @@ package io.vertx.ext.web.impl;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.*;
-import io.vertx.core.http.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.AllowForwardHeaders;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.WebServerRequest;
+
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +27,7 @@ import java.util.Map;
 class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequestWrapper implements WebServerRequest {
 
   private final ForwardedParser forwardedParser;
+  private final RoutingContext ctx;
 
   private boolean modified;
 
@@ -30,11 +37,6 @@ class HttpServerRequestWrapper extends io.vertx.core.http.impl.HttpServerRequest
   private String uri;
   private String absoluteURI;
   private MultiMap params;
-  private RoutingContext ctx;
-
-  HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward) {
-    this(request, allowForward, null);
-  }
 
   HttpServerRequestWrapper(HttpServerRequest request, AllowForwardHeaders allowForward, RoutingContext ctx) {
     super((HttpServerRequestInternal) request);

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc.
+ * Copyright 2024 Red Hat, Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -74,7 +74,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   public RoutingContextImpl(String mountPoint, RouterImpl router, HttpServerRequest request, Set<RouteImpl> routes) {
     super(mountPoint, routes, router);
     this.router = router;
-    this.request = new HttpServerRequestWrapper(request, router.getAllowForward());
+    this.request = new HttpServerRequestWrapper(request, router.getAllowForward(), this);
     this.body = new RequestBodyImpl(this);
 
     final String path = request.path();

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -17,7 +17,9 @@
 package io.vertx.ext.web;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.*;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
@@ -32,7 +34,10 @@ import io.vertx.ext.web.impl.RoutingContextInternal;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +60,15 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testSimpleRoute() throws Exception {
-    router.route().handler(rc -> rc.response().end());
+    router.route().handler(rc -> {
+      if (rc.request() instanceof WebServerRequest) {
+        WebServerRequest request = (WebServerRequest) rc.request();
+        if (request.routingContext() == rc) {
+          rc.response().end();
+        }
+      }
+      rc.fail(500);
+    });
     testRequest(HttpMethod.GET, "/", 200, "OK");
   }
 


### PR DESCRIPTION
Before this change, it was expected that a `Route` handler implementation wraps the `HttpServerRequest` (again, since it was already wrapped by the routing context).

This was confusing, because in Vert.x Web apps, the `HttpServerRequest` implemented `WebServerRequest` but invocations of its `routingContext()` method always returned `null`.