### PR TITLE
Improve ProtocolUpgradeHandler priority checking

### DIFF
--- a/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/tests/handler/ProxyHandlerTest.java
+++ b/vertx-web-proxy/src/test/java/io/vertx/ext/web/proxy/tests/handler/ProxyHandlerTest.java
@@ -1,7 +1,10 @@
 package io.vertx.ext.web.proxy.tests.handler;
 
+import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.SimpleAuthenticationHandler;
 import io.vertx.ext.web.proxy.handler.ProxyHandler;
 import io.vertx.ext.web.proxy.tests.WebProxyTestBase;
 import io.vertx.httpproxy.HttpProxy;
@@ -29,6 +32,21 @@ public class ProxyHandlerTest extends WebProxyTestBase {
     router.get("/path")
       .handler(BodyHandler.create())
       .handler(ProxyHandler.create(proxy));
+  }
+
+  @Test
+  public void shouldPassAuthHandlerOnSameRoute() throws Exception {
+    HttpProxy proxy = HttpProxy.reverseProxy(proxyClient);
+    proxy.origin(1234, "localhost");
+    router.get("/path")
+      .handler(SimpleAuthenticationHandler.create().authenticate(rc -> Future.succeededFuture(User.fromName("John"))))
+      .handler(ProxyHandler.create(proxy));
+    backendRouter.route(HttpMethod.GET, "/path").handler(rc -> {
+      rc.response().setStatusCode(200);
+      rc.response().setStatusMessage("statusMessage");
+      rc.response().end("data");
+    });
+    testRequest(HttpMethod.GET, "/path", 200, "statusMessage", "data");
   }
 
   @Test

--- a/vertx-web-proxy/src/test/java/module-info.java
+++ b/vertx-web-proxy/src/test/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc.
+ * Copyright 2025 Red Hat, Inc.
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -20,4 +20,5 @@ open module io.vertx.web.proxy.tests {
   requires io.vertx.web.proxy;
   requires io.vertx.web.tests;
   requires junit;
+  requires io.vertx.auth.common;
 }


### PR DESCRIPTION
See #2676

`ProtocolUpgradeHandler` (GraphQLWS, Proxy) instances must not be installed after the `BodyHandler`. However, they are often used with authentication handlers (e.g. Basic auth handler), because authentication can be required before allowing the connection upgrade. The problem is that, currently, authn/authz handlers have higher priorities than body handlers (for good reasons, we may need to inspect the body to perform form login). So, if a user tries to install a `ProtocolUpgradeHandler` after an auth handler, an ISE is thrown.

With this change, the order of priorities is not changed. Instead, there's a special check for `ProtocolUpgradeHandler` instances: the `BodyHandler` must not be found in the already installed handlers.

Also, the warning about `ProtocolUpgradeHandler` being installed before another handler has been removed. Indeed, it is a fairly common case to hand over the request to another handler if the protocol upgrade has not been made (e.g. `GraphQLHandler` installed after the `GraphQLWSHandler`).