### PR TITLE
The routing context should use the HTTP server query param decoder.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -17,13 +17,13 @@
 package io.vertx.ext.web.impl;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.internal.net.RFC3986;
 import io.vertx.ext.web.*;
 import io.vertx.ext.web.handler.HttpException;
@@ -449,19 +449,16 @@ public class RoutingContextImpl extends RoutingContextImplBase {
     if (charset != null || queryParams == null) {
       try {
         // Decode query parameters and put inside context.queryParams
+        QueryParamDecoder decoder = ((HttpServerRequestInternal)request).queryParamDecoder();
         if (charset == null) {
-          queryParams = MultiMap.caseInsensitiveMultiMap();
-          Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
-          for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
-            queryParams.add(entry.getKey(), entry.getValue());
-          }
+          queryParams = decoder.decode(request.uri());
         } else {
-          MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
-          Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri(), charset).parameters();
-          for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
-            queryParams.add(entry.getKey(), entry.getValue());
-          }
-          return queryParams;
+          QueryParamDecoderConfig config = new QueryParamDecoderConfig()
+            .setUseSemicolonAsDelimiter(decoder.isUseSemiColonAsDelimiter())
+            .setMaxSize(decoder.maxParams())
+            .setCharset(charset);
+          decoder = new QueryParamDecoder(config);
+          return decoder.decode(request.uri());
         }
       } catch (IllegalArgumentException e) {
         throw new HttpException(400, "Error while decoding query params", e);

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -3022,6 +3022,28 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testDoNotUseSemicolonDelimiter() throws Exception {
+
+    HttpServerConfig config = new HttpServerConfig(getHttpServerOptions())
+      .setQueryParamConfig(new QueryParamDecoderConfig().setUseSemicolonAsDelimiter(false));
+
+    server.close().await();
+    server = vertx
+      .createHttpServer(config)
+      .requestHandler(router);
+    server.listen().await();
+
+    router
+      .route()
+      .handler(rc -> {
+        MultiMap params = rc.queryParams();
+        assertEquals("b;c", params.get("a"));
+        rc.end();
+      });
+    testRequest(HttpMethod.GET, "/?a=b;c", 200, "OK");
+  }
+
+  @Test
   public void testETag() throws Exception {
     router.route("/check/e-tag").handler(ctx -> {
       ctx.etag("1234");


### PR DESCRIPTION
Motivation:

`RoutingContext` can decode query parameters, sometimes it is desirable to change the configuration of the decoder such as the charset, the semicolon as delimiter, etc...

Vert.x core has introduced a `QueryParamDecoder` exposed by the internal HTTP server request that we can reuse.

Changes:

`RoutingContext` implementation now uses the current HTTP server request query param decoder.

Query param decoder is now configured by the `QueryParamDecoderConfig` of the HTTP server.
