### PR TITLE
Fix #2773: send secure cookie when localhost

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CookieStoreImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CookieStoreImpl.java
@@ -57,7 +57,7 @@ public class CookieStoreImpl implements CookieStore {
     TreeMap<String, Cookie> matches = new TreeMap<>();
 
     Consumer<Cookie> adder = c -> {
-      if (ssl != Boolean.TRUE && c.isSecure()) {
+      if (c.isSecure() && (!Boolean.TRUE.equals(ssl) && !"localhost".equals(domain))) {
         return;
       }
       if (c.path() != null && !cleanPath.equals(c.path())) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/SessionAwareWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/SessionAwareWebClientTest.java
@@ -542,6 +542,14 @@ public class SessionAwareWebClientTest {
     validate(context, store.get(true, "test.vertx.io", "/"),
         new String[] { "a", "b", "e" },
         new String[] { "1", "2", "5" });
+
+    c = new DefaultCookie("localhost-secure", "http-localhost");
+    c.setDomain("localhost");
+    c.setPath("/");
+    store.put(c);
+
+    validate(context, store.get(true, "localhost", "/"), new String[] { "a", "localhost-secure" }, new String[] { "1", "http-localhost" });
+    validate(context, store.get(false, "localhost", "/"), new String[] { "a", "localhost-secure" }, new String[] { "1", "http-localhost" });
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Issues: #2773 

if the cookie is secure, but a except on localhost.

[MDN Set-Cookie Secure](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#secure)
Indicates that the cookie is sent to the server only when a request is made with the https: scheme (except on localhost),

Conformance:
I have signed ECA, and linked github.