### PR TITLE
Add CharSequence overloads for putHeader methods in HttpRequest

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -32,6 +32,7 @@ import io.vertx.ext.web.multipart.MultipartForm;
 import io.vertx.uritemplate.Variables;
 import io.vertx.uritemplate.UriTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -184,6 +185,21 @@ public interface HttpRequest<T> {
   HttpRequest<T> putHeader(String name, String value);
 
   /**
+   * Configure the request to set a new HTTP header using {@link CharSequence}.
+   * <p>
+   * This is an overload of {@link #putHeader(String, String)} that accepts {@link CharSequence} parameters.
+   *
+   * @param name  the header name
+   * @param value the header value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default HttpRequest<T> putHeader(CharSequence name, CharSequence value) {
+    return putHeader(name.toString(), value.toString());
+  }
+
+  /**
    * Configure the request to set a new HTTP header with multiple values.
    *
    * @param name  the header name
@@ -193,6 +209,25 @@ public interface HttpRequest<T> {
   @Fluent
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   HttpRequest<T> putHeader(String name, Iterable<String> value);
+
+  /**
+   * Configure the request to set a new HTTP header with multiple values using {@link CharSequence}.
+   * <p>
+   * This is an overload of {@link #putHeader(String, Iterable)} that accepts {@link CharSequence} parameters.
+   *
+   * @param name   the header name
+   * @param values the header values
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default HttpRequest<T> putHeader(CharSequence name, Iterable<CharSequence> values) {
+    List<String> stringValues = new ArrayList<>();
+    for (CharSequence cs : values) {
+      stringValues.add(cs.toString());
+    }
+    return putHeader(name.toString(), stringValues);
+  }
 
   /**
    * @return The HTTP headers

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -242,8 +242,20 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   @Override
+  public HttpRequest<T> putHeader(CharSequence name, CharSequence value) {
+    headers().set(name, value);
+    return this;
+  }
+
+  @Override
   public HttpRequest<T> putHeader(String name, Iterable<String> value) {
     headers().set(name, value);
+    return this;
+  }
+
+  @Override
+  public HttpRequest<T> putHeader(CharSequence name, Iterable<CharSequence> values) {
+    headers().set(name, values);
     return this;
   }
 

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
@@ -521,7 +521,7 @@ public class WebClientTest extends WebClientTestBase {
     Future<HttpResponse<Buffer>> send(WebClient client) {
       return client
         .get("somepath")
-        .putHeader("bla", Arrays.asList("1", "2"))
+        .putHeader("bla", List.<String>of("1", "2"))
         .send();
     }
   }
@@ -629,7 +629,7 @@ public class WebClientTest extends WebClientTestBase {
     Future<HttpResponse<Buffer>> send(WebClient client) {
       MultiMap form = MultiMap.caseInsensitiveMultiMap();
       return client.post("/somepath")
-        .putHeader("bla", Arrays.asList("1", "2"))
+        .putHeader("bla", List.<String>of("1", "2"))
         .sendForm(form);
     }
   }
@@ -1669,7 +1669,7 @@ public class WebClientTest extends WebClientTestBase {
     @Override
     Future<HttpResponse<Buffer>> send(WebClient client) {
       HttpRequest<Buffer> builder = webClient.post("somepath");
-      builder.putHeader("bla", Arrays.asList("1", "2"));
+      builder.putHeader("bla", List.<String>of("1", "2"));
       builder.multipartMixed(multipartMixed);
       return builder.sendMultipartForm(form);
     }


### PR DESCRIPTION
## Motivation
As discussed in #2770, the `HttpServerResponse` interface in vertx-core already provides CharSequence overloads for header methods, but the web client's `HttpRequest` interface only accepts String parameters. This inconsistency means users need to convert CharSequence values (like Netty's `HttpHeaderNames` constants) to Strings unnecessarily.