### PR TITLE
fix: subject may be null which renders the log incorrectly

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/LoggerHandler.java
@@ -21,7 +21,10 @@ import io.vertx.ext.web.handler.impl.LoggerHandlerImpl;
 
 /**
  * A handler which logs request information to the Vert.x logger.
- * You should mount this handler before any handler that could fail the routing context
+ * You should mount this handler before any handler that could fail the routing context.
+ * Logs will be produced with the appropriate severity level depending on the status code of the response.
+ * To capture the logs configure the logger in your logging configuration with the name:
+ * {@code io.vertx.ext.web.handler.LoggerHandler}.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/LoggerHandlerImpl.java
@@ -30,8 +30,6 @@ import io.vertx.ext.web.handler.LoggerFormatter;
 import io.vertx.ext.web.handler.LoggerHandler;
 import io.vertx.ext.web.impl.Utils;
 
-import java.util.function.Function;
-
 /** # Logger
  *
  * Logger for request. There are 4 formats included:
@@ -49,7 +47,7 @@ import java.util.function.Function;
  */
 public class LoggerHandlerImpl implements LoggerHandler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(LoggerHandlerImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LoggerHandler.class);
 
   /** log before request or after
    */
@@ -138,7 +136,18 @@ public class LoggerHandlerImpl implements LoggerHandler {
         userAgent = userAgent == null ? "-" : userAgent;
 
         User user = context.user();
-        String userId = user == null ? "-" : user.subject();
+        String userId = "-";
+        // user may be null if no auth was performed
+        if (user != null) {
+          // subject may be null if no auth was performed
+          if (user.subject() != null) {
+            userId = user.subject();
+            // if the userId contains spaces, we need to quote it
+            if (userId.indexOf(' ') != -1) {
+              userId = "\"" + userId + "\"";
+            }
+          }
+        }
 
         message = String.format("%s - %s [%s] \"%s %s %s\" %d %d \"%s\" \"%s\"",
           remoteClient,


### PR DESCRIPTION
# LoggerHandler

`user.subject` may be null and it would break the log format. Also vert.x auth imposes no restrictions on the use of ` ` (spaces) so we need to quote the username if spaces are present.