### PR TITLE
CORS to respect the configured METHODS

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java
@@ -233,6 +233,17 @@ public class CorsHandlerImpl implements CorsHandler {
           .end();
 
       } else {
+        // Origin correct and not a pre-flight request
+
+        // in this case, we to verify the method, if it is not allowed we return a 403
+        if (!allowedMethods.isEmpty() && !allowedMethods.contains(request.method().name())) {
+          response
+            .setStatusMessage("CORS Rejected - Method not allowed");
+          context
+            .fail(403, new VertxException("CORS Rejected - Method not allowed", true));
+          return;
+        }
+
         // when it is possible to determine if only one origin is allowed, we can skip this extra caching header
         // If allow credentials is set, the response cannot be '*' thus we need to vary on origin
         if (!(starOrigin() && !allowCredentials) && !uniqueOrigin()) {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/CORSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/CORSHandlerTest.java
@@ -143,6 +143,18 @@ public class CORSHandlerTest extends WebTestBase {
   }
 
   @Test
+  public void testPreflightMismatchMethod() throws Exception {
+    Consumer<RoutingContext> handler = mock(Consumer.class);
+
+    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
+
+    router.route().handler(CorsHandler.create().addOrigin("http://vertx.io").allowedMethods(allowedMethods));
+    router.route().handler(context -> context.response().end());
+    router.errorHandler(403, handler::accept);
+    testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> verify(handler).accept(any()), 403, "CORS Rejected - Method not allowed", null);
+  }
+
+  @Test
   public void testPreflightAllowedHeaders() throws Exception {
     Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
     Set<String> allowedHeaders = new LinkedHashSet<>(Arrays.asList("X-wibble", "X-blah"));
@@ -207,7 +219,7 @@ public class CORSHandlerTest extends WebTestBase {
 
   @Test
   public void testRealRequestAllowCredentials() throws Exception {
-    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
+    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE));
     router.route().handler(CorsHandler.create().addOriginWithRegex("http://vertx\\.io").allowedMethods(allowedMethods).allowCredentials(true));
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> checkHeaders(resp, "http://vertx.io", null, null, null, "true", null), 200, "OK", null);
@@ -215,7 +227,7 @@ public class CORSHandlerTest extends WebTestBase {
 
   @Test
   public void testRealRequestCredentialsNoWildcardOrigin() throws Exception {
-    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
+    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE));
     router.route().handler(CorsHandler.create().addOriginWithRegex("http://vertx.*").allowedMethods(allowedMethods).allowCredentials(true));
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> checkHeaders(resp, "http://vertx.io", null, null, null, "true", null), 200, "OK", null);
@@ -223,7 +235,7 @@ public class CORSHandlerTest extends WebTestBase {
 
   @Test
   public void testRealRequestCredentialsWildcard() throws Exception {
-    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
+    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE));
     router.route().handler(CorsHandler.create().allowedMethods(allowedMethods).allowCredentials(true));
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "http://vertx.io"), resp -> checkHeaders(resp, "http://vertx.io", null, null, null, "true", null), 200, "OK", null);
@@ -502,7 +514,7 @@ public class CORSHandlerTest extends WebTestBase {
 
   @Test
   public void testRealRequestAllowCredentialsMultiOrigin() throws Exception {
-    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.PUT, HttpMethod.DELETE));
+    Set<HttpMethod> allowedMethods = new LinkedHashSet<>(Arrays.asList(HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE));
     router.route().handler(CorsHandler.create().addOrigins(Arrays.asList("http://www.example.com", "https://www.vertx.io")).allowedMethods(allowedMethods).allowCredentials(true));
     router.route().handler(context -> context.response().end());
     testRequest(HttpMethod.GET, "/", req -> req.headers().add("origin", "https://www.vertx.io"), resp -> checkHeaders(resp, "https://www.vertx.io", null, null, null, "true", null), 200, "OK", null);


### PR DESCRIPTION
Motivation:

Currently the list of configured METHODs are only used to populate the preflight headers. This PR ensures that that requests are blocked `403` as per fetch spec: https://fetch.spec.whatwg.org/#http-cors-protocol

Open for discussion:

* should this be configurable?