### PR TITLE
Implement WebClient HttpRequest#uri() for UriTemplate.

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -159,7 +159,8 @@ public interface HttpRequest<T> {
   HttpRequest<T> uri(String value);
 
   /**
-   * @return the request uri or {@code null} when none is set for absolute URI templates
+   * @return the request uri or {@code null} when none is set for absolute URI templates, when the request
+   * uri is a template, the template is extrapolated tolerating missing variables.
    */
   String uri();
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpRequestImpl.java
@@ -35,6 +35,7 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
+import io.vertx.uritemplate.ExpandOptions;
 import io.vertx.uritemplate.UriTemplate;
 import io.vertx.uritemplate.Variables;
 
@@ -47,6 +48,8 @@ import java.util.*;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class HttpRequestImpl<T> implements HttpRequest<T> {
+
+  private static final ExpandOptions INTERNAL_EXPAND_OPTIONS = new ExpandOptions().setAllowVariableMiss(true);
 
   private final WebClientBase client;
   private ProxyOptions proxyOptions;
@@ -205,7 +208,14 @@ public class HttpRequestImpl<T> implements HttpRequest<T> {
   }
 
   public String uri() {
-    return uri.toString();
+    if (uri == null) {
+      return null;
+    } else if (uri instanceof UriTemplate) {
+      UriTemplate uriTemplate = (UriTemplate) uri;
+      return uriTemplate.expandToString(templateParams(), INTERNAL_EXPAND_OPTIONS);
+    } else {
+      return uri.toString();
+    }
   }
 
   @Override

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/UriTemplateTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/UriTemplateTest.java
@@ -73,10 +73,16 @@ public class UriTemplateTest extends WebClientTestBase {
     Map<String, String> query = new HashMap<>();
     query.put("color", "red");
     query.put("currency", EURO_SYMBOL);
-    testRequest(client -> client.request(HttpMethod.GET, UriTemplate.of("/{action}?username={username}{&query*}"))
-      .setTemplateParam("action", "info")
-      .setTemplateParam("username", "vietj")
-      .setTemplateParam("query", query), req -> {
+    testRequest(client -> {
+      HttpRequest<Buffer> request = client.request(HttpMethod.GET, UriTemplate.of("/{action}?username={username}{&query*}"))
+        .setTemplateParam("action", "info")
+        .setTemplateParam("query", query);
+      // Missing variable is accepted
+      assertEquals("/info?username=&color=red&currency=%E2%82%AC", request.uri());
+      request.setTemplateParam("username", "vietj");
+      assertEquals("/info?username=vietj&color=red&currency=%E2%82%AC", request.uri());
+      return request;
+    }, req -> {
       assertEquals("/info", req.path());
       assertEquals("vietj", req.getParam("username"));
       assertEquals("red", req.getParam("color"));


### PR DESCRIPTION
Motivation:

HttpRequest#uri assumes that its uri implements correctly toString() when it is an instance of UriTemplate and therefore returns the Object implementation of toString().

Changes:

When HttpRequest implementation uri is an instance of UriTemplate, expand the template with the HttpRequest template params.
