### PR TITLE
Run GraphiQL smoke test only when building for 5.1

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -14,3 +14,4 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
+      graphiql-tests: true

--- a/.github/workflows/ci-matrix-5.x.yml
+++ b/.github/workflows/ci-matrix-5.x.yml
@@ -5,6 +5,9 @@ on:
       branch:
         required: true
         type: string
+      graphiql-tests:
+        default: false
+        type: boolean
 jobs:
   CI:
     strategy:
@@ -27,6 +30,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       jdk: 11
+      graphiql-tests: ${{ inputs.graphiql-tests }}
     secrets: inherit
   Deploy:
     if: ${{ github.repository_owner == 'vert-x3' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -8,6 +8,9 @@ on:
       jdk:
         default: 8
         type: string
+      graphiql-tests:
+        default: false
+        type: boolean
 jobs:
   GraphQLWS-Tests:
     runs-on: ubuntu-latest
@@ -43,6 +46,7 @@ jobs:
         working-directory: vertx-web-graphql
         if: ${{ always() }}
   GraphiQL-Tests:
+    if: ${{ inputs.graphiql-tests }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The GraphiQL test infrastructure only exists on the master branch.