### PR TITLE
Require transitively io.vertx.auth.common module

### DIFF
--- a/vertx-web-api-service/src/main/java/module-info.java
+++ b/vertx-web-api-service/src/main/java/module-info.java
@@ -4,7 +4,6 @@ module io.vertx.web.apiservice {
   requires static io.vertx.codegen.api;
   requires io.vertx.codegen.processor;
   requires io.vertx.core;
-  requires io.vertx.auth.common;
   requires io.vertx.openapi;
   requires io.vertx.serviceproxy;
   requires io.vertx.web.openapi.router;

--- a/vertx-web-openapi-router/src/main/java/module-info.java
+++ b/vertx-web-openapi-router/src/main/java/module-info.java
@@ -19,7 +19,6 @@ module io.vertx.web.openapi.router {
   requires static io.vertx.codegen.json;
   requires static io.vertx.docgen;
 
-  requires static io.vertx.auth.common; // Examples
   requires static io.vertx.auth.oauth2; // Examples
   requires static io.vertx.auth.jwt;    // Examples
 

--- a/vertx-web-openapi-router/src/test/java/module-info.java
+++ b/vertx-web-openapi-router/src/test/java/module-info.java
@@ -8,7 +8,6 @@ open module io.vertx.web.openapi.router.tests {
   requires org.junit.jupiter.params;
   requires truth;
   requires org.mockito;
-  requires io.vertx.auth.common;
   requires static io.vertx.auth.oauth2;
   requires static io.vertx.auth.jwt;
   exports io.vertx.router.test.base;

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/module-info.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/module-info.java
@@ -19,7 +19,6 @@ module io.vertx.web.sstore.cookie {
 
   requires io.vertx.core;
   requires io.vertx.web;
-  requires io.vertx.auth.common;
 
   exports io.vertx.ext.web.sstore.cookie;
 

--- a/vertx-web-session-stores/vertx-web-sstore-redis/src/main/java/module-info.java
+++ b/vertx-web-session-stores/vertx-web-sstore-redis/src/main/java/module-info.java
@@ -20,7 +20,6 @@ module io.vertx.web.sstore.redis {
   requires io.vertx.core;
   requires io.vertx.web;
   requires io.vertx.redis.client;
-  requires io.vertx.auth.common;
 
   exports io.vertx.ext.web.sstore.redis;
 

--- a/vertx-web/src/main/java/module-info.java
+++ b/vertx-web/src/main/java/module-info.java
@@ -29,7 +29,9 @@ module io.vertx.web {
   requires io.netty.codec.http;
   requires com.fasterxml.jackson.core;
 
-  requires static io.vertx.auth.common;
+  // Required by Vert.x Web even when no Vert.x Auth handler is used
+  requires transitive io.vertx.auth.common;
+
   requires static io.vertx.auth.htdigest;
   requires static io.vertx.auth.jwt;
   requires static io.vertx.auth.otp;


### PR DESCRIPTION
This module is required by Vert.x Web applications even when no Vert.x Auth handler is used.

Indeed, Vert.x Web uses the `SecurityAudit` class in several places.

Instead of making all JPMS users of Vert.x Web require that module explicitly, we should make it a transitive requirement.