### PR TITLE
Align pattern based methods with the suffix WithRegex as used across …

### DIFF
--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -919,7 +919,7 @@ public class WebExamples {
     router.route()
       .handler(
         CorsHandler.create()
-          .addRelativeOrigin("vertx\\.io")
+          .addOriginWithRegex("vertx\\.io")
           .allowedMethod(HttpMethod.GET));
 
     router.route().handler(ctx -> {

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/CorsHandler.java
@@ -51,22 +51,22 @@ public interface CorsHandler extends SecurityPolicyHandler {
   CorsHandler addOrigin(String origin);
 
   /**
-   * Set the list of allowed relative origins.
-   * A relative origin is a regex that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
-   * @param origins the well formatted relative origin list
+   * Set the list of allowed regex origins.
+   * A regex origin is a pattern that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
+   * @param origins the well formatted regex origin list
    * @return self
    */
   @Fluent
-  CorsHandler addRelativeOrigins(List<String> origins);
+  CorsHandler addOriginsWithRegex(List<String> origins);
 
   /**
-   * Add a relative origin to the list of allowed Origins.
-   * A relative origin is a regex that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
+   * Add a regex origin to the list of allowed Origins.
+   * A regex origin is a pattern that should match the format {@code <scheme> "://" <hostname> [ ":" <port> ]}.
    * @param origin the well formatted static origin
    * @return self
    */
   @Fluent
-  CorsHandler addRelativeOrigin(String origin);
+  CorsHandler addOriginWithRegex(String origin);
 
   /**
    * Set the list of allowed origins. An origin follows rfc6454#section-7

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSCORSTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSCORSTest.java
@@ -32,7 +32,7 @@ public class SockJSCORSTest extends WebTestBase {
   public void testNoConflictsSockJSAndCORSHandler() {
     router
       .route()
-      .handler(CorsHandler.create().addRelativeOrigin(".*").allowCredentials(false))
+      .handler(CorsHandler.create().addOriginWithRegex(".*").allowCredentials(false))
       .handler(BodyHandler.create());
     SockJSProtocolTest.installTestApplications(router, vertx);
     client.request(HttpMethod.GET, "/echo/info?t=21321")
@@ -54,7 +54,7 @@ public class SockJSCORSTest extends WebTestBase {
     router
       .route()
       .handler(BodyHandler.create())
-      .handler(CorsHandler.create().addRelativeOrigin(".*").allowCredentials(false));
+      .handler(CorsHandler.create().addOriginWithRegex(".*").allowCredentials(false));
     SockJSProtocolTest.installTestApplications(router, vertx);
   }
 
@@ -65,7 +65,7 @@ public class SockJSCORSTest extends WebTestBase {
       router
         .route()
         .handler(BodyHandler.create())
-        .handler(CorsHandler.create().addRelativeOrigin(".*").allowCredentials(false));
+        .handler(CorsHandler.create().addOriginWithRegex(".*").allowCredentials(false));
       SockJSProtocolTest.installTestApplications(router, vertx);
     } finally {
       System.clearProperty("io.vertx.web.router.setup.lenient");


### PR DESCRIPTION
…other APIs

Motivation:

CORS Handler predates vertx-web and the original code refered to pattern based origins as relative origins. This can be confusing and to keep the naming style across other modules this PR renames those with the suffix `WithRegex`
