### PR TITLE
fix(#2283): Prevent MultipartFormUpload PostRequestEncoder including transfer-encoding:chunked

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -431,7 +431,7 @@ public class HttpContext<T> {
         try {
           boolean multipart = "multipart/form-data".equals(contentType);
           HttpPostRequestEncoder.EncoderMode encoderMode = this.request.multipartMixed() ? HttpPostRequestEncoder.EncoderMode.RFC1738 : HttpPostRequestEncoder.EncoderMode.HTML5;
-          multipartForm = new MultipartFormUpload(context,  (MultipartForm) this.body, multipart, encoderMode);
+          multipartForm = new MultipartFormUpload(context,  (MultipartForm) this.body, multipart, this.options.getProtocolVersion(), encoderMode);
           this.body = multipartForm;
         } catch (Exception e) {
           fail(e);


### PR DESCRIPTION
Motivation:

Currently, `MultipartFormUpload` uses `PostRequestEncoder` which includes `transfer-encoding` headers which are illegal in HTTP2 and HTTP3 as per the RFC.

Currently it is a simple fix, maybe this should be improved from the `netty` side itself to prevent needing to rewrite/polyfill the entire `PostRequestEncoder` just for such a small thing.

Fixes #2283 

Side note: When testing, I noticed that the `MultipartFormUpload` does not report any exceptions. If theres a failure in any of the handlers, the context is unaware. Is that intentional?