### PR TITLE
fix: Ignoring test if docker is not properly configured.

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSProtocolTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSProtocolTest.java
@@ -43,6 +43,8 @@ import java.util.function.Predicate;
 import static io.vertx.core.buffer.Buffer.buffer;
 import static org.junit.Assert.assertTrue;
 
+import org.testcontainers.DockerClientFactory;
+
 /**
  * SockJS protocol tests
  *
@@ -53,8 +55,19 @@ public class SockJSProtocolTest {
   private static Vertx vertx;
   private static HttpServer server;
 
+    public static boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+            return false;
+        }
+    }
   @BeforeClass
   public static void before() throws Exception {
+    //Ignoring tests if docker is not configured
+    Assume.assumeTrue("Docker is not available.", isDockerAvailable());
     vertx = Vertx.vertx();
     server = vertx.createHttpServer();
     Router router = Router.router(vertx);
@@ -64,8 +77,11 @@ public class SockJSProtocolTest {
 
   @AfterClass
   public static void after() {
-    server.close();
-    vertx.close();
+    //Ignoring tests if docker is not configured
+    if (isDockerAvailable()) { 
+      server.close();
+      vertx.close();
+    }
   }
 
   private String runPython(String cmd, Predicate<String> exitTest) throws Exception {


### PR DESCRIPTION
Motivation:

The test is expecting docker to be present and properly configure. It currently fails if podman is there instead (permissions issue) so it should be ignored until a proper workaround is defined.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
