### PR TITLE
[2678] Send multiple headers for url-encoded and multipart-form bodies

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -443,11 +443,14 @@ public class HttpContext<T> {
           fail(e);
           return;
         }
-        for (String headerName : this.request.headers().names()) {
-          requestOptions.putHeader(headerName, this.request.headers().get(headerName));
+        MultiMap headers = this.request.checkHeaders(requestOptions);
+        MultiMap requestHeaders = this.request.headers();
+        for (String headerName : requestHeaders.names()) {
+          headers.remove(headerName);
         }
+        headers.addAll(requestHeaders);
         multipartForm.headers().forEach(header -> {
-          requestOptions.putHeader(header.getKey(), header.getValue());
+          headers.set(header.getKey(), header.getValue());
         });
       }
       if (body instanceof ReadStream<?>) {

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -535,13 +535,18 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
     return ctx.future();
   }
 
+  MultiMap checkHeaders(RequestOptions options) {
+    MultiMap tmp = options.getHeaders();
+    if (tmp == null) {
+      tmp = MultiMap.caseInsensitiveMultiMap();
+      options.setHeaders(tmp);
+    }
+    return tmp;
+  }
+
   void mergeHeaders(RequestOptions options) {
     if (headers != null) {
-      MultiMap tmp = options.getHeaders();
-      if (tmp == null) {
-        tmp = MultiMap.caseInsensitiveMultiMap();
-        options.setHeaders(tmp);
-      }
+      MultiMap tmp = checkHeaders(options);
       tmp.addAll(headers);
     }
   }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
@@ -1184,6 +1184,23 @@ public class WebClientTest extends WebClientTestBase {
   }
 
   @Test
+  public void testFormUrlEncodedMultipleHeaders() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals(Arrays.asList("1", "2"), req.headers().getAll("bla"));
+        req.response().end();
+      });
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    HttpRequest<Buffer> builder = webClient.post("/somepath");
+    builder.putHeader("bla", Arrays.asList("1", "2"));
+    builder.sendForm(form).onComplete(onSuccess(resp -> complete()));
+    await();
+  }
+
+  @Test
   public void testFormMultipart() throws Exception {
     server.requestHandler(req -> {
       req.setExpectMultipart(true);
@@ -1393,6 +1410,23 @@ public class WebClientTest extends WebClientTestBase {
     static Upload memoryUpload(String name, String filename, Buffer data) {
       return new Upload(name, filename, true, null, data);
     }
+  }
+
+  @Test
+  public void testMultipartFormMultipleHeaders() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals(Arrays.asList("1", "2"), req.headers().getAll("bla"));
+        req.response().end();
+      });
+    });
+    startServer();
+    HttpRequest<Buffer> builder = webClient.post("somepath");
+    MultipartForm form = MultipartForm.create();
+    builder.putHeader("bla", Arrays.asList("1", "2"));
+    builder.sendMultipartForm(form).onComplete(onSuccess(resp -> complete()));
+    await();
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Multiple headers are not sent with url-encoded and multipart-form bodies.

Solution:

Change resolution of headers in `HttpContext#handleCreateRequest()`. Do not use `MultiMap#get()` to copy headers anymore. Instead, copy the entries from the original MultiMap using `MultiMap#addAll(MultiMap)`.

Fixes #2678
