### PR TITLE
Add a WebClient#request(RequestOptions) and deprecate overloaded versions of it.

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClient.java
@@ -287,11 +287,20 @@ public interface WebClient {
   HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, UriTemplate requestURI);
 
   /**
+   * Create an HTTP request to send to the server from the specified request {@code options}.
+   * @param options  the request options
+   * @return  an HTTP client request object
+   */
+  HttpRequest<Buffer> request(RequestOptions options);
+
+  /**
    * Create an HTTP request to send to the server at the specified host and port.
    * @param method  the HTTP method
    * @param options  the request options
    * @return  an HTTP client request object
+   * @deprecated instead use {@link #request(RequestOptions)}
    */
+  @Deprecated
   default HttpRequest<Buffer> request(HttpMethod method, RequestOptions options) {
     return request(method, null, options);
   }
@@ -303,7 +312,9 @@ public interface WebClient {
    * The request host header will still be created from the {@code options} parameter.
    * <p>
    * Use {@link SocketAddress#domainSocketAddress(String)} to connect to a unix domain socket server.
+   * @deprecated instead use {@link #request(RequestOptions)}
    */
+  @Deprecated
   HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, RequestOptions options);
 
   /**

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/WebClientBase.java
@@ -81,6 +81,16 @@ public class WebClientBase<C extends WebClientBase<C>> implements WebClientInter
 
   @Override
   public HttpRequest<Buffer> request(HttpMethod method, SocketAddress serverAddress, RequestOptions requestOptions) {
+    requestOptions = new RequestOptions(requestOptions);
+    requestOptions.setMethod(method);
+    if (serverAddress != null) {
+      requestOptions.setServer(serverAddress);
+    }
+    return request(requestOptions);
+  }
+
+  @Override
+  public HttpRequest<Buffer> request(RequestOptions requestOptions) {
     Integer port = requestOptions.getPort();
     if (port == null) {
       port = options.getDefaultPort();
@@ -89,7 +99,8 @@ public class WebClientBase<C extends WebClientBase<C>> implements WebClientInter
     if (host == null) {
       host = options.getDefaultHost();
     }
-    Address address = serverAddress != null ? serverAddress : requestOptions.getServer();
+    Address address = requestOptions.getServer();
+    HttpMethod method = requestOptions.getMethod();
     HttpRequestImpl<Buffer> request = new HttpRequestImpl<>(this, method, address, options.isSsl(), port, host,
       requestOptions.getURI(), BodyCodecImpl.BUFFER, options.isFollowRedirects(), buildProxyOptions(options), buildHeaders(options));
     request.ssl(requestOptions.isSsl());


### PR DESCRIPTION
Motivation:

`WebClient` provides:

- `request(HttpMethod method, RequestOptions options)`
- `request(HttpMethod method, SocketAddress serverAddress, RequestOptions options)`

In fact, it is possible now to specify those arguments in `RequestOptions`, so we only instead need `request(RequestOptions)`

Changes:

Deprecate

- `request(HttpMethod method, RequestOptions options)`
- `request(HttpMethod method, SocketAddress serverAddress, RequestOptions options)`

Add `WebClient#request(RequestOptions)`
