### PR TITLE
Replace free cast in TemplateEngine#unwrap with covariant return type.

### DIFF
--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/FreeMarkerTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/FreeMarkerTemplateEngine.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.ext.web.templ.freemarker;
 
+import freemarker.template.Configuration;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.template.TemplateEngine;
@@ -50,4 +51,7 @@ public interface FreeMarkerTemplateEngine extends TemplateEngine {
   static FreeMarkerTemplateEngine create(Vertx vertx, String extension) {
     return new FreeMarkerTemplateEngineImpl(vertx, extension);
   }
+
+  @Override
+  Configuration unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/impl/FreeMarkerTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/main/java/io/vertx/ext/web/templ/freemarker/impl/FreeMarkerTemplateEngineImpl.java
@@ -48,8 +48,8 @@ public class FreeMarkerTemplateEngineImpl extends CachingTemplateEngine<Template
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) config;
+  public Configuration unwrap() {
+    return config;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/HandlebarsTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/HandlebarsTemplateEngine.java
@@ -64,4 +64,7 @@ public interface HandlebarsTemplateEngine extends TemplateEngine {
    */
   @GenIgnore
   HandlebarsTemplateEngine setResolvers(ValueResolver... resolvers);
+
+  @Override
+  Handlebars unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/io/vertx/ext/web/templ/handlebars/impl/HandlebarsTemplateEngineImpl.java
@@ -102,8 +102,8 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) handlebars;
+  public Handlebars unwrap() {
+    return handlebars;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/HTTLTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/HTTLTemplateEngine.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.web.templ.httl;
 
+import httl.Engine;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.common.template.TemplateEngine;
@@ -52,4 +53,7 @@ public interface HTTLTemplateEngine extends TemplateEngine {
   static HTTLTemplateEngine create(Vertx vertx, String extension) {
     return new HTTLTemplateEngineImpl(vertx, extension);
   }
+
+  @Override
+  Engine unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/impl/HTTLTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-httl/src/main/java/io/vertx/ext/web/templ/httl/impl/HTTLTemplateEngineImpl.java
@@ -42,8 +42,8 @@ public class HTTLTemplateEngineImpl extends CachingTemplateEngine<Template> impl
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) engine;
+  public Engine unwrap() {
+    return engine;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/JteTemplateEngine.java
@@ -65,4 +65,7 @@ public interface JteTemplateEngine extends TemplateEngine {
   static JteTemplateEngine create(gg.jte.TemplateEngine engine) {
     return new JteTemplateEngineImpl(engine);
   }
+
+  @Override
+  gg.jte.TemplateEngine unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-jte/src/main/java/io/vertx/ext/web/templ/jte/impl/JteTemplateEngineImpl.java
@@ -77,8 +77,7 @@ public class JteTemplateEngineImpl implements JteTemplateEngine {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public <T> T unwrap() throws ClassCastException {
-    return (T) templateEngine;
+  public TemplateEngine unwrap() throws ClassCastException {
+    return templateEngine;
   }
 }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/PebbleTemplateEngine.java
@@ -76,4 +76,7 @@ public interface PebbleTemplateEngine extends TemplateEngine {
   static PebbleTemplateEngine create(Vertx vertx, String extension, PebbleEngine engine) {
     return new PebbleTemplateEngineImpl(vertx, extension, engine);
   }
+
+  @Override
+  PebbleEngine unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/main/java/io/vertx/ext/web/templ/pebble/impl/PebbleTemplateEngineImpl.java
@@ -52,8 +52,8 @@ public class PebbleTemplateEngineImpl extends CachingTemplateEngine<PebbleTempla
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) pebbleEngine;
+  public PebbleEngine unwrap() {
+    return pebbleEngine;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-pug/src/main/java/io/vertx/ext/web/templ/pug/PugTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-pug/src/main/java/io/vertx/ext/web/templ/pug/PugTemplateEngine.java
@@ -67,4 +67,7 @@ public interface PugTemplateEngine extends TemplateEngine {
   static PugTemplateEngine create(Vertx vertx, String extension, String encoding) {
     return new PugTemplateEngineImpl(vertx, extension, encoding);
   }
+
+  @Override
+  PugConfiguration unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-pug/src/main/java/io/vertx/ext/web/templ/pug/impl/PugTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-pug/src/main/java/io/vertx/ext/web/templ/pug/impl/PugTemplateEngineImpl.java
@@ -62,8 +62,8 @@ public class PugTemplateEngineImpl extends CachingTemplateEngine<PugTemplate> im
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) config;
+  public PugConfiguration unwrap() {
+    return config;
   }
 
   @Override

--- a/vertx-template-engines/vertx-web-templ-rocker/src/main/java/io/vertx/ext/web/templ/rocker/RockerTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-rocker/src/main/java/io/vertx/ext/web/templ/rocker/RockerTemplateEngine.java
@@ -50,4 +50,5 @@ public interface RockerTemplateEngine extends TemplateEngine {
   static RockerTemplateEngine create(String extension) {
     return new RockerTemplateEngineImpl(extension);
   }
+
 }

--- a/vertx-template-engines/vertx-web-templ-rythm/src/main/java/io/vertx/ext/web/templ/rythm/RythmTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-rythm/src/main/java/io/vertx/ext/web/templ/rythm/RythmTemplateEngine.java
@@ -36,4 +36,7 @@ public interface RythmTemplateEngine extends TemplateEngine {
   static RythmTemplateEngine create(Vertx vertx, String extension) {
     return new RythmTemplateEngineImpl(vertx, extension);
   }
+
+  @Override
+  RythmEngine unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-rythm/src/main/java/io/vertx/ext/web/templ/rythm/impl/RythmTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-rythm/src/main/java/io/vertx/ext/web/templ/rythm/impl/RythmTemplateEngineImpl.java
@@ -53,7 +53,7 @@ public class RythmTemplateEngineImpl extends CachingTemplateEngine<String>  impl
     }
   }
 
-  public <T> T unwrap() throws ClassCastException {
-    return (T) engine;
+  public RythmEngine unwrap() throws ClassCastException {
+    return engine;
   }
 }

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/ThymeleafTemplateEngine.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/ThymeleafTemplateEngine.java
@@ -40,4 +40,7 @@ public interface ThymeleafTemplateEngine extends TemplateEngine {
   static ThymeleafTemplateEngine create(Vertx vertx) {
     return new ThymeleafTemplateEngineImpl(vertx);
   }
+
+  @Override
+  org.thymeleaf.TemplateEngine unwrap();
 }

--- a/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
+++ b/vertx-template-engines/vertx-web-templ-thymeleaf/src/main/java/io/vertx/ext/web/templ/thymeleaf/impl/ThymeleafTemplateEngineImpl.java
@@ -66,8 +66,8 @@ public class ThymeleafTemplateEngineImpl implements ThymeleafTemplateEngine {
   }
 
   @Override
-  public <T> T unwrap() {
-    return (T) templateEngine;
+  public TemplateEngine unwrap() {
+    return templateEngine;
   }
 
   @Override

--- a/vertx-web-common/src/main/java/io/vertx/ext/web/common/template/TemplateEngine.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/common/template/TemplateEngine.java
@@ -64,13 +64,12 @@ public interface TemplateEngine {
   Future<Buffer> render(Map<String, Object> context, String templateFileName);
 
   /**
-   * Returns the underlying engine, so further configurations or customizations may be applied.
-   * @param <T> the engine object type.
+   * Returns the underlying engine, so further configurations or customizations may be applied or {@code null} when the
+   * engine cannot unwrap it.
    * @return the engine instance.
-   * @throws ClassCastException when the expected type does not match the internal type.
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  default <T> T unwrap() throws ClassCastException {
+  default Object unwrap() {
     return null;
   }
 


### PR DESCRIPTION
Motivation:

The `TemplateEngine#unwrap` uses a free downcast pattern (`<T> T`) that does not indicate the actual engine type and force the developer to know about the actual type to cast to.

This can be replaced by covariant return type that carries the exact type of the unwrapped engine.

Changes:

- remove generic <T> declaration in unwrap
- template engine supporting it, overrides this method with the actual engine type
