### PR TITLE
Ensuring that cookie sessions are reusable across nodes

### DIFF
--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/CookieSessionStore.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/main/java/io/vertx/ext/web/sstore/cookie/CookieSessionStore.java
@@ -23,7 +23,7 @@ import io.vertx.ext.web.sstore.cookie.impl.CookieSessionStoreImpl;
 
 /**
  * A SessionStore that uses a Cookie to store the session data. All data is stored in
- * encrypted form using {@code AES-256 with AES/CBC/PKCS5Padding}.
+ * encrypted form using {@code AES-256 with AES/GCM/NoPadding}.
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
@@ -33,16 +33,19 @@ public interface CookieSessionStore extends SessionStore {
   /**
    * Creates a CookieSessionStore.
    *
-   * Cookie data will be encrypted using the given secret and salt. The secret as the name
+   * Cookie data will be encrypted using the given secret. The secret as the name
    * reflects, should never leave the server, otherwise user agents could tamper
-   * with the payload. The salt adds an extra later of security and should be a random.
+   * with the payload.
+   * 
+   * The choice of GCM, ensures that no (IV, Key) is reusable, which means that
+   * there is no need for a salt. Also encrypting the same session multiple times
+   * will render different outputs, which prevents rainbow attacks.
    *
    * @param vertx a vert.x instance
    * @param secret a secret to derive a secure private key
-   * @param salt a binary salt used in the key derivation
    * @return the store
    */
-  static CookieSessionStore create(Vertx vertx, String secret, Buffer salt) {
-    return new CookieSessionStoreImpl(vertx, secret, salt);
+  static CookieSessionStore create(Vertx vertx, String secret) {
+    return new CookieSessionStoreImpl(vertx, secret);
   }
 }

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/tests/CookieSessionCreateTest.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/tests/CookieSessionCreateTest.java
@@ -37,24 +37,9 @@ public class CookieSessionCreateTest {
   public RunTestOnContext rule = new RunTestOnContext();
 
   @Test
-  public void testCreateStoreAll() throws Exception {
-    SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!").put("salt", "salt").put("iv", "iv"));
-    assertNotNull(store);
-    assertTrue(store instanceof CookieSessionStore);
-  }
-
-  @Test
-  public void testCreateStoreNoIV() throws Exception {
-    SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!").put("salt", "salt"));
-    assertNotNull(store);
-    assertTrue(store instanceof CookieSessionStore);
-  }
-
-  @Test
-  public void testCreateStoreNoSalt() throws Exception {
+  public void testCreateStore() throws Exception {
     SessionStore store = SessionStore.create(rule.vertx(), new JsonObject().put("secret", "KeyboardCat!"));
     assertNotNull(store);
-    // salt is missing, default to LocalStore as we don't want to leak session data if config isn't complete
-    assertFalse(store instanceof CookieSessionStore);
+    assertTrue(store instanceof CookieSessionStore);
   }
 }

--- a/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/tests/CookieSessionHandlerTest.java
+++ b/vertx-web-session-stores/vertx-web-sstore-cookie/src/test/java/io/vertx/ext/web/sstore/cookie/tests/CookieSessionHandlerTest.java
@@ -35,18 +35,20 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    store = CookieSessionStore.create(vertx, "KeyboardCat!", Buffer.buffer("salt"));
+    store = CookieSessionStore.create(vertx, "KeyboardCat!");
   }
 
   @Test
   public void testGetSession() throws Exception {
     Session session = store.createSession(30_000);
-    String cookieValue = session.value();
+    String cookieId = session.id();
 
-    store.get(cookieValue).onComplete(get -> {
+    store.get(session.value()).onComplete(get -> {
       if (get.failed()) {
         fail(get.cause());
       } else {
+        assertNotNull(get.result());
+        assertEquals(cookieId, get.result().id());
         testComplete();
       }
     });
@@ -60,8 +62,16 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
     String cookieValue = session.value();
 
     store.get(cookieValue).onComplete(get -> {
-      assertEquals(cookieValue, get.result().value());
-      testComplete();
+      if (get.failed()) {
+        fail(get.cause());
+      } else {
+        assertNotNull(get.result());
+        // the session id must be the same
+        assertEquals(session.id(), get.result().id());
+        // the session value will not be the same as IV is random
+        assertFalse(cookieValue.equals(get.result().value()));
+        testComplete();
+      }
     });
 
     await();
@@ -75,18 +85,21 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
   @Override
   public void testSessionFixation() throws Exception {
 
+    final AtomicReference<String> session = new AtomicReference<>();
     final AtomicReference<String> sessionId = new AtomicReference<>();
 
     router.route().handler(SessionHandler.create(store));
     // call #0 anonymous a random id should be returned
     router.route("/0").handler(rc -> {
-      sessionId.set(rc.session().value());
+      sessionId.set(rc.session().id());
+      // store the session value to be used in the next call
+      session.set(rc.session().value());
       rc.response().end();
     });
     // call #1 fake auth security upgrade is done so session id must change
     router.route("/1").handler(rc -> {
       // previous id must match
-      assertEquals(sessionId.get(), rc.session().value());
+      assertEquals(sessionId.get(), rc.session().id());
       rc.session().regenerateId();
       rc.response().end();
     });
@@ -96,11 +109,34 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
       assertNotNull(setCookie);
     }, 200, "OK", null);
 
-    testRequest(HttpMethod.GET, "/1", req -> req.putHeader("cookie", "vertx-web.session=" + sessionId.get() + "; Path=/"), resp -> {
+    testRequest(HttpMethod.GET, "/1", req -> req.putHeader("cookie", "vertx-web.session=" + session.get() + "; Path=/"), resp -> {
       String setCookie = resp.headers().get("set-cookie");
       assertNotNull(setCookie);
-      assertFalse(("vertx-web.session=" + sessionId.get() + "; Path=/").equals(setCookie));
+      assertFalse(("vertx-web.session=" + session.get() + "; Path=/").equals(setCookie));
     }, 200, "OK", null);
+  }
+
+  @Test
+  public void testInterStoreCommunication() throws Exception {
+    CookieSessionStore store1 = CookieSessionStore.create(vertx, "KeyboardCat!");
+    CookieSessionStore store2 = CookieSessionStore.create(vertx, "KeyboardCat!");
+
+    Session session = store1.createSession(30_000);
+    String cookieValue = session.value();
+
+    store2.get(cookieValue).onComplete(get -> {
+      if (get.failed()) {
+        fail(get.cause());
+      } else {
+        assertNotNull(get.result());
+        // the session id must be the same
+        assertEquals(session.id(), get.result().id());
+        // the session value will not be the same as IV is random
+        assertFalse(cookieValue.equals(get.result().value()));
+        testComplete();
+      }
+    });
+    await();
   }
 
   /**
@@ -112,7 +148,53 @@ public class CookieSessionHandlerTest extends SessionHandlerTestBase {
   @Ignore
   @Override
   public void testSessionExpires() throws Exception {
-    super.testSessionExpires();
   }
 
+  /**
+   * We explicitly ignore this test as there is value on signing a encrypted payload.
+   *
+   * @throws Exception
+   */
+  @Test
+  @Ignore
+  @Override
+  public void testSessionCookieSigning() throws Exception {
+  }
+
+  @Test
+  @Override
+	public void testSessionFields() throws Exception {
+		router.route().handler(SessionHandler.create(store));
+		AtomicReference<String> rid = new AtomicReference<>();
+		AtomicReference<String> rsession = new AtomicReference<>();
+		router.route("/").handler(rc -> {
+			Session sess = rc.session();
+			assertNotNull(sess);
+			assertTrue(System.currentTimeMillis() - sess.lastAccessed() < 500);
+			assertNotNull(sess.id());
+			rid.set(sess.id());
+			assertFalse(sess.isDestroyed());
+			assertEquals(SessionHandler.DEFAULT_SESSION_TIMEOUT, sess.timeout());
+			rc.response().end();
+		});
+		testRequest(HttpMethod.GET, "/", null, resp -> {
+			String setCookie = resp.headers().get("set-cookie");
+			assertTrue(setCookie.startsWith(SessionHandler.DEFAULT_SESSION_COOKIE_NAME + "="));
+			int pos = setCookie.indexOf("; Path=" + SessionHandler.DEFAULT_SESSION_COOKIE_PATH);
+			rsession.set(setCookie.substring(18, pos));
+		}, 200, "OK", null);
+
+
+      store.get(rsession.get()).onComplete(get -> {
+        if (get.failed()) {
+          fail(get.cause());
+        } else {
+          assertNotNull(get.result());
+          assertEquals(rid.get(), get.result().id());
+          testComplete();
+        }
+      });
+
+      await();
+  }
 }


### PR DESCRIPTION
Motivation:

Fix #2745

This PR changes the underlying algorithm for security reasons and fixes the test that IVs are stored in the cookie so they can be decripted on other nodes, making the statement that sessions can survive a server crash correct.

Regarding the algorithm:


Feature | AES/CBC | AES/GCM
-- | -- | --
Confidentiality | Yes | Yes
Data Integrity | No (needs separate MAC) | Yes (built-in authentication tag)
Padding Requirement | Required (e.g., PKCS5Padding) | Not required
Performance | Slower (sequential encryption) | Faster (parallelizable)
IV Requirements | Unique IV required | Unique IV critical (security failure if reused)
Security Against | Vulnerable to padding oracle attacks | Resists tampering attacks
Authentication Tag | No | Yes (128-bit tag by default)
Recommended By NIST | No | Yes
Use Cases | Legacy systems, compatibility | Modern apps, TLS 1.3, cloud security

With this update we move away from `AES/CBC` to the recommended (by NIST) `AES/GCM`