### PR TITLE
StaticHandler makes a redundant call to RFC3986.removeDotSegments

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -170,8 +170,8 @@ public class StaticHandlerImpl implements StaticHandler {
         context.next();
         return;
       }
-      // will normalize and handle all paths as UNIX paths
-      String path = RFC3986.removeDotSegments(uriDecodedPath.replace('\\', '/'));
+      // Handle all paths as UNIX paths
+      String path = uriDecodedPath.replace('\\', '/');
 
       // Access fileSystem once here to be safe
       FileSystem fs = context.vertx().fileSystem();


### PR DESCRIPTION
The dot segments are already taken care of by the call to context.normalizedPath().

See https://github.com/quarkusio/quarkus/pull/47395#issuecomment-2809168543