### PR TITLE
Fix encoded path traversal corruption in sub-router handlers

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -146,16 +146,7 @@ public class StaticHandlerImpl implements StaticHandler {
       if (!request.isEnded()) {
         request.pause();
       }
-      // decode URL path
-      String uriDecodedPath = RFC3986.decodeURIComponent(context.normalizedPath(), false);
-      // if the normalized path is null it cannot be resolved
-      if (uriDecodedPath == null) {
-        LOG.warn("Invalid path: " + context.request().path());
-        context.next();
-        return;
-      }
-      // will normalize and handle all paths as UNIX paths
-      String path = RFC3986.removeDotSegments(uriDecodedPath.replace('\\', '/'));
+      String path = context.normalizedPath();
 
       // Access fileSystem once here to be safe
       FileSystem fs = context.vertx().fileSystem();
@@ -178,7 +169,7 @@ public class StaticHandlerImpl implements StaticHandler {
     String file = null;
 
     if (!includeHidden) {
-      file = getFile(path, context);
+      file = getFile(context);
       for (int idx = file.indexOf('/'); idx >= 0; idx = file.indexOf('/', idx + 1)) {
         String name = file.substring(idx + 1);
         if (name.length() > 0 && name.charAt(0) == '.') {
@@ -226,7 +217,7 @@ public class StaticHandlerImpl implements StaticHandler {
     final String localFile;
 
     if (file == null) {
-      String ctxFile = getFile(path, context);
+      String ctxFile = getFile(context);
       if (index) {
         localFile = ctxFile + indexPage;
       } else {
@@ -639,8 +630,10 @@ public class StaticHandlerImpl implements StaticHandler {
     return this;
   }
 
-  private String getFile(String path, RoutingContext context) {
-    String file = webRoot + Utils.pathOffset(path, context);
+  private String getFile(RoutingContext context) {
+    String offsetPath = Utils.pathOffset(context.normalizedPath(), context);
+    offsetPath = RFC3986.decodeURIComponent(offsetPath, false);
+    String file = webRoot + RFC3986.removeDotSegments(offsetPath.replace('\\', '/'));
     if (LOG.isTraceEnabled()) {
       LOG.trace("File to serve is " + file);
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/TemplateHandlerImpl.java
@@ -45,10 +45,9 @@ public class TemplateHandlerImpl implements TemplateHandler {
 
   @Override
   public void handle(RoutingContext context) {
-    String uriDecodedPath = RFC3986.decodeURIComponent(context.normalizedPath(), false);
-    String path = RFC3986.removeDotSegments(uriDecodedPath.replace('\\', '/'));
-
-    String file = Utils.pathOffset(path, context);
+    String file = Utils.pathOffset(context.normalizedPath(), context);
+    file = RFC3986.decodeURIComponent(file, false);
+    file = RFC3986.removeDotSegments(file.replace('\\', '/'));
     if (file.endsWith("/") && null != indexTemplate) {
       file += indexTemplate;
     }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/SubRouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/SubRouterTest.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.web.tests;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -24,13 +25,17 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
-import static org.junit.jupiter.api.Assertions.*;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import io.vertx.ext.web.handler.StaticHandler;
+import io.vertx.ext.web.handler.TemplateHandler;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -838,5 +843,74 @@ public class SubRouterTest extends WebTestBase {
     assertNotNull(allowHeader);
     assertTrue(allowHeader.contains("POST"));
     assertTrue(allowHeader.contains("PUT"));
+  }
+
+  @Test
+  public void testStaticHandlerEncodedPathTraversalWithWildcardRoute() throws Exception {
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.route("/*").handler(StaticHandler.create());
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2fotherpage.html", 200, "OK", "<html><body>Other page</body></html>");
+  }
+
+  @Test
+  public void testStaticHandlerEncodedPathTraversalWithRegexRoute() throws Exception {
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.getWithRegex(".+\\.html").handler(StaticHandler.create());
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2fotherpage.html", 200, "OK", "<html><body>Other page</body></html>");
+  }
+
+  @Test
+  public void testStaticHandlerEncodedPathTraversalWithPathParamRoute() throws Exception {
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.get("/:file").handler(StaticHandler.create());
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2fotherpage.html", 200, "OK", "<html><body>Other page</body></html>");
+  }
+
+  @Test
+  public void testTemplateHandlerEncodedPathTraversalWithWildcardRoute() {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.route("/*").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2foutside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  @Test
+  public void testTemplateHandlerEncodedPathTraversalWithRegexRoute() {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.getWithRegex(".+\\.html").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2foutside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  @Test
+  public void testTemplateHandlerEncodedPathTraversalWithPathParamRoute() {
+    RecordingTemplateFileNameEngine engine = new RecordingTemplateFileNameEngine();
+    Router subRouter = Router.router(vertx);
+    router.route("/sub/*").subRouter(subRouter);
+    subRouter.get("/:page").handler(TemplateHandler.create(engine, "templates", "text/html"));
+    testRequest(HttpMethod.GET, "/sub/%2e%2e%2foutside.html", 200, "OK");
+    assertEquals("templates/outside.html", engine.lastTemplateFileName);
+  }
+
+  private static class RecordingTemplateFileNameEngine implements TemplateEngine {
+
+    String lastTemplateFileName;
+
+    @Override
+    public Future<Buffer> render(Map<String, Object> context, String templateFileName) {
+      this.lastTemplateFileName = templateFileName;
+      return Future.succeededFuture(Buffer.buffer());
+    }
+
+    @Override
+    public void clearCache() {
+    }
   }
 }


### PR DESCRIPTION
See #2898

When a request with encoded dot-segments (e.g. %2e%2e%2f) hit a handler mounted inside a sub-router via a regex or parameterized route, Utils.pathOffset corrupted the route-relative path because dot-segment resolution had already consumed the mount-point prefix.

Fix by running pathOffset on the raw normalizedPath first, then decoding and resolving dot-segments on the result.

Also remove the now redundant decodeURIComponent and removeDotSegments calls from StaticHandlerImpl.handle(), since normalizedPath() already decodes unreserved characters and resolves dot-segments, and file path resolution is now fully handled in getFile().

Some portions of this content were created with the assistance of Claude Code.