### PR TITLE
Add documentation on how to access the openapi operation from handlers

### DIFF
--- a/vertx-web-openapi-router/src/main/asciidoc/index.adoc
+++ b/vertx-web-openapi-router/src/main/asciidoc/index.adoc
@@ -49,6 +49,13 @@ These routes can then be customized by adding custom handlers or enable / disabl
 {@link examples.openapi.router.RouterExamples#modifyRoutes}
 ----
 
+The operation model is stored in the route metadata and be retrieved from the RoutingContext.
+
+[source,$lang]
+----
+{@link examples.openapi.router.RouterExamples#accessOpenAPIModel}
+----
+
 After a successful validation of the incoming request, the validated parameters and request body are stored in the RoutingContext and can be accessed inside your custom handlers.
 
 [source,$lang]

--- a/vertx-web-openapi-router/src/main/java/examples/openapi/router/RouterExamples.java
+++ b/vertx-web-openapi-router/src/main/java/examples/openapi/router/RouterExamples.java
@@ -15,6 +15,7 @@ import io.vertx.ext.web.openapi.router.RequestExtractor;
 import io.vertx.ext.web.openapi.router.RouterBuilder;
 import io.vertx.openapi.contract.OpenAPIContract;
 import io.vertx.openapi.contract.Operation;
+import io.vertx.openapi.contract.RequestBody;
 import io.vertx.openapi.validation.ValidatedRequest;
 
 public class RouterExamples {
@@ -128,5 +129,19 @@ public class RouterExamples {
     // room for mistakes. While the example is using "OpenIDConnectAuth", you can
     // use any of the OAuth2 providers that may reduce even further the
     // configuration needs.
+  }
+
+  void accessOpenAPIModel(Vertx vertx, RouterBuilder routerBuilder) {
+    OpenAPIRoute putPetRoute = routerBuilder.getRoute("putPet");
+
+    putPetRoute.addHandler(routingContext -> {
+      Operation operation = (Operation) routingContext
+        .currentRoute()
+        .metadata()
+        .get(RouterBuilder.KEY_META_DATA_OPERATION);
+      RequestBody requestBody = operation.getRequestBody();
+      // ..
+      // ..
+    });
   }
 }


### PR DESCRIPTION
Motivation:

Although it is implemented to access the openapi operation from the route handlers, it is not documented yet. This request adds a short section to the docs. This change was requested/endorsed by Julien in the discord open-api channel.

Conformance:

- [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
- [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

