### PR TITLE
fix #2787: RouterTest.testPauseResumeOnPipeline test fail

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -3310,7 +3310,7 @@ public class RouterTest extends WebTestBase {
         for (String req : reqs) {
           writer.print(req);
         }
-        writer.println();
+        writer.flush();
 
         InputStream input = socket.getInputStream();
         StringBuilder buffer = new StringBuilder();
@@ -3347,9 +3347,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 10\n" +
         "\n" +
         "/parse/ok\n",
-      test.apply(Arrays.asList(
-        "POST / HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+      test.apply(postReqs(
+        "/", "ABC",
+        "/parse/ok", "DEF"
       )));
 
     // Test:
@@ -3371,9 +3371,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 2\n" +
         "\n" +
         "/\n",
-      test.apply(Arrays.asList(
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+      test.apply(postReqs(
+        "/parse/ok", "DEF",
+        "/", "ABC"
       )));
 
     // Test:
@@ -3395,9 +3395,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 12\n" +
         "\n" +
         "/expect/end\n",
-      test.apply(Arrays.asList(
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+      test.apply(postReqs(
+        "/parse/ok", "DEF",
+        "/expect/end", "ABC"
       )));
 
     // Test:
@@ -3419,9 +3419,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 10\n" +
         "\n" +
         "/parse/ok\n",
-      test.apply(Arrays.asList(
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+      test.apply(postReqs(
+        "/expect/end", "ABC",
+        "/parse/ok", "DEF"
       )));
 
     // Test:
@@ -3443,9 +3443,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 12\n" +
         "\n" +
         "/expect/end\n",
-      test.apply(Arrays.asList(
-        "POST / HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+      test.apply(postReqs(
+        "/", "DEF",
+        "/expect/end", "ABC"
       )));
 
     // Test:
@@ -3467,9 +3467,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 2\n" +
         "\n" +
         "/\n",
-      test.apply(Arrays.asList(
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+      test.apply(postReqs(
+        "/expect/end", "ABC",
+        "/", "DEF"
       )));
 
     // Test:
@@ -3489,9 +3489,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 12\n" +
         "\n" +
         "/expect/end\n",
-      test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+      test.apply(postReqs(
+        "/not/found", "DEF",
+        "/expect/end", "ABC"
       )));
 
     // Test:
@@ -3512,9 +3512,9 @@ public class RouterTest extends WebTestBase {
         "content-length: 2\n" +
         "\n" +
         "/\n",
-      test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+      test.apply(postReqs(
+        "/not/found", "ABC",
+        "/", "DEF"
       )));
 
     // Test:
@@ -3535,10 +3535,19 @@ public class RouterTest extends WebTestBase {
         "content-length: 10\n" +
         "\n" +
         "/parse/ok\n",
-      test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+      test.apply(postReqs(
+        "/not/found", "ABC",
+        "/parse/ok", "DEF"
       )));
+  }
+
+  private static List<String> postReqs(String p1, String d1, String p2, String d2) {
+    return Arrays.asList(postReq(p1, false, d1), postReq(p2, true, d2));
+  }
+
+  private static String postReq(String path, boolean close, String body) {
+    return "POST " + path + " HTTP/1.1\r\nHost: localhost\r\nConnection: " + (close ? "close" : "keep-alive")
+      + "\r\nContent-Length: " + body.length() + "\r\n\r\n" + body;
   }
 
   @Test


### PR DESCRIPTION
fix #2787: enable strict HTTP parsing for CRLF delimiters

Adapt to Netty 4.2.5 strict rules for CRLF delimiters: https://github.com/netty/netty/pull/15611
