### PR TITLE
TemplateHandler does not normalize Windows backslashes for non-wildcard routes

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -16,12 +16,12 @@
 package io.vertx.ext.web.handler.impl;
 
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.json.JsonObject;
+import io.vertx.core.internal.net.RFC3986;
 import io.vertx.ext.web.LanguageHeader;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.template.TemplateEngine;
 import io.vertx.ext.web.handler.TemplateHandler;
 import io.vertx.ext.web.impl.Utils;
-import io.vertx.ext.web.common.template.TemplateEngine;
-import io.vertx.ext.web.RoutingContext;
 
 import java.util.Locale;
 
@@ -45,13 +45,16 @@ public class TemplateHandlerImpl implements TemplateHandler {
 
   @Override
   public void handle(RoutingContext context) {
-    String file = Utils.pathOffset(context.normalizedPath(), context);
+    String uriDecodedPath = RFC3986.decodeURIComponent(context.normalizedPath(), false);
+    String path = RFC3986.removeDotSegments(uriDecodedPath.replace('\\', '/'));
+
+    String file = Utils.pathOffset(path, context);
     if (file.endsWith("/") && null != indexTemplate) {
       file += indexTemplate;
     }
     // files are always normalized (start with /)
     // however if there's no base strip / to avoid making the path absolute
-    if (templateDirectory == null || "".equals(templateDirectory)) {
+    if (templateDirectory == null || templateDirectory.isEmpty()) {
       // strip the leading slash from the filename
       file = file.substring(1);
     }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/templ/TemplateHandlerWindowsPathTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/templ/TemplateHandlerWindowsPathTest.java
@@ -1,0 +1,61 @@
+package io.vertx.ext.web.tests.templ;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import io.vertx.ext.web.handler.TemplateHandler;
+import io.vertx.ext.web.tests.WebTestBase;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class TemplateHandlerWindowsPathTest extends WebTestBase {
+
+  @Test
+  public void testWildcardRoute() throws Exception {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    router.route("/templates/*").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/templates/..\\outside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  @Test
+  public void testRegexRoute() throws Exception {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    router.getWithRegex(".+\\.html").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/..\\outside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  @Test
+  public void testPathParamRoute() throws Exception {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    router.get("/templates/:name").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/templates/..\\outside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  @Test
+  public void testPathTraversalAttemptWithBackslash() throws Exception {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    router.getWithRegex(".+\\.html").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/..\\..\\outside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  private static class RecordingTemplateFileNameEngine implements TemplateEngine {
+
+    String lastTemplateFileName;
+
+    @Override
+    public Future<Buffer> render(Map<String, Object> context, String templateFileName) {
+      this.lastTemplateFileName = templateFileName;
+      return Future.succeededFuture(Buffer.buffer());
+    }
+
+    @Override
+    public void clearCache() {
+    }
+  }
+}


### PR DESCRIPTION
Backport #2895