### PR TITLE
fix(HttpContext): unnecesery string to buffer json encoding

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -474,9 +474,9 @@ public class HttpContext<T> {
         if (body instanceof Buffer) {
           buffer = (Buffer) body;
         } else if (body instanceof JsonObject) {
-          buffer = Buffer.buffer(((JsonObject)body).encode());
+          buffer = ((JsonObject) body).toBuffer();
         } else {
-          buffer = Buffer.buffer(Json.encode(body));
+          buffer = Json.encodeToBuffer(body);
         }
         requestOptions.putHeader(HttpHeaders.CONTENT_LENGTH, "" + buffer.length());
         requestPromise.future().onSuccess(request -> {


### PR DESCRIPTION
Motivation:

I noticed that `JSON` is getting double-encoded and wastefully converted `toString` then `toBuffer`

As per the benchmarks in [vertx-core](https://github.com/eclipse-vertx/vert.x/blob/4.x/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java) it shows that this is actually wasteful:

```
Benchmark                                          Mode  Cnt  Score    Error  Units
JsonEncodeBenchmark.deepBufferDatabind             avgt   10  0.974 ±  0.025  ms/op
JsonEncodeBenchmark.deepBufferJackson              avgt   10  0.935 ±  0.018  ms/op
JsonEncodeBenchmark.deepStringDatabind             avgt   10  1.258 ±  0.006  ms/op
JsonEncodeBenchmark.deepStringJackson              avgt   10  1.270 ±  0.006  ms/op
JsonEncodeBenchmark.deepStringThenBufferDatabind   avgt   10  1.471 ±  0.015  ms/op
JsonEncodeBenchmark.deepStringThenBufferJackson    avgt   10  1.461 ±  0.008  ms/op
JsonEncodeBenchmark.smallBufferDatabind            avgt   10  0.003 ±  0.001  ms/op
JsonEncodeBenchmark.smallBufferJackson             avgt   10  0.003 ±  0.001  ms/op
JsonEncodeBenchmark.smallStringDatabind            avgt   10  0.003 ±  0.001  ms/op
JsonEncodeBenchmark.smallStringJackson             avgt   10  0.003 ±  0.001  ms/op
JsonEncodeBenchmark.smallStringThenBufferDatabind  avgt   10  0.004 ±  0.001  ms/op
JsonEncodeBenchmark.smallStringThenBufferJackson   avgt   10  0.004 ±  0.001  ms/op
JsonEncodeBenchmark.wideBufferDatabind             avgt   10  0.233 ±  0.002  ms/op
JsonEncodeBenchmark.wideBufferJackson              avgt   10  0.231 ±  0.004  ms/op
JsonEncodeBenchmark.wideStringDatabind             avgt   10  0.328 ±  0.003  ms/op
JsonEncodeBenchmark.wideStringJackson              avgt   10  0.368 ±  0.005  ms/op
JsonEncodeBenchmark.wideStringThenBufferDatabind   avgt   10  0.414 ±  0.033  ms/op
JsonEncodeBenchmark.wideStringThenBufferJackson    avgt   10  0.393 ±  0.009  ms/op
```

```java
  private void stringThenBuffJackson(JsonObject jsonObject, Blackhole blackhole) throws Exception {
    blackhole.consume(Buffer.buffer(jsonObject.encode()));
  }

  private void stringThenBuffDatabind(JsonObject jsonObject, Blackhole blackhole) throws Exception {
    blackhole.consume(Buffer.buffer(databindCodec.toString(jsonObject)));
  }
  ```