### PR TITLE
feat: add package-info for vertx-web-openapi-router

### DIFF
--- a/vertx-web-openapi-router/src/main/java/io/vertx/ext/web/openapi/router/package-info.java
+++ b/vertx-web-openapi-router/src/main/java/io/vertx/ext/web/openapi/router/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "vertx-web-openapi-router", groupPackage = "io.vertx")
+package io.vertx.ext.web.openapi.router;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Motivation:

The new smallrye-vertx-mutiny-bindings generator relies on package-info to collect modules. We thus need to add it to `vertx-web-openapi-router` to properly generate mutiny bindings for it.
