### PR TITLE
Upgrade to GraphQL 24.1

### DIFF
--- a/vertx-web-graphql/pom.xml
+++ b/vertx-web-graphql/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>vertx-web-graphql</artifactId>
 
   <properties>
-    <graphql.java.version>23.1</graphql.java.version>
+    <graphql.java.version>24.1</graphql.java.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Backport of #2740

This is a breaking change that will be documented.

GraphQL-Java 23 is considered _poisoned_ by the team: https://github.com/graphql-java/graphql-java/releases/tag/v24.0

This is why we must upgrade to GraphQL-Java 24