### PR TITLE
Support escaped colons in route paths

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/Route.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Route.java
@@ -66,6 +66,8 @@ public interface Route {
   /**
    * Set the path prefix for this route. If set then this route will only match request URI paths which start with this
    * path prefix. Only a single path or path regex can be set for a route.
+   * <p>
+   * In non-regex paths, escape a literal colon as {@code \:}, for example {@code /foo/\:bar}.
    *
    * @param path the path prefix
    * @return a reference to this, so the API can be used fluently

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -283,13 +283,14 @@ public class RouteImpl implements Route {
   }
 
   private synchronized void setPath(String path) {
+    path = path.replace("\\:", ESCAPED_COLON_SENTINEL);
     // See if the path is a wildcard "*" is present - If so we need to configure this path to be not exact
     if (path.charAt(path.length() - 1) != '*') {
       state = state.setExactPath(true);
-      state = state.setPath(path);
+      state = state.setPath(path.replace(ESCAPED_COLON_SENTINEL, ":"));
     } else {
       state = state.setExactPath(false);
-      state = state.setPath(path.substring(0, path.length() - 1));
+      state = state.setPath(path.substring(0, path.length() - 1).replace(ESCAPED_COLON_SENTINEL, ":"));
     }
 
     state = state.setPathEndsWithSlash(state.getPath().endsWith("/"));
@@ -335,6 +336,7 @@ public class RouteImpl implements Route {
 
   // intersection of regex chars and https://tools.ietf.org/html/rfc3986#section-3.3
   private static final Pattern RE_OPERATORS_NO_STAR = Pattern.compile("([\\(\\)\\$\\+\\.])");
+  private static final String ESCAPED_COLON_SENTINEL = "\u0000";
 
   private synchronized int createPatternRegex(String path) {
     // escape path from any regex special chars
@@ -366,7 +368,7 @@ public class RouteImpl implements Route {
     if (state.isExactPath() && !state.isPathEndsWithSlash()) {
       sb.append("/?");
     }
-    path = sb.toString();
+    path = sb.toString().replace(ESCAPED_COLON_SENTINEL, ":");
 
     state = state.setGroups(groups);
     state = state.setPattern(Pattern.compile(path));

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -808,6 +808,23 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testEscapedColonInPath() throws Exception {
+    router.route("/foo/\\:literal").handler(rc -> rc.response().end("literal"));
+    testRequest(HttpMethod.GET, "/foo/:literal", 200, "OK", "literal");
+    testRequest(HttpMethod.GET, "/foo/not-literal", 404, "Not Found");
+  }
+
+  @Test
+  public void testEscapedColonInPathWithParam() throws Exception {
+    router.route("/foo/\\:literal/:id").handler(rc -> {
+      assertEquals("123", rc.pathParam("id"));
+      rc.response().end(rc.pathParam("id"));
+    });
+    testRequest(HttpMethod.GET, "/foo/:literal/123", 200, "OK", "123");
+    testRequest(HttpMethod.GET, "/foo/not-literal/123", 404, "Not Found");
+  }
+
+  @Test
   public void testPattern1WithMethod() throws Exception {
     router.route(HttpMethod.GET, "/:abc").handler(rc -> rc.response().setStatusMessage(rc.request().params().get("abc")).end());
     testPattern("/tim", "tim");


### PR DESCRIPTION
Motivation:

Fixes #2782.
In non-regex route paths, `:` starts a path parameter. That means matching a literal colon currently requires using a regex route.
This change lets non-regex routes use `\:` to represent a literal colon. For example, `/foo/\:literal/:id` matches `/foo/:literal/123` and captures only the `id` parameter.

Regex routes are unchanged.

Conformance:
I have signed the Eclipse Contributor Agreement.
