### PR TITLE
Move the routing context implementation to a separate method instead of failing the context within the constructor

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -65,10 +65,8 @@ public class RouterImpl implements Router {
       LOG.trace("Router: " + System.identityHashCode(this) + " accepting request " + request.method() + " " + request.absoluteURI());
     }
 
-    RoutingContext routingContext = new RoutingContextImpl(null, this, request, state.getRoutes());
-    if (!routingContext.failed()) {
-      routingContext.next();
-    }
+    RoutingContextImpl routingContext = new RoutingContextImpl(null, this, request, state.getRoutes());
+    routingContext.route();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -72,10 +72,11 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     this.router = router;
     this.request = new HttpServerRequestWrapper(request, router.getAllowForward(), this);
     this.body = new RequestBodyImpl(this);
+  }
 
+  void route() {
     String path = request.path();
     HostAndPort authority = request.authority();
-
     if ((authority == null && request.version() != HttpVersion.HTTP_1_0) || path == null || path.isEmpty()) {
       // Authority must be present (HTTP/1.x host header // HTTP/2 :authority pseudo header)
       // HTTP paths must start with a '/'
@@ -83,6 +84,8 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     } else if (path.charAt(0) != '/') {
       // For compatiblity we return `Not Found` when a path does not start with `/`
       fail(404);
+    } else {
+      next();
     }
   }
 


### PR DESCRIPTION
Motivation:

The implementation of routing context might fail the context within its constructor forcing the router to check the context status before routing the request.

Changes:

Create package private route method that performs the preliminary checks of the routing context and calls the routing context handler chain whenever the checks have passed
