### PR TITLE
Fix testPauseResumeOnPipeline on Windows

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -3305,12 +3305,12 @@ public class RouterTest extends WebTestBase {
     Function<List<String>, String> test = reqs -> {
       try (Socket socket = new Socket("localhost", 8080)) {
         OutputStream output = socket.getOutputStream();
-        PrintWriter writer = new PrintWriter(output, true);
+        PrintWriter writer = new PrintWriter(output, false);
 
         for (String req : reqs) {
           writer.print(req);
         }
-        writer.println();
+        writer.flush();
 
         InputStream input = socket.getInputStream();
         StringBuilder buffer = new StringBuilder();
@@ -3348,8 +3348,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/parse/ok\n",
       test.apply(Arrays.asList(
-        "POST / HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+        "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nABC\r\n",
+        "POST /parse/ok HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nDEF\r\n"
       )));
 
     // Test:
@@ -3372,8 +3372,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/\n",
       test.apply(Arrays.asList(
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+        "POST /parse/ok HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nDEF\r\n",
+        "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nABC\r\n"
       )));
 
     // Test:
@@ -3396,8 +3396,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/expect/end\n",
       test.apply(Arrays.asList(
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+        "POST /parse/ok HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nDEF\r\n",
+        "POST /expect/end HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nABC\r\n"
       )));
 
     // Test:
@@ -3420,8 +3420,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/parse/ok\n",
       test.apply(Arrays.asList(
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+        "POST /expect/end HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nABC\r\n",
+        "POST /parse/ok HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nDEF\r\n"
       )));
 
     // Test:
@@ -3444,8 +3444,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/expect/end\n",
       test.apply(Arrays.asList(
-        "POST / HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+        "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nDEF\r\n",
+        "POST /expect/end HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nABC\r\n"
       )));
 
     // Test:
@@ -3468,8 +3468,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/\n",
       test.apply(Arrays.asList(
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+        "POST /expect/end HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nABC\r\n",
+        "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nDEF\r\n"
       )));
 
     // Test:
@@ -3490,8 +3490,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/expect/end\n",
       test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nDEF",
-        "POST /expect/end HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nABC"
+        "POST /not/found HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nDEF\r\n",
+        "POST /expect/end HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nABC\r\n"
       )));
 
     // Test:
@@ -3513,8 +3513,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/\n",
       test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST / HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+        "POST /not/found HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nABC\r\n",
+        "POST / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nDEF\r\n"
       )));
 
     // Test:
@@ -3536,8 +3536,8 @@ public class RouterTest extends WebTestBase {
         "\n" +
         "/parse/ok\n",
       test.apply(Arrays.asList(
-        "POST /not/found HTTP/1.1\nHost: localhost\nConnection: keep-alive\nContent-Length: 3\n\nABC",
-        "POST /parse/ok HTTP/1.1\nHost: localhost\nConnection: close\nContent-Length: 3\n\nDEF"
+        "POST /not/found HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nContent-Length: 3\r\n\r\nABC\r\n",
+        "POST /parse/ok HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Length: 3\r\n\r\nDEF\r\n"
       )));
   }
 


### PR DESCRIPTION
This test fails repeatedly on Windows (gets 400 BAD Request).

Fix it by sending CRLF (as mandated by the spec).

Latest Netty version applies a strict policy regarding line endings for security reasons.