### PR TITLE
Upgrade pug4j from 2.0.6 to 2.3.1

### DIFF
--- a/vertx-template-engines/vertx-web-templ-pug/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-pug/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>de.neuland-bfi</groupId>
       <artifactId>pug4j</artifactId>
-      <version>2.0.6</version>
+      <version>2.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
@@ -39,12 +39,12 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>2.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.19.0</version>
     </dependency>
     <dependency>
       <!-- For dependency convergence with Kotlin -->


### PR DESCRIPTION
Obsoletes https://github.com/vert-x3/vertx-web/pull/2697

See https://github.com/neuland/pug4j/releases

The pug4j upgrade indirectly upgrades graalvm from 21.3.0 to 21.3.12 fixing multiple vulnerabilities:
https://security.snyk.io/package/maven/org.graalvm.sdk%3Agraal-sdk

Motivation:

Bump pug4j version to bump outdates and vulnerable graalvm version.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
