### PR TITLE
WebClient: exception in doSendRequest does not fail the returned future

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -532,7 +532,11 @@ public class HttpContext<T> {
         fail(ar.cause());
       }
     });
-    doSendRequest(clientRequest);
+    try {
+      doSendRequest(clientRequest);
+    } catch (Exception e) {
+      fail(e);
+    }
   }
 
   private void doSendRequest(HttpClientRequest request) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HttpContextTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HttpContextTest.java
@@ -1,17 +1,15 @@
 package io.vertx.ext.web.client.tests;
 
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.impl.ClientPhase;
 import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.WebClientInternal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Proxy;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -62,47 +60,24 @@ public class HttpContextTest extends WebClientTestBase {
 
   @Test
   public void testSynchronousExceptionInDoSendRequestFailsTheContext() {
-    RuntimeException boom = new RuntimeException("synchronous exception in doSendRequest");
-    Promise<HttpClientResponse> responsePromise = Promise.promise();
+    server.requestHandler(req -> req.response().end());
+    startServer();
+
     AtomicReference<Throwable> capturedFailure = new AtomicReference<>();
 
-    HttpClientRequest fakeRequest = mockHttpClientRequest(responsePromise, boom);
-
     webClientInternal.addInterceptor(ctx -> {
-      switch (ctx.phase()) {
-        case CREATE_REQUEST:
-          ctx.sendRequest(fakeRequest);
-          break;
-        case FAILURE:
-          capturedFailure.set(ctx.failure());
-          ctx.next();
-          break;
-        default:
-          ctx.next();
-          break;
+      if (Objects.requireNonNull(ctx.phase()) == ClientPhase.FAILURE) {
+        capturedFailure.set(ctx.failure());
+        ctx.next();
+      } else {
+        ctx.next();
       }
     });
 
-    RuntimeException e = assertThrows(RuntimeException.class, () -> webClientInternal.get("/somepath").send().await());
-    assertSame(boom, e);
-    assertSame(boom, capturedFailure.get(), "The exception should have been captured in the FAILURE phase.");
+    RuntimeException err = assertThrows(RuntimeException.class, () -> webClientInternal.get("/some illegal path").send().await());
+    assertNotNull(capturedFailure.get(), "The exception should have been captured in the FAILURE phase.");
+    assertSame(err, capturedFailure.get());
 
-  }
-
-  private static HttpClientRequest mockHttpClientRequest(Promise<HttpClientResponse> responsePromise, RuntimeException boom) {
-    return (HttpClientRequest) Proxy.newProxyInstance(
-            HttpClientRequest.class.getClassLoader(),
-            new Class[]{HttpClientRequest.class},
-            (proxy, method, args) -> {
-              switch (method.getName()) {
-                case "response":
-                  return responsePromise.future();
-                case "send":
-                  throw boom;
-                default:
-                  return null;
-              }
-            });
   }
 
 }

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HttpContextTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HttpContextTest.java
@@ -1,13 +1,17 @@
 package io.vertx.ext.web.client.tests;
 
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.impl.WebClientInternal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Proxy;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -55,4 +59,50 @@ public class HttpContextTest extends WebClientTestBase {
       assertSame(cause, err);
     }
   }
+
+  @Test
+  public void testSynchronousExceptionInDoSendRequestFailsTheContext() {
+    RuntimeException boom = new RuntimeException("synchronous exception in doSendRequest");
+    Promise<HttpClientResponse> responsePromise = Promise.promise();
+    AtomicReference<Throwable> capturedFailure = new AtomicReference<>();
+
+    HttpClientRequest fakeRequest = mockHttpClientRequest(responsePromise, boom);
+
+    webClientInternal.addInterceptor(ctx -> {
+      switch (ctx.phase()) {
+        case CREATE_REQUEST:
+          ctx.sendRequest(fakeRequest);
+          break;
+        case FAILURE:
+          capturedFailure.set(ctx.failure());
+          ctx.next();
+          break;
+        default:
+          ctx.next();
+          break;
+      }
+    });
+
+    RuntimeException e = assertThrows(RuntimeException.class, () -> webClientInternal.get("/somepath").send().await());
+    assertSame(boom, e);
+    assertSame(boom, capturedFailure.get(), "The exception should have been captured in the FAILURE phase.");
+
+  }
+
+  private static HttpClientRequest mockHttpClientRequest(Promise<HttpClientResponse> responsePromise, RuntimeException boom) {
+    return (HttpClientRequest) Proxy.newProxyInstance(
+            HttpClientRequest.class.getClassLoader(),
+            new Class[]{HttpClientRequest.class},
+            (proxy, method, args) -> {
+              switch (method.getName()) {
+                case "response":
+                  return responsePromise.future();
+                case "send":
+                  throw boom;
+                default:
+                  return null;
+              }
+            });
+  }
+
 }


### PR DESCRIPTION
When HttpClientRequest.send() throws a synchronous exception (e.g. IllegalArgumentException
from Netty's HttpUtil.validateRequestLineTokens() due to illegal characters in the URI),
the exception escapes to the Netty I/O thread and is never propagated to the Future returned
by the WebClient request. The future remains pending indefinitely instead of being failed.
