### PR TITLE
Revert RoutingContext#user() returning UserContext to User

### DIFF
--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/OpenAPIRouterHandlerImpl.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/OpenAPIRouterHandlerImpl.java
@@ -54,7 +54,7 @@ public class OpenAPIRouterHandlerImpl extends EventbusHandler implements OpenAPI
   protected Future<JsonObject> transformRequest(ValidatedRequest request, RoutingContext routingContext,
                                                 Operation operation) {
     JsonObject params = buildParametersObject(request);
-    JsonObject userPrincipal = Optional.ofNullable(routingContext.user().get()).map(User::principal).orElse(null);
+    JsonObject userPrincipal = Optional.ofNullable(routingContext.user()).map(User::principal).orElse(null);
 
     ServiceRequest sr = new ServiceRequest(
       params,

--- a/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
+++ b/vertx-web-api-service/src/main/java/io/vertx/ext/web/api/service/impl/RouteToEBServiceHandlerImpl.java
@@ -73,7 +73,7 @@ public class RouteToEBServiceHandlerImpl implements RouteToEBServiceHandler {
 
   private JsonObject buildPayload(RoutingContext context) {
     JsonObject params = context.get("parsedParameters") != null ? ((RequestParameters)context.get("parsedParameters")).toJson() : null;
-    User user = context.user().get();
+    User user = context.user();
     return new JsonObject().put("context", new ServiceRequest(
       params,
       context.request().headers(),

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/RouteToEBServiceHandlerTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/RouteToEBServiceHandlerTest.java
@@ -181,7 +181,7 @@ public class RouteToEBServiceHandlerTest extends BaseValidationHandlerTest {
       .handler(
         ValidationHandlerBuilder.create(schemaRepo).build()
       ).handler(rc -> {
-        ((UserContextInternal) rc.user()).setUser(User.fromName("slinkydeveloper")); // Put user mock into context
+        ((UserContextInternal) rc.userContext()).setUser(User.fromName("slinkydeveloper")); // Put user mock into context
         rc.next();
       })
       .handler(

--- a/vertx-web-graphql/src/main/java/examples/GraphQLExamples.java
+++ b/vertx-web-graphql/src/main/java/examples/GraphQLExamples.java
@@ -154,7 +154,7 @@ public class GraphQLExamples {
 
       RoutingContext routingContext = environment.getGraphQlContext().get(RoutingContext.class);
 
-      UserContext user = routingContext.user();
+      UserContext user = routingContext.userContext();
 
       Future<List<Link>> future = retrieveLinksPostedBy(user);
       return future.toCompletionStage();

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalCallbackawareTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalCallbackawareTest.java
@@ -60,10 +60,10 @@ class RouterBuilderSecurityOptionalCallbackawareTest extends RouterBuilderTestBa
       .onSuccess(self -> {
         self
           .getRoute("opA")
-          .addHandler(ctx -> ctx.json(ctx.user().get().principal()));
+          .addHandler(ctx -> ctx.json(ctx.user().principal()));
         self
           .getRoute("opB")
-          .addHandler(ctx -> ctx.json(ctx.user().get().principal()));
+          .addHandler(ctx -> ctx.json(ctx.user().principal()));
       }))
       // this test may seem useless but it proves that the chain auth properly sets up a chain when the a handler
       // can perform redirects (callback aware) and doesn't throw an exception at setup time.

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityOptionalTest.java
@@ -46,8 +46,8 @@ class RouterBuilderSecurityOptionalTest extends RouterBuilderTestBase {
 
       rb.getRoute("pets")
         .addHandler(ctx -> {
-          if (ctx.user().authenticated()) {
-            ctx.json(ctx.user().get().principal());
+          if (ctx.userContext().authenticated()) {
+            ctx.json(ctx.user().principal());
           } else {
             ctx.json(null);
           }

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -1209,7 +1209,7 @@ make sure your authentication handler is before your application handlers on tho
 
 If the authentication handler has successfully authenticated the user it will inject a {@link io.vertx.ext.auth.User}
 object into the {@link io.vertx.ext.web.UserContext} so it's available in your handlers from the routing context:
-{@link io.vertx.ext.web.RoutingContext#user()}.
+{@link io.vertx.ext.web.RoutingContext#userContext()}.
 
 If you want your User object to be stored in the session so it's available between requests so you don't have to
 authenticate on each request, then you should make sure you have a session handler before the authentication handler.

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -42,7 +42,6 @@ import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * These are the examples used in the documentation.
@@ -837,7 +836,7 @@ public class WebExamples {
       // This will require a login
 
       // This will have the value true
-      boolean isAuthenticated = ctx.user().authenticated();
+      boolean isAuthenticated = ctx.userContext().authenticated();
 
     });
   }
@@ -871,7 +870,7 @@ public class WebExamples {
         // This will require a login
 
         // This will have the value true
-        boolean isAuthenticated = ctx.user().authenticated();
+        boolean isAuthenticated = ctx.userContext().authenticated();
 
       });
 
@@ -1268,8 +1267,8 @@ public class WebExamples {
   public void example53(Vertx vertx) {
 
     Handler<RoutingContext> handler = ctx -> {
-      String theSubject = ctx.user().get().principal().getString("sub");
-      String someKey = ctx.user().get().principal().getString("someKey");
+      String theSubject = ctx.user().principal().getString("sub");
+      String someKey = ctx.user().principal().getString("someKey");
     };
   }
 
@@ -1495,7 +1494,7 @@ public class WebExamples {
       // at this moment your user object should contain the info
       // from the Oauth2 response, since this is a protected resource
       // as specified above in the handler config the user object is never null
-      User user = ctx.user().get();
+      User user = ctx.user();
       // just dump it to the client for demo purposes
       ctx.response().end(user.toString());
     });
@@ -1947,7 +1946,7 @@ public class WebExamples {
       .handler(ctx -> {
         // if the user isn't admin, we ask the user to login again as admin
         ctx
-          .user()
+          .userContext()
           .loginHint("admin")
           .impersonate();
       });
@@ -1958,7 +1957,7 @@ public class WebExamples {
       .route("/high/security/route/back/to/me")
       .handler(ctx -> {
         ctx
-          .user()
+          .userContext()
           .restore();
       });
   }
@@ -1968,7 +1967,7 @@ public class WebExamples {
       .route("/high/security/route/refresh/me")
       .handler(ctx -> {
         ctx
-          .user()
+          .userContext()
           .refresh();
       });
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/RoutingContext.java
@@ -23,6 +23,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.impl.ParsableMIMEValue;
 import io.vertx.ext.web.impl.Utils;
 
@@ -223,7 +224,15 @@ public interface RoutingContext {
    * as perform authentication refreshes, logout and other operations.
    * @return the user context
    */
-  UserContext user();
+  UserContext userContext();
+
+  /**
+   * Get the authenticated user (if any). This will usually be injected by an auth handler if authentication if successful.
+   * @return  the user, or null if the current user is not authenticated.
+   */
+  default @Nullable User user() {
+    return userContext().get();
+  }
 
   /**
    * If the context is being routed to failure handlers after a failure has been triggered by calling

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthenticationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthenticationHandlerImpl.java
@@ -60,7 +60,7 @@ public abstract class AuthenticationHandlerImpl<T extends AuthenticationProvider
       ctx.request().pause();
     }
 
-    final User user = ctx.user().get();
+    final User user = ctx.user();
 
     if (user != null) {
       if (mfa != null) {
@@ -85,7 +85,7 @@ public abstract class AuthenticationHandlerImpl<T extends AuthenticationProvider
     // perform the authentication
     authenticate(ctx)
       .onSuccess(authenticated -> {
-        ((UserContextInternal) ctx.user())
+        ((UserContextInternal) ctx.userContext())
           .setUser(authenticated);
         Session session = ctx.session();
         if (session != null) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java
@@ -94,7 +94,7 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
 
   @Override
   public void handle(RoutingContext ctx) {
-    final User user = ctx.user().get();
+    final User user = ctx.user();
 
     if (user == null) {
       ctx.fail(FORBIDDEN_CODE, FORBIDDEN_EXCEPTION);
@@ -141,7 +141,7 @@ public class AuthorizationHandlerImpl implements AuthorizationHandler {
    * @param providers            the providers iterator
    */
   private void checkOrFetchAuthorizations(RoutingContext ctx, Authorization authorization, AuthorizationContext authorizationContext, Iterator<AuthorizationProvider> providers) {
-    final User user = ctx.user().get();
+    final User user = ctx.user();
     final SecurityAudit audit = ((RoutingContextInternal) ctx).securityAudit();
     audit.authorization(authorization);
     audit.user(user);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/HotpAuthHandlerImpl.java
@@ -61,7 +61,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       return Future.failedFuture(new HttpException(500, new IllegalStateException("No callback mounted!")));
     }
 
-    final User user = ctx.user().get();
+    final User user = ctx.user();
 
     if (user == null) {
       return Future.failedFuture(new HttpException(401));
@@ -145,7 +145,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user().get();
+        final User user = ctx.user();
         if (user == null || user.get("username") == null) {
           ctx.fail(new VertxException("User object misses 'username' attribute", true));
           return;
@@ -169,7 +169,7 @@ public class HotpAuthHandlerImpl extends AuthenticationHandlerImpl<HotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user().get();
+        final User user = ctx.user();
         if (user == null || user.get("username") == null) {
           ctx.fail(new VertxException("User object misses 'username' attribute", true));
           return;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java
@@ -118,7 +118,7 @@ public class JWTAuthHandlerImpl extends HTTPAuthorizationHandler<JWTAuth> implem
    */
   @Override
   public void postAuthentication(RoutingContext ctx) {
-    final User user = ctx.user().get();
+    final User user = ctx.user();
     if (user == null) {
       // bad state
       ctx.fail(403, new VertxException("no user in the context", true));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -337,7 +337,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
     final List<String> scopes = getScopesOrSearchMetadata(this.scopes, ctx);
 
     if (scopes.size() > 0) {
-      final User user = ctx.user().get();
+      final User user = ctx.user();
       if (user == null) {
         // bad state
         ctx.fail(403, new VertxException("no user in the context", true));
@@ -506,7 +506,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
         .andThen(op -> audit.audit(Marker.AUTHENTICATION, op.succeeded()))
         .onFailure(ctx::fail)
         .onSuccess(user -> {
-          ((UserContextInternal) ctx.user())
+          ((UserContextInternal) ctx.userContext())
             .setUser(user);
           String location = resource != null ? resource : "/";
           if (session != null) {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/SessionHandlerImpl.java
@@ -181,7 +181,7 @@ public class SessionHandlerImpl implements SessionHandler {
         Boolean storeUser = context.get(SESSION_STOREUSER_KEY);
         if (storeUser != null && storeUser) {
           // during the request the user might have been removed
-          if (context.user().get() != null) {
+          if (context.user() != null) {
             session.put(SESSION_USER_HOLDER_KEY, new UserHolder(context));
           }
         }
@@ -368,7 +368,7 @@ public class SessionHandlerImpl implements SessionHandler {
     if (!cookieless) {
       context.response().removeCookie(sessionCookieName, false);
     }
-    ((UserContextInternal) context.user())
+    ((UserContextInternal) context.userContext())
       .setUser(user);
     // signal we must store the user to link it to the session
     context.put(SESSION_STOREUSER_KEY, true);

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TotpAuthHandlerImpl.java
@@ -61,7 +61,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       return Future.failedFuture(new HttpException(500, new IllegalStateException("No callback mounted!")));
     }
 
-    final User user = ctx.user().get();
+    final User user = ctx.user();
 
     if (user == null) {
       return Future.failedFuture(new HttpException(401));
@@ -143,7 +143,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user().get();
+        final User user = ctx.user();
         if (user == null || user.get("username") == null) {
           ctx.fail(new VertxException("User object misses 'username' attribute", true));
           return;
@@ -167,7 +167,7 @@ public class TotpAuthHandlerImpl extends AuthenticationHandlerImpl<TotpAuth> imp
       .method(HttpMethod.POST)
       .order(order - 1)
       .handler(ctx -> {
-        final User user = ctx.user().get();
+        final User user = ctx.user();
 
         if (user == null || user.get("username") == null) {
           ctx.fail(new VertxException("User object misses 'username' attribute", true));

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/UserHolder.java
@@ -47,12 +47,12 @@ public class UserHolder implements ClusterSerializable {
   public synchronized void refresh(RoutingContext context) {
     if (this.context != null) {
       // this is a new object instance or already refreshed
-      user = this.context.user().get();
+      user = this.context.user();
     }
     // refresh the context
     this.context = context;
     if (user != null) {
-      ((UserContextInternal) this.context.user())
+      ((UserContextInternal) this.context.userContext())
         .setUser(user);
     }
   }
@@ -63,7 +63,7 @@ public class UserHolder implements ClusterSerializable {
     final User user;
 
     synchronized (this) {
-      user = context != null ? context.user().get() : this.user;
+      user = context != null ? context.user() : this.user;
       // clear the context as this holder is not in a request anymore
       context = null;
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthn4JHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/WebAuthn4JHandlerImpl.java
@@ -100,7 +100,7 @@ public class WebAuthn4JHandlerImpl extends AuthenticationHandlerImpl<WebAuthn4J>
       return Future.failedFuture(new HttpException(500, new IllegalStateException("No callback mounted!")));
     }
 
-    final User user = ctx.user().get();
+    final User user = ctx.user();
 
     if (user == null) {
       return Future.failedFuture(new HttpException(401));
@@ -301,7 +301,7 @@ public class WebAuthn4JHandlerImpl extends AuthenticationHandlerImpl<WebAuthn4J>
             .onSuccess(user -> {
               audit.audit(Marker.AUTHENTICATION, true);
               // save the user into the context
-              ((UserContextInternal) ctx.user())
+              ((UserContextInternal) ctx.userContext())
                 .setUser(user);
               // the user has upgraded from unauthenticated to authenticated
               // session should be upgraded as recommended by owasp

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/SockJSSocketBase.java
@@ -126,6 +126,6 @@ public abstract class SockJSSocketBase implements SockJSSocket {
 
   @Override
   public User webUser() {
-    return routingContext.user().get();
+    return routingContext.user();
   }
 }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextDecorator.java
@@ -9,7 +9,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.audit.SecurityAudit;
 import io.vertx.ext.web.*;
 
@@ -195,8 +194,8 @@ public class RoutingContextDecorator implements RoutingContextInternal {
   }
 
   @Override
-  public UserContext user() {
-    return decoratedContext.user();
+  public UserContext userContext() {
+    return decoratedContext.userContext();
   }
 
   @Override

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -339,7 +339,7 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   }
 
   @Override
-  public UserContext user() {
+  public UserContext userContext() {
     if (identity == null) {
       identity = new UserContextImpl(this);
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextWrapper.java
@@ -178,8 +178,8 @@ public class RoutingContextWrapper extends RoutingContextImplBase {
   }
 
   @Override
-  public UserContext user() {
-    return inner.user();
+  public UserContext userContext() {
+    return inner.userContext();
   }
 
   @Override

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/APIKeyHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/APIKeyHandlerTest.java
@@ -52,7 +52,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -69,7 +69,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).header("xyz-api-key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -86,7 +86,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).parameter("api_key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -103,7 +103,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).cookie("api-key"));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -120,7 +120,7 @@ public class APIKeyHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(APIKeyHandler.create(authProvider).tokenExtractor(token -> Future.succeededFuture(token.substring(token.indexOf(" ") + 1))));
 
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/AuthHandlerTestBase.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/AuthHandlerTestBase.java
@@ -79,11 +79,11 @@ public abstract class AuthHandlerTestBase extends WebTestBase {
     AuthenticationHandler authNHandler = createAuthHandler(authNProvider);
     router.route().handler(rc -> {
       // we need to be logged in
-      if (!rc.user().authenticated()) {
+      if (!rc.userContext().authenticated()) {
         UsernamePasswordCredentials authInfo = new UsernamePasswordCredentials(username, "delicious:sausages");
         authNProvider.authenticate(authInfo).onComplete(res -> {
           if (res.succeeded()) {
-            ((UserContextInternal) rc.user())
+            ((UserContextInternal) rc.userContext())
               .setUser(res.result());
             rc.next();
           } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/AuthXRequestedWithTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/AuthXRequestedWithTest.java
@@ -31,8 +31,8 @@ public class AuthXRequestedWithTest extends AuthHandlerTestBase {
   public void testNoWwwAuthenticateForAjaxCalls() throws Exception {
     String realm = BasicAuthHandler.DEFAULT_REALM;
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("tim", rc.user().get().principal().getString("username"));
+      assertNotNull(rc.user());
+      assertEquals("tim", rc.user().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/BasicAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/BasicAuthHandlerTest.java
@@ -58,8 +58,8 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
   private void doLogin(String realm) throws Exception {
 
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("tim", rc.user().get().principal().getString("username"));
+      assertNotNull(rc.user());
+      assertEquals("tim", rc.user().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 
@@ -101,10 +101,10 @@ public class BasicAuthHandlerTest extends AuthHandlerTestBase {
       if (sessID != null) {
         assertEquals(sessID, rc.session().id());
       }
-      assertNotNull(rc.user().get());
-      assertEquals("tim", rc.user().get().principal().getString("username"));
+      assertNotNull(rc.user());
+      assertEquals("tim", rc.user().principal().getString("username"));
       if (c == 7) {
-        rc.user().clear();
+        rc.userContext().clear();
       }
       rc.response().end("Welcome to the protected resource!");
     };

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/BasicAuthImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/BasicAuthImpersonationTest.java
@@ -47,7 +47,7 @@ public class BasicAuthImpersonationTest extends WebTestBase {
     router.route("/user-switch/impersonate")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.user()
+        ctx.userContext()
           .loginHint(ctx.request().getParam("login_hint"))
           .impersonate(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -62,7 +62,7 @@ public class BasicAuthImpersonationTest extends WebTestBase {
     router.route("/user-switch/undo")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.user()
+        ctx.userContext()
           .loginHint(ctx.request().getParam("login_hint"))
           .restore(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -85,8 +85,8 @@ public class BasicAuthImpersonationTest extends WebTestBase {
       .route("/protected/base")
       .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("read")).addAuthorizationProvider(authz))
       .handler(rc -> {
-        assertNotNull(rc.user().get());
-        userRef.set(rc.user().get());
+        assertNotNull(rc.user());
+        userRef.set(rc.user());
         rc.end("OK");
       });
 
@@ -96,12 +96,12 @@ public class BasicAuthImpersonationTest extends WebTestBase {
       .route("/protected/admin")
       .handler(AuthorizationHandler.create(RoleBasedAuthorization.create("write")).addAuthorizationProvider(authz))
       .handler(rc -> {
-        assertNotNull(rc.user().get());
+        assertNotNull(rc.user());
 
         // assert that the old and new users are not the same
         User oldUser = userRef.get();
         assertNotNull(oldUser);
-        User newUser = rc.user().get();
+        User newUser = rc.user();
         assertFalse(oldUser.equals(newUser));
 
         // also the old user should be in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/CustomAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/CustomAuthHandlerTest.java
@@ -119,7 +119,7 @@ public class CustomAuthHandlerTest extends AuthHandlerTestBase {
       .handler(SimpleAuthenticationHandler.create().authenticate(ctx -> Future.succeededFuture()))
       .handler(ctx -> {
         // validation
-        assertNull(ctx.user().get());
+        assertNull(ctx.user());
         ctx.next();
       })
       .handler(ctx -> ctx.response().end("Welcome to the protected resource!"));

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/DigestAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/DigestAuthHandlerTest.java
@@ -74,8 +74,8 @@ public class DigestAuthHandlerTest extends WebTestBase {
   private void doLogin(String realm) throws Exception {
     router.clear();
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("Mufasa", rc.user().get().principal().getString("username"));
+      assertNotNull(rc.user());
+      assertEquals("Mufasa", rc.user().principal().getString("username"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/EventbusBridgeTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/EventbusBridgeTest.java
@@ -1170,7 +1170,7 @@ public class EventbusBridgeTest extends WebTestBase {
   private AuthenticationHandler addLoginHandler(AuthenticationProvider authProvider) {
     return SimpleAuthenticationHandler.create()
       .authenticate(ctx -> {
-        if (ctx.user().get() == null) {
+        if (ctx.user() == null) {
           return authProvider.authenticate(new UsernamePasswordCredentials("tim", "delicious:sausages"));
         } else {
           return Future.failedFuture("non null user");

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/JWTAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/JWTAuthHandlerTest.java
@@ -52,8 +52,8 @@ public class JWTAuthHandlerTest extends WebTestBase {
   public void testLogin() throws Exception {
 
     Handler<RoutingContext> handler = rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome to the protected resource!");
     };
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/MultiAuthorizationHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/MultiAuthorizationHandlerTest.java
@@ -47,8 +47,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(JWTAuthHandler.create(authProvider));
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -70,8 +70,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(AuthorizationHandler.create(RoleBasedAuthorization.create("role1")));
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -97,8 +97,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -126,8 +126,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -155,8 +155,8 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
@@ -199,14 +199,14 @@ public class MultiAuthorizationHandlerTest extends WebTestBase {
       .addAuthorizationProvider(createProvider("authzProvider1", RoleBasedAuthorization.create("role2"))));
 
     router.route("/protected1/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user().get());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.user());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/OAuth2AuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/OAuth2AuthHandlerTest.java
@@ -103,7 +103,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -165,7 +165,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -227,7 +227,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -288,7 +288,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
       .handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -350,7 +350,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
       .handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -415,7 +415,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -497,7 +497,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -584,7 +584,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
 
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -611,7 +611,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route().handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -673,7 +673,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -698,7 +698,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     router.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     router.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 
@@ -865,7 +865,7 @@ public class OAuth2AuthHandlerTest extends WebTestBase {
     subRouter.route("/protected/*").handler(oauth2Handler);
     // mount some handler under the protected zone
     subRouter.route("/protected/somepage").handler(rc -> {
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/OAuth2ImpersonationTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/OAuth2ImpersonationTest.java
@@ -134,7 +134,7 @@ public class OAuth2ImpersonationTest extends WebTestBase {
     router.route("/user-switch/impersonate")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.user()
+        ctx.userContext()
           .loginHint(ctx.request().getParam("login_hint"))
           .impersonate(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -149,7 +149,7 @@ public class OAuth2ImpersonationTest extends WebTestBase {
     router.route("/user-switch/undo")
       // this is a high precedence handler
       .handler(ctx -> {
-        ctx.user()
+        ctx.userContext()
           .loginHint(ctx.request().getParam("login_hint"))
           .restore(ctx.request().getParam("redirect_uri"))
           .onFailure(err -> {
@@ -176,8 +176,8 @@ public class OAuth2ImpersonationTest extends WebTestBase {
           .create(PermissionBasedAuthorization.create("read"))
           .addAuthorizationProvider(ScopeAuthorization.create()))
       .handler(rc -> {
-        assertNotNull(rc.user().get());
-        userRef.set(rc.user().get());
+        assertNotNull(rc.user());
+        userRef.set(rc.user());
         rc.end("OK");
       });
 
@@ -190,13 +190,13 @@ public class OAuth2ImpersonationTest extends WebTestBase {
           .create(PermissionBasedAuthorization.create("write"))
           .addAuthorizationProvider(ScopeAuthorization.create()))
       .handler(rc -> {
-        assertNotNull(rc.user().get());
-        System.out.println(rc.user().get().principal().encodePrettily());
+        assertNotNull(rc.user());
+        System.out.println(rc.user().principal().encodePrettily());
 
         // assert that the old and new users are not the same
         User oldUser = userRef.get();
         assertNotNull(oldUser);
-        User newUser = rc.user().get();
+        User newUser = rc.user();
         assertFalse(oldUser.equals(newUser));
 
         // also the old user should be in the session

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/RedirectAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/RedirectAuthHandlerTest.java
@@ -59,7 +59,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
       Session sess = rc.session();
       assertNotNull(sess);
       assertEquals(sessionCookie.get().substring(18, 50), sess.id());
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
     // And request it again
@@ -67,7 +67,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
     }, 200, "OK", "Welcome to the protected resource!");
     // Now logout
     router.route("/logout").handler(rc -> {
-      rc.user().clear();
+      rc.userContext().clear();
       rc.response().end("logged out");
     });
     testRequest(HttpMethod.GET, "/logout", req -> req.putHeader("cookie", sessionCookie.get()), resp -> {
@@ -245,7 +245,7 @@ public class RedirectAuthHandlerTest extends AuthHandlerTestBase {
       Session sess = rc.session();
       assertNotNull(sess);
       assertEquals(sessionCookie.get().substring(18, 54), sess.id());
-      assertNotNull(rc.user().get());
+      assertNotNull(rc.user());
       rc.response().end("Welcome to the protected resource!");
     });
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/SecurityAuditLoggerHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/SecurityAuditLoggerHandlerTest.java
@@ -133,8 +133,8 @@ public class SecurityAuditLoggerHandlerTest extends WebTestBase {
       );
 
     router.route("/protected/page1").handler(rc -> {
-      assertNotNull(rc.user());
-      assertEquals("paulo", rc.user().get().attributes().getJsonObject("accessToken").getString("sub"));
+      assertNotNull(rc.userContext());
+      assertEquals("paulo", rc.user().attributes().getJsonObject("accessToken").getString("sub"));
       rc.response().end("Welcome");
     });
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/WebAuthn4JHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/WebAuthn4JHandlerTest.java
@@ -19,37 +19,25 @@ package io.vertx.ext.web.tests.handler;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.JWTOptions;
-import io.vertx.ext.auth.KeyStoreOptions;
-import io.vertx.ext.auth.jwt.JWTAuth;
-import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.auth.webauthn4j.RelyingParty;
 import io.vertx.ext.auth.webauthn4j.Authenticator;
 import io.vertx.ext.auth.webauthn4j.CredentialStorage;
 import io.vertx.ext.auth.webauthn4j.WebAuthn4J;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials;
 import io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import io.vertx.ext.web.handler.JWTAuthHandler;
 import io.vertx.ext.web.handler.SessionHandler;
 import io.vertx.ext.web.handler.WebAuthn4JHandler;
 import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.tests.WebTestBase;
-import io.vertx.ext.web.tests.handler.WebAuthn4JHandlerTest.TestStorage;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -93,7 +81,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -212,8 +199,8 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 	public void testRegisterAndLogin() throws Exception {
 
 		Handler<RoutingContext> handler = rc -> {
-			assertNotNull(rc.user().get());
-			assertEquals(username, rc.user().get().subject());
+			assertNotNull(rc.user());
+			assertEquals(username, rc.user().subject());
 			rc.response().end("Welcome to the protected resource!");
 		};
 
@@ -234,7 +221,7 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 
 		// Now try again with credentials
 		testRequest(HttpMethod.GET, "/protected/somepage", req -> req.putHeader(HttpHeaders.COOKIE, session1Cookie), 200, "OK", "Welcome to the protected resource!");
-		
+
 		// Let's drop this session and try logging in
 		String session2Cookie = testAuthentication(clientPlatform);
 
@@ -276,7 +263,7 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 			String cookie = resp.getHeader(HttpHeaders.SET_COOKIE);
 			obtainedCookie[0] = extractVertxSessionCookie(cookie);
 		}, 204, "No Content", null);
-		
+
 		testStorage.find(username, null)
 		.onSuccess(authenticators -> {
 			Assert.assertNotNull(authenticators);
@@ -289,7 +276,7 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 			Assert.assertEquals(publicKey, authenticator.getPublicKey());
 		})
 		.onFailure(x -> Assert.fail("Well that did not work"));
-		
+
 		return obtainedCookie[0];
 	}
 
@@ -383,7 +370,7 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 			String cookie = resp.getHeader(HttpHeaders.SET_COOKIE);
 			obtainedCookie[0] = extractVertxSessionCookie(cookie);
 		}, 204, "No Content", null);
-		
+
 		testStorage.find(username, null)
 		.onSuccess(authenticators -> {
 			Assert.assertNotNull(authenticators);
@@ -396,7 +383,7 @@ public class WebAuthn4JHandlerTest extends WebTestBase {
 			Assert.assertEquals(publicKey, authenticator.getPublicKey());
 		})
 		.onFailure(x -> Assert.fail("Well that did not work"));
-		
+
 		return obtainedCookie[0];
 	}
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSHandlerTest.java
@@ -393,7 +393,7 @@ public class SockJSHandlerTest extends WebTestBase {
           assertEquals(session, sock.webSession());
           ((RoutingContextInternal) sock.routingContext()).setSession(session);
           assertEquals(sock.webSession(), sock.routingContext().session());
-          assertEquals(sock.webUser(), sock.routingContext().user().get());
+          assertEquals(sock.webUser(), sock.routingContext().user());
           assertEquals(sock.webUser(), user);
           assertEquals(session, sock.webSession());
           assertEquals(session, store.get(session.id()).result());


### PR DESCRIPTION
Motivation:

`RoutingContext#user()` method returns the `io.vertx.ext.auth.User` interface in Vert.x 4.x, its return type has been change to `UserContext` instead (in addition of other changes), as `UserContext` is the preferred API for interacting with the user and the `User` interface actually represents the `User`.

However, there is nothing wrong with having the user method returns the `io.vertx.ext.auth.User` interface, since the `User` interface is still the API for accessing user informations. The `UserContext` API can be returned from a `userContext` method instead. This avoids breaking the contract of the user method between 4.x and 5.0

Changes:

Introduce a new `userContext` method returning the `UserContext` and change the return type of the user method to return the `User` type.