### PR TITLE
Adding support for combined log format

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerFormat.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerFormat.java
@@ -31,6 +31,11 @@ public enum LoggerFormat {
   DEFAULT,
 
   /**
+   * <i>remote-client</i> - <i>user</> [<i>timestamp in strftime format</i>] "<i>method</i> <i>uri</i> <i>version</i>" <i>status</i> <i>content-length</i> "<i>referrer</i>" "<i>user-agent</i>"
+   */
+  COMBINED,
+
+  /**
    * <i>remote-client</i> - <i>method</i> <i>uri</i> <i>version</i> <i>status</i> <i>content-length</i> <i>duration</i> ms
    */
   SHORT,

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/Utils.java
@@ -31,6 +31,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 
@@ -69,6 +70,12 @@ public class Utils {
 
   public static String formatRFC1123DateTime(final long time) {
     return DateTimeFormatter.RFC_1123_DATE_TIME.format(Instant.ofEpochMilli(time).atZone(ZONE_GMT));
+  }
+
+  private static final DateTimeFormatter STRFTIME = DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z").withLocale(Locale.US);
+
+  public static String formatStrftimeDateTime(final long time) {
+    return STRFTIME.format(Instant.ofEpochMilli(time).atZone(ZoneId.systemDefault()));
   }
 
   public static long parseRFC1123DateTime(final String header) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/LoggerHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/LoggerHandlerTest.java
@@ -45,6 +45,12 @@ public class LoggerHandlerTest extends WebTestBase {
   }
 
   @Test
+  public void testLoggerCombined() throws Exception {
+    LoggerHandler logger = LoggerHandler.create(LoggerFormat.COMBINED);
+    testLogger(logger);
+  }
+
+  @Test
   public void testLogger2() throws Exception {
     LoggerHandler logger = LoggerHandler.create(LoggerFormat.TINY);
     testLogger(logger);


### PR DESCRIPTION
Motivation:

Vert.x Web Log handler uses a custom format similar to apache.

This PR adds a valid NSCA Combined log format that allows users to consume the log in web log analysis tools without fidling with the format.