### PR TITLE
Bump jte version to 3.2.1

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -15,15 +15,19 @@ jobs:
         include:
           - os: ubuntu-latest
             jdk: 11
+            jte: false
           - os: ubuntu-latest
             jdk: 21
+            jte: true
           - os: windows-latest
             jdk: 11
+            jte: false
     uses: ./.github/workflows/ci.yml
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
+      jte: ${{ matrix.jte }}
     secrets: inherit
   IT:
     uses: ./.github/workflows/it.yml
@@ -37,5 +41,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
-      jdk: 11
+      jdk: 17
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       os:
         default: ubuntu-latest
         type: string
+      jte:
+        default: true
+        type: boolean
 jobs:
   Test:
     name: Run tests
@@ -26,4 +29,20 @@ jobs:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
       - name: Run tests
-        run: mvn -s .github/maven-ci-settings.xml clean verify -B
+        run: mvn -s .github/maven-ci-settings.xml clean verify -pl -:vertx-web-templ-jte -B
+  Test-JTE:
+    if: ${{ inputs.jte }}
+    name: Run JTE tests
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Install JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ inputs.jdk }}
+          distribution: temurin
+      - name: Run tests
+        run: mvn -s .github/maven-ci-settings.xml clean verify -pl :vertx-web-templ-jte -B

--- a/vertx-template-engines/vertx-web-templ-jte/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-jte/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>vertx-web-templ-jte</artifactId>
 
   <properties>
-    <jte.version>2.3.2</jte.version>
+    <jte.version>3.2.1</jte.version>
   </properties>
 
   <dependencies>
@@ -37,51 +37,117 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-test</id>
-            <configuration>
-              <useModulePath>false</useModulePath>
-            </configuration>
-          </execution>
-          <execution>
-            <id>jpms-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <useModulePath>true</useModulePath>
-              <includes>
-                <include>**/JteCompiledTemplateEngineTest.java</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>gg.jte</groupId>
-        <artifactId>jte-maven-plugin</artifactId>
-        <version>${jte.version}</version>
-        <configuration>
-          <sourceDirectory>${project.basedir}/src/test/templates</sourceDirectory>
-          <targetDirectory>${project.build.directory}/test-classes</targetDirectory>
-          <contentType>Html</contentType>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>process-test-classes</phase>
-            <goals>
-              <goal>precompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
+
+  <!-- Java 11 => use Maven Toolchain to compile this module with JDK 17
+       The config file .m2/toolchains.xml is needed with this content
+
+       <toolchains>
+         <toolchain>
+           <type>jdk</type>
+           <provides>
+             <id>Java17</id>
+             <version>17</version>
+           </provides>
+           <configuration>
+             <jdkHome>/PATH/TO/JDK/17</jdkHome>
+           </configuration>
+         </toolchain>
+       </toolchains>
+  -->
+  <profiles>
+    <profile>
+      <id>Java11</id>
+      <activation>
+        <jdk>[11,17)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <version>1.0</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>toolchain</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>17</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>Java17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>gg.jte</groupId>
+            <artifactId>jte-maven-plugin</artifactId>
+            <version>${jte.version}</version>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/templates</sourceDirectory>
+              <targetDirectory>${project.build.directory}/test-classes</targetDirectory>
+              <contentType>Html</contentType>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>precompile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <configuration>
+                  <useModulePath>false</useModulePath>
+                </configuration>
+              </execution>
+              <execution>
+                <id>jpms-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <useModulePath>true</useModulePath>
+                  <includes>
+                    <include>**/JteCompiledTemplateEngineTest.java</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
Upgrade JTE template engine to 3.2.1

Maven toolchain is used to compile with JDK17 (required) when Maven is executed with JDK11 

JTE Maven plugin doesn't support toolchains so it's executed when running on JDK17+.
As a consequence tests can be run only when running on JDK17+.

On GitHub Actions, JTE tests will be executed separately.
Enabled by default, they are disabled in ci-5.x.yml when testing with JDK11.

Note that deployment in ci-5.x.yml is executed with JDK17 because Maven toolchains are not easy to set up on GitHub Actions.