### PR TITLE
Fix: The OPENID_SCOPES maintained by OAuth2AuthHandlerImpl should have offline_access instead of offline

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java
@@ -325,7 +325,7 @@ public class OAuth2AuthHandlerImpl extends HTTPAuthorizationHandler<OAuth2Auth> 
     OPENID_SCOPES.add("profile");
     OPENID_SCOPES.add("email");
     OPENID_SCOPES.add("phone");
-    OPENID_SCOPES.add("offline");
+    OPENID_SCOPES.add("offline_access");
   }
 
   /**


### PR DESCRIPTION
Motivation:

This is to fix the issue [2742](https://github.com/vert-x3/vertx-web/issues/2742). According to [OpenID spec](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes), there is no "offline" scope, it should be called "offline_access" instead.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
