### PR TITLE
JTE upgrade to 3.2.0 (from 2.3.2) in order to fix the CVE-2025-23026

### DIFF
--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>vertx-web-templ-jte</artifactId>
 
   <properties>
-    <jte.version>2.3.2</jte.version>
+    <jte.version>3.2.0</jte.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## JTE upgrade to 3.2.0 (from 2.3.2) to fix the CVE-2025-23026.

#### Dependency maven:gg.jte:jte-runtime:2.3.2 is vulnerable
Advise: Upgrade to 3.1.16

CVE-2025-23026,  Score: 6.1

jte (Java Template Engine) is a secure and lightweight template engine for Java and Kotlin. In affected versions Jte HTML templates with `script` tags or script attributes that include a Javascript template string (backticks) are subject to XSS. The `javaScriptBlock` and `javaScriptAttribute` methods in the `Escape` class do not escape backticks, which are used for Javascript template strings. Dollar signs in template strings should also be escaped as well to prevent undesired interpolation. HTML templates rendered by Jte's `OwaspHtmlTemplateOutput` in versions less than or equal to `3.1.15` with `script` tags or script attributes that contain Javascript template strings (backticks) are vulnerable. Users are advised to upgrade to version 3.1.16 or later to resolve this issue. There are no known workarounds for this vulnerability.

Read More: https://www.mend.io/vulnerability-database/CVE-2025-23026?utm_source=JetBrains

