### PR TITLE
Adds methods to update SSL Options to WebClient

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -16,6 +16,7 @@
 package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -23,6 +24,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.PoolOptions;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.internal.http.HttpClientInternal;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.impl.WebClientBase;
 import io.vertx.uritemplate.UriTemplate;
@@ -772,6 +774,35 @@ public interface WebClient {
   default HttpRequest<Buffer> headAbs(UriTemplate absoluteURI) {
     return requestAbs(HttpMethod.HEAD, absoluteURI);
   }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 
   /**
    * Close the client. Closing will close down any pooled connections.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.ext.web.client.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
@@ -23,9 +24,10 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
-import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.net.Address;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
@@ -163,6 +165,12 @@ public class WebClientBase implements WebClientInternal {
   public <T> HttpContext<T> createContext(ContextInternal context) {
     HttpClientInternal client = (HttpClientInternal) this.client;
     return new HttpContext<>(context, client, options, interceptors, context.promise());
+  }
+
+  @Override
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
+    HttpClientInternal client = (HttpClientInternal) this.client;
+    return client.updateSSLOptions(options, force);
   }
 
   @Override


### PR DESCRIPTION
This commit adds the ability to update the SSLOptions on the WebClient, similar to the methods in `io.vertx.core.http.HttpClient`. Internally, we delegate the calls to the underlying client.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
