### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-freemarker/src/test/java/io/vertx/ext/web/templ/FreeMarkerTemplateTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/vertx-template-engines/vertx-web-templ-httl/src/test/java/io/vertx/ext/web/templ/HTTLTemplateEngineTest.java
+++ b/vertx-template-engines/vertx-web-templ-httl/src/test/java/io/vertx/ext/web/templ/HTTLTemplateEngineTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/mvel/tests/MVELTemplateNoCacheTest.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/mvel/tests/MVELTemplateNoCacheTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import io.vertx.ext.web.templ.mvel.MVELTemplateEngine;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/mvel/tests/MVELTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-mvel/src/test/java/io/vertx/ext/web/templ/mvel/tests/MVELTemplateTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
+++ b/vertx-template-engines/vertx-web-templ-pebble/src/test/java/io/vertx/ext/web/templ/PebbleTemplateTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import io.vertx.ext.web.templ.pebble.PebbleTemplateEngine;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/generator/param_extraction/HandlerParamsTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/generator/param_extraction/HandlerParamsTest.java
@@ -13,7 +13,6 @@ import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.ext.web.api.service.ServiceResponse;
 import io.vertx.ext.web.validation.impl.RequestParameterImpl;
 import io.vertx.ext.web.validation.impl.RequestParametersImpl;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTest;
 import io.vertx.serviceproxy.ServiceBinder;
 import org.junit.jupiter.api.AfterEach;

--- a/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/impl/OpenAPIRouterHandlerImplTest.java
+++ b/vertx-web-api-service/src/test/java/io/vertx/ext/web/api/service/tests/impl/OpenAPIRouterHandlerImplTest.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.ext.web.api.service.ServiceResponse.completedWithJson;
 

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/CachingWebClientConfig.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/CachingWebClientConfig.java
@@ -17,12 +17,8 @@ package io.vertx.ext.web.client;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
-import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.uritemplate.ExpandOptions;
 
 import java.time.Duration;
@@ -30,7 +26,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author <a href="mailto:craigday3@gmail.com">Craig Day</a>

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/HttpRequest.java
@@ -20,7 +20,6 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.streams.ReadStream;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientConfig.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/WebClientConfig.java
@@ -19,9 +19,7 @@ package io.vertx.ext.web.client;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.http.*;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.*;
-import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.uritemplate.ExpandOptions;
 
 import java.time.Duration;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CachingWebClientImpl.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/CachingWebClientImpl.java
@@ -16,7 +16,6 @@
 package io.vertx.ext.web.client.impl;
 
 import io.vertx.ext.web.client.CachingWebClientConfig;
-import io.vertx.ext.web.client.CachingWebClientOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.impl.cache.CacheInterceptor;
 import io.vertx.ext.web.client.spi.CacheStore;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -27,7 +27,6 @@ import io.vertx.core.streams.Pipe;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClientConfig;
-import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.spi.CacheStore;
 import io.vertx.ext.web.codec.spi.BodyStream;
 import io.vertx.ext.web.multipart.MultipartForm;

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheInterceptor.java
@@ -22,7 +22,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.ext.web.client.CachingWebClientConfig;
-import io.vertx.ext.web.client.CachingWebClientOptions;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.impl.HttpContext;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HandlerExceptionTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/HandlerExceptionTest.java
@@ -4,12 +4,10 @@ import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/JsonStreamTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/JsonStreamTest.java
@@ -9,7 +9,6 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTest;
-import io.vertx.test.core.VertxRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/SimpleWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/SimpleWebClientTest.java
@@ -8,7 +8,6 @@ import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.impl.WebClientInternal;
 import io.vertx.test.fakeresolver.FakeAddress;
 import io.vertx.test.fakeresolver.FakeAddressResolver;
 import org.assertj.core.api.Assertions;

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/VerticleUndeployTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/VerticleUndeployTest.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import static io.vertx.core.Future.all;
 import static io.vertx.core.Future.await;
 import static java.util.concurrent.ThreadLocalRandom.current;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class VerticleUndeployTest {
 

--- a/vertx-web-common/src/main/java/io/vertx/ext/web/codec/impl/BodyCodecImpl.java
+++ b/vertx-web-common/src/main/java/io/vertx/ext/web/codec/impl/BodyCodecImpl.java
@@ -15,7 +15,6 @@
  */
 package io.vertx.ext.web.codec.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;

--- a/vertx-web-openapi-router/src/main/java/io/vertx/ext/web/openapi/router/Security.java
+++ b/vertx-web-openapi-router/src/main/java/io/vertx/ext/web/openapi/router/Security.java
@@ -17,7 +17,6 @@ package io.vertx.ext.web.openapi.router;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.*;
 import io.vertx.openapi.contract.SecurityScheme;
 

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/PathParameterTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/PathParameterTest.java
@@ -12,17 +12,13 @@
 
 package io.vertx.router.test.e2e;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpResponseExpectation;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.openapi.router.RouterBuilder;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.openapi.validation.ValidatedRequest;
 import io.vertx.router.test.ResourceHelper;
 import io.vertx.router.test.base.RouterBuilderTestBase;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -31,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.core.http.HttpMethod.GET;
-import static io.vertx.core.http.HttpMethod.POST;
 
 class PathParameterTest extends RouterBuilderTestBase {
 

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RootPathTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RootPathTest.java
@@ -12,23 +12,19 @@
 
 package io.vertx.router.test.e2e;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpResponseExpectation;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.openapi.router.RouterBuilder;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.openapi.validation.ValidatedRequest;
 import io.vertx.router.test.ResourceHelper;
 import io.vertx.router.test.base.RouterBuilderTestBase;
-import io.vertx.test.core.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.core.http.HttpMethod.POST;
 
 class RootPathTest extends RouterBuilderTestBase {

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityAndAuthZTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityAndAuthZTest.java
@@ -21,14 +21,12 @@ import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.APIKeyHandler;
 import io.vertx.ext.web.handler.AuthorizationHandler;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.router.test.ResourceHelper;
 import io.vertx.router.test.base.RouterBuilderTestBase;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.core.http.HttpMethod.GET;
 
 class RouterBuilderSecurityAndAuthZTest extends RouterBuilderTestBase {

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityScopesTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityScopesTest.java
@@ -21,7 +21,6 @@ import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.web.handler.JWTAuthHandler;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.router.test.ResourceHelper;
 import io.vertx.router.test.base.RouterBuilderTestBase;
@@ -31,7 +30,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.truth.Truth.assertThat;
 import static io.vertx.core.http.HttpMethod.GET;
 
 class RouterBuilderSecurityScopesTest extends RouterBuilderTestBase {

--- a/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityTest.java
+++ b/vertx-web-openapi-router/src/test/java/io/vertx/router/test/e2e/RouterBuilderSecurityTest.java
@@ -24,7 +24,6 @@ import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.APIKeyHandler;
 import io.vertx.ext.web.handler.OAuth2AuthHandler;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.router.test.ResourceHelper;
 import io.vertx.router.test.base.RouterBuilderTestBase;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/OtpAuthHandler.java
@@ -21,7 +21,6 @@ import io.vertx.ext.auth.otp.OtpKeyGenerator;
 import io.vertx.ext.auth.otp.hotp.HotpAuth;
 import io.vertx.ext.auth.otp.totp.TotpAuth;
 import io.vertx.ext.web.Route;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.UserContext;
 import io.vertx.ext.web.handler.impl.HotpAuthHandlerImpl;
 import io.vertx.ext.web.handler.impl.TotpAuthHandlerImpl;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -16,7 +16,6 @@
 package io.vertx.ext.web.handler.impl;
 
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.LanguageHeader;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.impl.Utils;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventSourceTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/EventSourceTransport.java
@@ -32,7 +32,6 @@
 
 package io.vertx.ext.web.handler.sockjs.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/HtmlFileTransport.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/HtmlFileTransport.java
@@ -32,7 +32,6 @@
 
 package io.vertx.ext.web.handler.sockjs.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/TransportListener.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/sockjs/impl/TransportListener.java
@@ -32,9 +32,7 @@
 
 package io.vertx.ext.web.handler.sockjs.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/ServerWebSocketWrapper.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/ServerWebSocketWrapper.java
@@ -16,7 +16,6 @@ import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class ServerWebSocketWrapper implements ServerWebSocket {
   private final ServerWebSocket delegate;

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSSessionTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSSessionTest.java
@@ -17,7 +17,6 @@ package io.vertx.ext.web.tests.handler.sockjs;
 
 import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.