### PR TITLE
Always return a 415 if the content type is mismatching, also if its value is empty

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteState.java
@@ -1157,11 +1157,7 @@ final class RouteState {
       MIMEHeader contentType = context.parsedHeaders().contentType();
       MIMEHeader consumal = contentType.findMatchedBy(consumes);
       if (consumal == null && !(contentType.rawValue().isEmpty() && emptyBodyPermittedWithConsumes)) {
-        if (contentType.rawValue().isEmpty()) {
-          return 400;
-        } else {
-          return 415;
-        }
+        return 415;
       }
     }
     if (!isEmpty(produces)) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -1173,7 +1173,7 @@ public class RouterTest extends WebTestBase {
   @Test
   public void testConsumesNoContentType() throws Exception {
     router.route().consumes("text/html").handler(rc -> rc.response().end());
-    testRequest(HttpMethod.GET, "/foo", HttpResponseStatus.BAD_REQUEST);
+    testRequest(HttpMethod.GET, "/foo", HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Solves the bug described in #2656. Instead of returning a 400 in case of a missing content type, it now returns a 415. For further details, see the issue.

It does not add the return of an `Accept` header in case of a mismatched content type. But I would not see this as a bug but rather as an enhancement which needs its own issue.

Currently waiting for an account with the Eclipse Foundation but they currently experience issues with user sign up. I will sign the ECA as soon as possible.

EDIT: Signed the ECA.


