### PR TITLE
fix ChainAuthHandler.any() is interrupted by JWTAuthHandler's postAuthentication

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ChainAuthHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/ChainAuthHandlerImpl.java
@@ -9,28 +9,25 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.AuthenticationHandler;
 import io.vertx.ext.web.handler.ChainAuthHandler;
 import io.vertx.ext.web.handler.HttpException;
+import io.vertx.ext.web.impl.RoutingContextDecorator;
+import io.vertx.ext.web.impl.RoutingContextInternal;
+import io.vertx.ext.web.impl.UserContextInternal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class ChainAuthHandlerImpl extends AuthenticationHandlerImpl<AuthenticationProvider> implements ChainAuthHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ChainAuthHandler.class);
 
-  private static final String HANDLER_KEY_PREFIX = "__vertx.auth.chain.idx.";
-  private static final AtomicInteger HANDLER_KEY_SEQ = new AtomicInteger();
-
   private final List<AuthenticationHandlerInternal> handlers = new ArrayList<>();
   private final boolean all;
-  private final String chainAuthHandlerKey;
 
   private int willRedirect = -1;
 
   public ChainAuthHandlerImpl(boolean all) {
     super(null);
     this.all = all;
-    this.chainAuthHandlerKey = HANDLER_KEY_PREFIX + HANDLER_KEY_SEQ.getAndIncrement();
   }
 
   @Override
@@ -86,36 +83,85 @@ public class ChainAuthHandlerImpl extends AuthenticationHandlerImpl<Authenticati
         if (all) {
           // all handlers need to be valid, a single failure is enough to
           // abort the execution of the chain
+          handler.complete(null, err);
         } else {
           // any handler can be valid, if the response is within a validation error
           // the chain is allowed to proceed, otherwise we must abort.
-          if (err instanceof HttpException) {
-            final HttpException ex = (HttpException) err;
-            switch (ex.getStatusCode()) {
-              case 302:
-              case 400:
-              case 401:
-              case 403:
-                // try again with next provider since we know what kind of error it is
-                iterate(idx + 1, ctx, null, ex, handler);
-                return;
-            }
+          if (isRecoverable(err)) {
+            // try again with next provider since we know what kind of error it is
+            iterate(idx + 1, ctx, null, err, handler);
+            return;
           }
           // the error is not a validation exception, so we abort regardless
+          handler.complete(null, err);
         }
-        handler.complete(null, err);
       })
       .onSuccess(user -> {
-      if (all) {
-        // this handler is succeeded, but as we need all, we must continue with
-        // the iteration of the remaining handlers.
-        iterate(idx + 1, ctx, user, null, handler);
-      } else {
-        // a single success is enough to signal the end of the validation
-        ctx.put(chainAuthHandlerKey, idx);
+        if (all) {
+          // this handler is succeeded, but as we need all, we must continue with
+          // the iteration of the remaining handlers.
+          iterate(idx + 1, ctx, user, null, handler);
+          return;
+        }
+        // `any` mode: a successful authenticate is not enough on its own. The handler's
+        // postAuthentication step (e.g. JWT scope check) may still reject the request.
+        // Run it now against a context wrapper that captures next()/fail(...) so we can
+        // continue iterating to the next handler instead of stopping at the first one
+        // that authenticates. See issue #2691.
+        runPostAuthentication(idx, ctx, authHandler, user, handler);
+      });
+  }
+
+  private void runPostAuthentication(final int idx, final RoutingContext ctx,
+                                     final AuthenticationHandlerInternal authHandler,
+                                     final User user, final Completable<User> handler) {
+    // postAuthentication implementations rely on ctx.user() to return the authenticated
+    // user. The framework normally sets it after authenticate() succeeds; do it here so
+    // the inner handler observes the same state.
+    ((UserContextInternal) ctx.userContext()).setUser(user);
+
+    final PostAuthenticationCapture wrapper = new PostAuthenticationCapture(ctx);
+    try {
+      authHandler.postAuthentication(wrapper);
+    } catch (RuntimeException e) {
+      wrapper.completion.tryFail(e);
+    }
+    wrapper.completion.future().onComplete(o -> {
+      if (o.succeeded() && Boolean.TRUE.equals(o.result())) {
+        // postAuthentication called next() -> this handler fully accepts the request
         handler.complete(user, null);
+        return;
+      }
+      // postAuthentication called fail(...) (or threw): treat it like an authenticate
+      // failure and try the next handler in the chain when the status is recoverable.
+      final int sc = wrapper.statusCode;
+      final Throwable f = o.failed() ? o.cause() : wrapper.failure;
+      final Throwable err = f != null ? f : new HttpException(sc != 0 ? sc : 403);
+      if (isRecoverable(err) || isRecoverableStatus(sc)) {
+        iterate(idx + 1, ctx, null, err, handler);
+      } else {
+        handler.complete(null, err);
       }
     });
+  }
+
+  private static boolean isRecoverable(Throwable err) {
+    if (err instanceof HttpException) {
+      return isRecoverableStatus(((HttpException) err).getStatusCode());
+    }
+    return false;
+  }
+
+  private static boolean isRecoverableStatus(int sc) {
+    switch (sc) {
+      case 302:
+      case 400:
+      case 401:
+      case 403:
+        return true;
+      default:
+        return false;
+    }
   }
 
   @Override
@@ -136,11 +182,49 @@ public class ChainAuthHandlerImpl extends AuthenticationHandlerImpl<Authenticati
 
   @Override
   public void postAuthentication(RoutingContext ctx) {
-    Integer idx;
-    if (all || (idx = ctx.get(chainAuthHandlerKey)) == null) {
-      ctx.next();
-    } else {
-      handlers.get(idx).postAuthentication(ctx);
+    // In `any` mode the matched handler's postAuthentication already ran (and succeeded)
+    // during authenticate(). In `all` mode there is no per-handler postAuthentication
+    // chained here either. So we just continue with the router pipeline.
+    ctx.next();
+  }
+
+  /**
+   * Decorator that intercepts {@link RoutingContext#next()} and {@link RoutingContext#fail}
+   * calls performed by an inner {@code postAuthentication} so the chain can decide whether
+   * to advance to the next handler instead of immediately failing the request.
+   */
+  private static final class PostAuthenticationCapture extends RoutingContextDecorator {
+
+    final Promise<Boolean> completion = Promise.promise();
+    int statusCode = 0;
+    Throwable failure;
+
+    PostAuthenticationCapture(RoutingContext ctx) {
+      super(ctx.currentRoute(), (RoutingContextInternal) ctx);
+    }
+
+    @Override
+    public void next() {
+      completion.tryComplete(Boolean.TRUE);
+    }
+
+    @Override
+    public void fail(int statusCode) {
+      this.statusCode = statusCode;
+      completion.tryComplete(Boolean.FALSE);
+    }
+
+    @Override
+    public void fail(Throwable throwable) {
+      this.failure = throwable;
+      completion.tryComplete(Boolean.FALSE);
+    }
+
+    @Override
+    public void fail(int statusCode, Throwable throwable) {
+      this.statusCode = statusCode;
+      this.failure = throwable;
+      completion.tryComplete(Boolean.FALSE);
     }
   }
 }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/ChainAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/ChainAuthHandlerTest.java
@@ -22,7 +22,6 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class ChainAuthHandlerTest extends WebTestBase {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/ChainAuthHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/ChainAuthHandlerTest.java
@@ -5,8 +5,13 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.htdigest.HtdigestAuth;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.auth.properties.PropertyFileAuthentication;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.handler.*;
 import io.vertx.ext.web.tests.WebTestBase;
@@ -17,6 +22,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class ChainAuthHandlerTest extends WebTestBase {
@@ -135,6 +141,40 @@ public class ChainAuthHandlerTest extends WebTestBase {
     assertNotNull(setCookie);
     // client will be redirected
     assertTrue(respHeaders.contains(HttpHeaders.LOCATION, "/welcome", false));
+  }
+
+  @Test
+  public void testWithMultipleJWTAuthHandlers() throws Exception {
+    // Reproducer for https://github.com/vert-x3/vertx-web/issues/2691
+    router.clear();
+
+    JWTAuth jwtAuth = JWTAuth.create(vertx, new JWTAuthOptions()
+      .setKeyStore(new KeyStoreOptions()
+        .setType("jceks")
+        .setPath("keystore.jceks")
+        .setPassword("secret")));
+
+    chain = ChainAuthHandler.any()
+      .add(JWTAuthHandler.create(jwtAuth).withScope("users:read"))
+      .add(JWTAuthHandler.create(jwtAuth).withScope("users:all"));
+    router.route()
+      .handler(chain)
+      .handler(RoutingContext::end);
+
+    JsonObject payloadA = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", "users:read");
+    testRequest(webClient.get("/").putHeader("Authorization", "Bearer " + jwtAuth.generateToken(payloadA)), 200, "OK");
+
+    JsonObject payloadB = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", "users:read users:all");
+    testRequest(webClient.get("/").putHeader("Authorization", "Bearer " + jwtAuth.generateToken(payloadB)), 200, "OK");
+
+    JsonObject payloadC = new JsonObject()
+      .put("sub", "Paulo")
+      .put("scope", "users:all");
+    testRequest(webClient.get("/").putHeader("Authorization", "Bearer " + jwtAuth.generateToken(payloadC)), 200, "OK");
   }
 
 }


### PR DESCRIPTION
### Motivation:

Solves #2691.

### Problem Brief:

In ChainAuthHandler.any(), the chain commits to the first handler whose authenticate() succeeds, even if that handler's postAuthentication() later rejects the request. This breaks setups like two JWTAuthHandlers with different required scopes:

```
ChainAuthHandler.any()
  .add(JWTAuthHandler.create(jwt).withScope("users:read"))
  .add(JWTAuthHandler.create(jwt).withScope("users:all"));
```

A token carrying only users:all authenticates against the first handler, then gets rejected with 403 for the scope mismatch — the second handler is never tried, even though it would have accepted the request.

**PR Details:**

Instead of calling postAuthentication methods for authHandlers in the chain after the authentication succeeds, it now iterates authHandlers in authenticate and also calls postAuthentication for each of them in case of one might fail the context on postAuthentication. Implemented a context wrapper so we can catch the ctx.fail() calls and continue with the next authHandler in the chain instead of failing fast without trying the next in line.