### PR TITLE
Promote WebClient interceptor to public API

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/OAuth2WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/OAuth2WebClient.java
@@ -13,9 +13,11 @@ package io.vertx.ext.web.client;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.Oauth2WebClientAware;
 
 /**
@@ -63,6 +65,10 @@ public interface OAuth2WebClient extends WebClient {
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OAuth2WebClient withCredentials(Credentials credentials);
+
+  @GenIgnore
+  @Override
+  OAuth2WebClient addInterceptor(Handler<HttpContext<?>> interceptor);
 
   /**
    * Get the authenticated user (if any) that is associated with this client.

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -15,8 +15,10 @@
  */
 package io.vertx.ext.web.client;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -26,6 +28,7 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.WebClientBase;
 import io.vertx.uritemplate.UriTemplate;
 
@@ -774,6 +777,22 @@ public interface WebClient {
   default HttpRequest<Buffer> headAbs(UriTemplate absoluteURI) {
     return requestAbs(HttpMethod.HEAD, absoluteURI);
   }
+
+  /**
+   * Add interceptor in the chain.
+   * <p/>
+   * The interceptor can maintain per request state with {@link HttpContext#get(String)}/{@link HttpContext#set(String, Object)}.
+   * <p/>
+   * A request/response can be processed several times (in case of retry) and thus they should use the per request state
+   * to ensure an operation is not done twice.
+   * <p/>
+   * This API is internal.
+   *
+   * @param interceptor the interceptor to add, must not be null
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore
+  WebClient addInterceptor(Handler<HttpContext<?>> interceptor);
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientSession.java
@@ -13,6 +13,8 @@ package io.vertx.ext.web.client;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.WebClientSessionAware;
 import io.vertx.ext.web.client.spi.CookieStore;
 
@@ -135,4 +137,8 @@ public interface WebClientSession extends WebClient {
    */
   @GenIgnore(PERMITTED_TYPE)
   CookieStore cookieStore();
+
+  @GenIgnore
+  @Override
+  WebClientSession addInterceptor(Handler<HttpContext<?>> interceptor);
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/Oauth2WebClientAware.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/Oauth2WebClientAware.java
@@ -17,7 +17,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.OAuth2WebClient;
 import io.vertx.ext.web.client.OAuth2WebClientOptions;
 
-public class Oauth2WebClientAware extends WebClientBase implements OAuth2WebClient {
+public class Oauth2WebClientAware extends WebClientBase<Oauth2WebClientAware> implements OAuth2WebClient {
 
   private final OAuth2Auth oauth2Auth;
   private final OAuth2WebClientOptions option;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -44,7 +44,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class WebClientBase implements WebClientInternal {
+public class WebClientBase<C extends WebClientBase<C>> implements WebClientInternal {
 
   final HttpClient client;
   final WebClientOptions options;
@@ -152,13 +152,13 @@ public class WebClientBase implements WebClientInternal {
   }
 
   @Override
-  public WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor) {
+  public C addInterceptor(Handler<HttpContext<?>> interceptor) {
     // If a web client is constructed using another client, interceptors could get added twice.
     if (interceptors.stream().anyMatch(i -> i.getClass() == interceptor.getClass())) {
       throw new IllegalStateException(String.format("Client already contains a %s interceptor", interceptor.getClass()));
     }
     interceptors.add(interceptor);
-    return this;
+    return (C) this;
   }
 
   @Override

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientInternal.java
@@ -26,19 +26,6 @@ public interface WebClientInternal extends WebClient {
 
   <T> HttpContext<T> createContext(ContextInternal context);
 
-  /**
-   * Add interceptor in the chain.
-   * <p/>
-   * The interceptor can maintain per request state with {@link HttpContext#get(String)}/{@link HttpContext#set(String, Object)}.
-   * <p/>
-   * A request/response can be processed several times (in case of retry) and thus they should use the per request state
-   * to ensure an operation is not done twice.
-   * <p/>
-   * This API is internal.
-   *
-   * @param interceptor the interceptor to add, must not be null
-   * @return a reference to this, so the API can be used fluently
-   */
+  @Override
   WebClientInternal addInterceptor(Handler<HttpContext<?>> interceptor);
-
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientSessionAware.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientSessionAware.java
@@ -21,7 +21,7 @@ import io.vertx.ext.web.client.spi.CookieStore;
 /**
  * @author <a href="mailto:tommaso.nolli@gmail.com">Tommaso Nolli</a>
  */
-public class WebClientSessionAware extends WebClientBase implements WebClientSession {
+public class WebClientSessionAware extends WebClientBase<WebClientSessionAware> implements WebClientSession {
 
   private final CookieStore cookieStore;
   private final CacheStore cacheStore;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/VerticleUndeployTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/VerticleUndeployTest.java
@@ -1,0 +1,208 @@
+package io.vertx.ext.web.client.tests;
+
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.TrustOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
+
+import java.util.*;
+import java.util.Timer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static io.vertx.core.Future.all;
+import static io.vertx.core.Future.await;
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class VerticleUndeployTest {
+
+  private static final Vertx vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+
+  final static Buffer b_12000 = Buffer.buffer();
+  final static Buffer b_1024 = Buffer.buffer();
+
+  static {
+    for (int i = 0;i < 12_000;i++) {
+      b_12000.appendByte((byte) 65);
+    }
+    for (int i = 0;i < 1_024;i++) {
+      b_1024.appendByte((byte) 65);
+    }
+  }
+
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
+    vertx.exceptionHandler(Throwable::printStackTrace);
+    startServer();
+
+    //setup scanner, 1 deploys verticles, 2 undeploys
+    Timer timer = new Timer();
+    TimerTask timerTask = null;
+    Scanner scanner = new Scanner(System.in);
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        switch (scanner.nextInt()) {
+          case 1:
+            startAll();
+            break;
+          case 2:
+            stopAll();
+            break;
+          case 3: {
+            if(timerTask == null) {
+              timerTask = new TimerTask() {
+                @Override
+                public void run() {
+                  System.out.println("Test starting");
+                  startAll();
+                  try {
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(1250, 5000));
+                    stopAll();
+                    Thread.sleep(5000);
+                  } catch (Exception e) {
+                    System.out.println("Test failed: " + e.getMessage());
+                  }
+                }
+              };
+              timer.schedule(timerTask, 0, 10_000);
+            } else {
+              System.out.println("Stopping test");
+              timerTask.cancel();
+              timerTask = null;
+            }
+          }
+        }
+      } catch (Exception e) {
+        //ignore
+      }
+    }
+  }
+
+  public static void startAll() {
+    for (int i = 0; i < 1000; i++) {
+      vertx.deployVerticle(new TestHttpVerticle(), new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD)).await();
+    }
+  }
+
+  public static void stopAll() throws ExecutionException, InterruptedException {
+    List<Future<Void>> futs = vertx.deploymentIDs().stream().map(vertx::undeploy).collect(Collectors.toList());
+    all(futs).await();
+  }
+
+  private static void startServer() throws ExecutionException, InterruptedException {
+    vertx.createHttpServer(createHttp2ServerOptions(8080, "0.0.0.0"))
+      .requestHandler(req -> {
+        req.body().onComplete(ar -> {
+//          System.out.println("Request received "+req.connection() + " "+ar.result().length());
+          req.response().end(b_1024);
+        });
+      })
+      .listen()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get();
+  }
+
+  private static class TestHttpVerticle extends AbstractVerticle {
+    private HttpClient client;
+    private boolean isStopped;
+
+    @Override
+    public void start() throws Exception {
+      this.client = this.vertx.createHttpClient(createHttp2ClientOptions());
+      this.context.runOnContext(v -> loopAwait());
+    }
+
+    private void loopAwait() {
+      while (!this.isStopped) {
+        try {
+          HttpClientRequest req = await(this.client.request(HttpMethod.POST, 8080, "localhost", "/"));
+          req.idleTimeout(10_000);
+          await(req.end(b_12000));
+          HttpClientResponse resp = await(req.response());
+          Buffer body = await(resp.body());
+          sleep();
+        } catch (Throwable e) {
+          String msg = e.getMessage() == null ? e.getClass().getName() : e.getMessage();
+//          System.out.println("Failed to get response " + msg);
+        }
+      }
+    }
+
+    private void sleep() {
+      Promise<Void> p = Promise.promise();
+      this.vertx.setTimer(current().nextInt(400, 6000), x -> p.tryComplete());
+      await(p.future());
+    }
+
+    @Override
+    public void stop(Promise<Void> stopPromise) throws Exception {
+      this.isStopped = true;
+      this.client.close().onComplete(stopPromise);
+    }
+  }
+
+  private static class TestWebClientVerticle extends AbstractVerticle {
+    private WebClient client;
+    private boolean isStopped;
+
+    @Override
+    public void start() throws Exception {
+      this.client = WebClient.create(this.vertx, new WebClientOptions(createHttp2ClientOptions()).setShared(false));
+      this.context.runOnContext(v -> loopAwait());
+    }
+
+    private void loop() {
+      try {
+        this.client.getAbs("https://localhost:8080").timeout(10_000).sendBuffer(b_12000).onComplete(ar -> {
+          if (!ar.succeeded()) {
+            System.out.println("Failed to get response " + ar.cause().getMessage());
+          }
+          this.vertx.setTimer(current().nextInt(400, 6000), x -> loop());
+        });
+      } catch (Exception e) {
+        System.out.println("Failed to loop request: "+ e.getMessage());
+      }
+    }
+
+    private void loopAwait() {
+      while (!this.isStopped) {
+        try {
+          await(this.client.postAbs("https://localhost:8080").timeout(10_000).sendBuffer(b_12000));
+          sleep();
+        } catch (Exception e) {
+          String msg = e.getMessage() == null ? e.getClass().getName() : e.getMessage();
+//          System.out.println("Failed to get response " + msg);
+        }
+      }
+    }
+
+    private void sleep() {
+      Promise<Void> p = Promise.promise();
+      this.vertx.setTimer(current().nextInt(400, 6000), x -> p.tryComplete());
+      await(p.future());
+    }
+
+    @Override
+    public void stop() throws Exception {
+      this.isStopped = true;
+      Optional.of(this.client).ifPresent(WebClient::close);
+//      System.out.println("Verticle stopped");
+    }
+  }
+
+  public static HttpServerOptions createHttp2ServerOptions(int port, String host) {
+    return (new HttpServerOptions()).setPort(port).setHost(host).setSslEngineOptions(new JdkSSLEngineOptions()).setUseAlpn(true).setSsl(true).addEnabledCipherSuite("TLS_RSA_WITH_AES_128_CBC_SHA").setKeyCertOptions((KeyCertOptions) Cert.SERVER_JKS.get());
+  }
+
+  public static HttpClientOptions createHttp2ClientOptions() {
+    return (new HttpClientOptions()).setSslEngineOptions(new JdkSSLEngineOptions()).setUseAlpn(true).setSsl(true).setTrustOptions((TrustOptions) Trust.SERVER_JKS.get()).setProtocolVersion(HttpVersion.HTTP_2);
+  }
+}


### PR DESCRIPTION
Motivation:

WebClient interceptor API is still internal and has proven to be stable

Changes:

Move WebClient interceptor to public API.
