### PR TITLE
Adds methods to update SSL Options to WebClient

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -16,12 +16,16 @@
 package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientInternal;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.impl.WebClientBase;
 import io.vertx.uritemplate.UriTemplate;
@@ -758,6 +762,64 @@ public interface WebClient {
    */
   default HttpRequest<Buffer> headAbs(UriTemplate absoluteURI) {
     return requestAbs(HttpMethod.HEAD, absoluteURI);
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
   }
 
   /**

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
@@ -27,7 +27,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.uritemplate.ExpandOptions;
-import io.vertx.core.http.WebSocketClientOptionsConverter;
 
 import java.util.List;
 import java.util.Set;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientOptions.java
@@ -27,6 +27,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.uritemplate.ExpandOptions;
+import io.vertx.core.http.WebSocketClientOptionsConverter;
 
 import java.util.List;
 import java.util.Set;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -16,6 +16,7 @@
 package io.vertx.ext.web.client.impl;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
@@ -26,6 +27,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
@@ -159,6 +161,11 @@ public class WebClientBase implements WebClientInternal {
   public <T> HttpContext<T> createContext(Handler<AsyncResult<HttpResponse<T>>> handler) {
     HttpClientInternal client = (HttpClientInternal) this.client;
     return new HttpContext<>(client, options, interceptors, handler);
+  }
+
+  @Override
+  public Future<Boolean> updateSSLOptions(SSLOptions options, boolean force) {
+    return client.updateSSLOptions(options, force);
   }
 
   @Override


### PR DESCRIPTION
This commit adds the ability to update the SSLOptions on the WebClient, similar to the methods in `io.vertx.core.http.HttpClient`. Internally, we delegate the calls to the underlying client.

Motivation:

We don't have a way to directly update the SSLOptions in WebClient. We need to keep a reference
to the wrapped HttpClient in able to update SSLOptions.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
