### PR TITLE
Reuse the HTTP server request semicolon char behavior for query param parsing.

### DIFF
--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RoutingContextImpl.java
@@ -471,17 +471,22 @@ public class RoutingContextImpl extends RoutingContextImplBase {
   private MultiMap getQueryParams(Charset charset) {
     // Check if query params are already parsed
     if (charset != null || queryParams == null) {
+      HttpServerRequestInternal request = (HttpServerRequestInternal) this.request;
+      QueryStringDecoder.Builder builder = QueryStringDecoder.builder()
+        .semicolonIsNormalChar(!request.isUseSemicolonAsQueryParamDelimiter());
       try {
         // Decode query parameters and put inside context.queryParams
         if (charset == null) {
           queryParams = MultiMap.caseInsensitiveMultiMap();
-          Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri()).parameters();
+          Map<String, List<String>> decodedParams = builder
+            .build(request.uri())
+            .parameters();
           for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
             queryParams.add(entry.getKey(), entry.getValue());
           }
         } else {
           MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
-          Map<String, List<String>> decodedParams = new QueryStringDecoder(request.uri(), charset).parameters();
+          Map<String, List<String>> decodedParams = builder.charset(charset).build(request.uri()).parameters();
           for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
             queryParams.add(entry.getKey(), entry.getValue());
           }

--- a/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/RouterTest.java
@@ -43,6 +43,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -3039,6 +3040,37 @@ public class RouterTest extends WebTestBase {
       });
 
     testRequest(HttpMethod.GET, "/?u=" + utf8 + "&l=" + latin1, 200, "OK");
+  }
+
+  @Test
+  public void testDoNotUseSemicolonDelimiter() throws Exception {
+
+    HttpServerOptions options = new HttpServerOptions(getHttpServerOptions()).setUseSemicolonAsQueryParamDelimiter(false);
+
+    server
+      .close()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(10, TimeUnit.SECONDS);
+    server = vertx
+      .createHttpServer(options)
+      .requestHandler(router);
+    server
+      .listen()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(10, TimeUnit.SECONDS);
+
+    router
+      .route()
+      .handler(rc -> {
+        MultiMap params = rc.queryParams();
+        assertEquals("b;c", params.get("a"));
+        params = rc.queryParams(StandardCharsets.UTF_8);
+        assertEquals("b;c", params.get("a"));
+        rc.end();
+      });
+    testRequest(HttpMethod.GET, "/?a=b;c", 200, "OK");
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The routing context currently handles the semicolon as a query param delimiter.

Vert.x HTTP server has been recently made configurable for this behavior and the routing context should reuse the configuration when it implement query parameter parsing.

Changes:

Configure the QueryStringDecoder parsing semicolon behavior according to the HttpServerRequest setting.
