### PR TITLE
Use decoded file path as cache key in StaticHandlerImpl

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/StaticHandlerImpl.java
@@ -166,10 +166,9 @@ public class StaticHandlerImpl implements StaticHandler {
    */
   private void sendStatic(RoutingContext context, FileSystem fileSystem, String path, boolean index) {
 
-    String file = null;
+    final String file = getFile(context);
 
     if (!includeHidden) {
-      file = getFile(context);
       for (int idx = file.indexOf('/'); idx >= 0; idx = file.indexOf('/', idx + 1)) {
         String name = file.substring(idx + 1);
         if (name.length() > 0 && name.charAt(0) == '.') {
@@ -184,7 +183,7 @@ public class StaticHandlerImpl implements StaticHandler {
     }
 
     // Look in cache
-    final CacheEntry entry = cache.get(path);
+    final CacheEntry entry = cache.get(file);
 
     if (entry != null) {
       if ((filesReadOnly || !entry.isOutOfDate())) {
@@ -214,22 +213,7 @@ public class StaticHandlerImpl implements StaticHandler {
     }
 
     final boolean dirty = cache.enabled() && entry != null;
-    final String localFile;
-
-    if (file == null) {
-      String ctxFile = getFile(context);
-      if (index) {
-        localFile = ctxFile + indexPage;
-      } else {
-        localFile = ctxFile;
-      }
-    } else {
-      if (index) {
-        localFile = file + indexPage;
-      } else {
-        localFile = file;
-      }
-    }
+    final String localFile = index ? file + indexPage : file;
 
     // verify if the file exists
     fileSystem
@@ -244,7 +228,7 @@ public class StaticHandlerImpl implements StaticHandler {
         // file does not exist, continue...
         if (!exists) {
           if (cache.enabled()) {
-            cache.put(path, null);
+            cache.put(file, null);
           }
           if (!context.request().isEnded()) {
             context.request().resume();
@@ -259,7 +243,7 @@ public class StaticHandlerImpl implements StaticHandler {
             if (fprops == null) {
               // File does not exist
               if (dirty) {
-                cache.remove(path);
+                cache.remove(file);
               }
               if (!context.request().isEnded()) {
                 context.request().resume();
@@ -269,7 +253,7 @@ public class StaticHandlerImpl implements StaticHandler {
               if (index) {
                 // file does not exist (well it exists but it's a directory), continue...
                 if (cache.enabled()) {
-                  cache.put(path, null);
+                  cache.put(file, null);
                 }
                 if (!context.request().isEnded()) {
                   context.request().resume();
@@ -277,13 +261,13 @@ public class StaticHandlerImpl implements StaticHandler {
                 context.next();
               } else {
                 if (dirty) {
-                  cache.remove(path);
+                  cache.remove(file);
                 }
                 sendDirectory(context, fileSystem, path, localFile);
               }
             } else {
               if (cache.enabled()) {
-                cache.put(path, fprops);
+                cache.put(file, fprops);
 
                 if (Utils.fresh(context, Utils.secondsFactor(fprops.lastModifiedTime()))) {
                   context.response().setStatusCode(NOT_MODIFIED.code()).end();


### PR DESCRIPTION
Follows-up on https://github.com/vert-x3/vertx-web/pull/2900

After moving URI decoding into getFile(), sendStatic() was using context.normalizedPath() (which may still contain percent-encoded characters) as the cache key. Requests for the same file with different encodings (e.g. /foo/%62ar.txt vs /foo/bar.txt) created separate cache entries, wasting slots in the bounded LRU cache.

Use the decoded file path from getFile() as the cache key so that encoding-equivalent paths share a single entry.

As a side effect, getFile() is now called unconditionally at the top of sendStatic(), which simplifies the code. Previously, it was deferred when includeHidden was true (skipping the dot-segment check), requiring a null guard and a second getFile() call for the localFile computation.

Some portions of this content were created with the assistance of Claude Code.