### PR TITLE
Handle routing errors once

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -66,7 +66,9 @@ public class RouterImpl implements Router {
     }
 
     RoutingContext routingContext = new RoutingContextImpl(null, this, request, state.getRoutes());
-    if (!routingContext.failed()) routingContext.next();
+    if (!routingContext.failed()) {
+      routingContext.next();
+    }
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -65,7 +65,8 @@ public class RouterImpl implements Router {
       LOG.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
     }
 
-    new RoutingContextImpl(null, this, request, state.getRoutes()).next();
+    RoutingContext routingContext = new RoutingContextImpl(null, this, request, state.getRoutes());
+    if (!routingContext.failed()) routingContext.next();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -78,10 +78,10 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
     if ((authority == null && request.version() != HttpVersion.HTTP_1_0) || path == null || path.isEmpty()) {
       // Authority must be present (HTTP/1.x host header // HTTP/2 :authority pseudo header)
-      // HTTP paths must be present
+      // HTTP paths must start with a '/'
       fail(400);
     } else if (path.charAt(0) != '/') {
-      // For compatibility, we return `Not Found` when a path does not start with `/`
+      // For compatiblity we return `Not Found` when a path does not start with `/`
       fail(404);
     }
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -78,10 +78,10 @@ public class RoutingContextImpl extends RoutingContextImplBase {
 
     if ((authority == null && request.version() != HttpVersion.HTTP_1_0) || path == null || path.isEmpty()) {
       // Authority must be present (HTTP/1.x host header // HTTP/2 :authority pseudo header)
-      // HTTP paths must start with a '/'
+      // HTTP paths must be present
       fail(400);
     } else if (path.charAt(0) != '/') {
-      // For compatiblity we return `Not Found` when a path does not start with `/`
+      // For compatibility, we return `Not Found` when a path does not start with `/`
       fail(404);
     }
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -54,7 +54,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -3670,5 +3669,18 @@ public class RouterTest extends WebTestBase {
       HttpMethod.GET,
       "/?x=1#4",
       200, "OK");
+  }
+
+  @Test
+  public void testErrorHandlerInvokedOnce() throws Exception {
+    AtomicInteger errorHandlerInvocations = new AtomicInteger();
+
+    router.errorHandler(404, rc -> {
+      errorHandlerInvocations.incrementAndGet();
+      rc.response().setStatusCode(404).end();
+    });
+
+    testRequest(HttpMethod.GET, "path-without-slash-prefix", HttpResponseStatus.NOT_FOUND);
+    assertEquals(1, errorHandlerInvocations.get());
   }
 }


### PR DESCRIPTION
**Motivation:**

For certain types of bad requests, any error handlers for status code 400 will be invoked more often than desired. This means that such an error handler is invoked twice in a row, or immediately after a failure handler has already handled the bad request.

I've created a demo application that illustrates the issue and provides additional details: https://github.com/ljpengelen/vertx-errors-and-failures.

**Conformance:**

I've signed the Eclipse Contributor Agreement, and my commits are verified.