### PR TITLE
Support typed path parameters in route paths

### DIFF
--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -346,7 +346,7 @@ Note: You can also capture `*` as path param `*`.
 
 === Typed path parameters
 
-A path parameter can be restricted to a known type by appending `:` followed by the type name to the parameter:
+A path parameter can be restricted to a known type by appending `::` followed by the type name to the parameter:
 
 [source,$lang]
 ----
@@ -365,9 +365,9 @@ Known types are:
 * `boolean` - `true` or `false` (lower case)
 * `uuid` - a UUID, e.g.: `123e4567-e89b-12d3-a456-426614174000`
 
-A second token that is not a known type is parsed as another parameter, e.g.: `/:from:to` declares the two adjacent
-parameters `from` and `to`, not a parameter with an unknown type. This also means that a parameter named like a type,
-e.g.: `/:integer`, is just a regular parameter that matches anything.
+Adjacent parameters with single colons, e.g.: `/:from:to`, declare two separate parameters `from` and `to`.
+A parameter named like a type, e.g.: `/:integer`, is just a regular parameter that matches anything.
+Using `::` with an unknown type name, e.g.: `/:id::foo`, throws an `IllegalArgumentException`.
 
 For validation beyond these simple types use a regular expression route or the `vertx-web-validation` module.
 

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -357,17 +357,17 @@ The route only matches when the captured value matches the declared type, otherw
 remaining routes (which usually results in a `404` response). The parameter value is still accessed as a `String`
 with {@link io.vertx.ext.web.RoutingContext#pathParam}.
 
-The known types are:
+Known types are:
 
-* `int` - an integer number, e.g.: `42`, `-7`. Note that the value is not bound to a Java type,
+* `integer` - an integer number, e.g.: `42`, `-7`. Note that the value is not bound to a Java type,
   so it may overflow e.g.: an `Integer`, it is up to the application to convert it appropriately.
 * `number` - an integer or decimal number, e.g.: `3.14`
-* `bool` - `true` or `false` (lower case)
+* `boolean` - `true` or `false` (lower case)
 * `uuid` - a UUID, e.g.: `123e4567-e89b-12d3-a456-426614174000`
 
 A second token that is not a known type is parsed as another parameter, e.g.: `/:from:to` declares the two adjacent
 parameters `from` and `to`, not a parameter with an unknown type. This also means that a parameter named like a type,
-e.g.: `/:int`, is just a regular parameter that matches anything.
+e.g.: `/:integer`, is just a regular parameter that matches anything.
 
 For validation beyond these simple types use a regular expression route or the `vertx-web-validation` module.
 

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -353,9 +353,10 @@ A path parameter can be restricted to a known type by appending `::` followed by
 {@link examples.WebExamples#example4_3}
 ----
 
-The route only matches when the captured value matches the declared type, otherwise the router carries on with the
-remaining routes (which usually results in a `404` response). The parameter value is still accessed as a `String`
-with {@link io.vertx.ext.web.RoutingContext#pathParam}.
+Typed path parameters only validate the captured value when matching a route. They do not convert the value to a Java
+object: the primary source of interaction in the API remains the `String` value returned by
+{@link io.vertx.ext.web.RoutingContext#pathParam}. When the captured value does not match the declared type, the router
+carries on with the remaining routes (which usually results in a `404` response).
 
 Known types are:
 
@@ -365,8 +366,6 @@ Known types are:
 * `boolean` - `true` or `false` (lower case)
 * `uuid` - a UUID, e.g.: `123e4567-e89b-12d3-a456-426614174000`
 
-Adjacent parameters with single colons, e.g.: `/:from:to`, declare two separate parameters `from` and `to`.
-A parameter named like a type, e.g.: `/:integer`, is just a regular parameter that matches anything.
 Using `::` with an unknown type name, e.g.: `/:id::foo`, throws an `IllegalArgumentException`.
 
 For validation beyond these simple types use a regular expression route or the `vertx-web-validation` module.

--- a/vertx-web/src/main/asciidoc/index.adoc
+++ b/vertx-web/src/main/asciidoc/index.adoc
@@ -344,6 +344,33 @@ A parameter is not required to be a path segment. For example path parameters li
 
 Note: You can also capture `*` as path param `*`.
 
+=== Typed path parameters
+
+A path parameter can be restricted to a known type by appending `:` followed by the type name to the parameter:
+
+[source,$lang]
+----
+{@link examples.WebExamples#example4_3}
+----
+
+The route only matches when the captured value matches the declared type, otherwise the router carries on with the
+remaining routes (which usually results in a `404` response). The parameter value is still accessed as a `String`
+with {@link io.vertx.ext.web.RoutingContext#pathParam}.
+
+The known types are:
+
+* `int` - an integer number, e.g.: `42`, `-7`. Note that the value is not bound to a Java type,
+  so it may overflow e.g.: an `Integer`, it is up to the application to convert it appropriately.
+* `number` - an integer or decimal number, e.g.: `3.14`
+* `bool` - `true` or `false` (lower case)
+* `uuid` - a UUID, e.g.: `123e4567-e89b-12d3-a456-426614174000`
+
+A second token that is not a known type is parsed as another parameter, e.g.: `/:from:to` declares the two adjacent
+parameters `from` and `to`, not a parameter with an unknown type. This also means that a parameter named like a type,
+e.g.: `/:int`, is just a regular parameter that matches anything.
+
+For validation beyond these simple types use a regular expression route or the `vertx-web-validation` module.
+
 == Routing with regular expressions
 
 Regular expressions can also be used to match URI paths in routes.

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -187,7 +187,7 @@ public class WebExamples {
   public void example4_3(Router router) {
 
     router
-      .route(HttpMethod.GET, "/users/:id:int")
+      .route(HttpMethod.GET, "/users/:id:integer")
       .handler(ctx -> {
         // the route only matches when the "id" parameter is an integer, so
         // requests like /users/abc do not match and are answered with a 404

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -187,7 +187,7 @@ public class WebExamples {
   public void example4_3(Router router) {
 
     router
-      .route(HttpMethod.GET, "/users/:id:integer")
+      .route(HttpMethod.GET, "/users/:id::integer")
       .handler(ctx -> {
         // the route only matches when the "id" parameter is an integer, so
         // requests like /users/abc do not match and are answered with a 404

--- a/vertx-web/src/main/java/examples/WebExamples.java
+++ b/vertx-web/src/main/java/examples/WebExamples.java
@@ -184,6 +184,20 @@ public class WebExamples {
 
   }
 
+  public void example4_3(Router router) {
+
+    router
+      .route(HttpMethod.GET, "/users/:id:int")
+      .handler(ctx -> {
+        // the route only matches when the "id" parameter is an integer, so
+        // requests like /users/abc do not match and are answered with a 404
+        int id = Integer.parseInt(ctx.pathParam("id"));
+
+        // Do something with it...
+      });
+
+  }
+
   public void example5(Router router) {
 
     // Matches any path ending with 'foo'

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -333,14 +333,11 @@ public class RouteImpl implements Route {
 
   // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id:int" only matches integers.
   // A second token that is not a known type is parsed as another parameter, like any other ":<token name>" in the path
-  private static final Map<String, String> TYPE_PATTERNS = new HashMap<>();
-
-  static {
-    TYPE_PATTERNS.put("int", "-?\\d+");
-    TYPE_PATTERNS.put("number", "-?\\d+(?:\\.\\d+)?");
-    TYPE_PATTERNS.put("bool", "true|false");
-    TYPE_PATTERNS.put("uuid", "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
-  }
+  private static final Map<String, String> TYPE_PATTERNS = Map.of(
+    "int", "-?\\d+",
+    "number", "-?\\d+(?:\\.\\d+)?",
+    "bool", "true|false",
+    "uuid", "\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}");
 
   // Pattern for (?<token name>) in path
   private static final Pattern RE_TOKEN_NAME_SEARCH = Pattern.compile("\\(\\?<(" + RE_VAR_NAME + ")>");

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -328,11 +328,10 @@ public class RouteImpl implements Route {
     "[A-Za-z_$][A-Za-z0-9_$-]*" :
     "[A-Za-z0-9_]+";
 
-  // Pattern for :<token name> in path, optionally followed by a :<type> annotation, e.g.: ":id:integer"
-  private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":(" + RE_VAR_NAME + ")(?::(" + RE_VAR_NAME + "))?");
+  // Pattern for :<token name> in path, optionally followed by a ::<type> annotation, e.g.: ":id::integer"
+  private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":(" + RE_VAR_NAME + ")(?:::(" + RE_VAR_NAME + "))?");
 
-  // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id:integer" only matches integers.
-  // A second token that is not a known type is parsed as another parameter, like any other ":<token name>" in the path
+  // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id::integer" only matches integers.
   private static final Map<String, String> TYPE_PATTERNS = Map.of(
     "integer", "-?\\d+",
     "number", "-?\\d+(?:\\.\\d+)?",
@@ -365,15 +364,17 @@ public class RouteImpl implements Route {
       String name = m.group(1);
       String type = m.group(2);
       StringBuilder replacement = new StringBuilder();
-      if (type == null || TYPE_PATTERNS.containsKey(type)) {
-        // a single param, optionally restricted to a known type, e.g.: ":id:integer"
-        appendNamedGroup(replacement, groups, name, type == null ? "[^/]+" : TYPE_PATTERNS.get(type));
-        colons += type == null ? 1 : 2;
-      } else {
-        // the second token is not a known type, parse it as another param, e.g.: ":from:to"
+      if (type == null) {
         appendNamedGroup(replacement, groups, name, "[^/]+");
-        appendNamedGroup(replacement, groups, type, "[^/]+");
-        colons += 2;
+        colons += 1;
+      } else {
+        String typePattern = TYPE_PATTERNS.get(type);
+        if (typePattern == null) {
+          throw new IllegalArgumentException("Unknown path parameter type: " + type + ". Known types: " + TYPE_PATTERNS.keySet());
+        }
+        // a typed param, e.g.: ":id::integer"
+        appendNamedGroup(replacement, groups, name, typePattern);
+        colons += 3; // 1 for :name, 2 for ::type
       }
       m.appendReplacement(sb, Matcher.quoteReplacement(replacement.toString()));
     }
@@ -442,13 +443,8 @@ public class RouteImpl implements Route {
       Set<String> groups = new HashSet<>();
       while (m.find()) {
         String name = m.group(1);
-        String type = m.group(2);
         if (!groups.add(name)) {
           throw new IllegalStateException("Cannot use identifier :" + name + " more than once in pattern string");
-        }
-        // a second token that is not a known type is another parameter
-        if (type != null && !TYPE_PATTERNS.containsKey(type) && !groups.add(type)) {
-          throw new IllegalStateException("Cannot use identifier :" + type + " more than once in pattern string");
         }
       }
     }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -328,8 +328,20 @@ public class RouteImpl implements Route {
     "[A-Za-z_$][A-Za-z0-9_$-]*" :
     "[A-Za-z0-9_]+";
 
-  // Pattern for :<token name> in path
-  private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":(" + RE_VAR_NAME + ")");
+  // Pattern for :<token name> in path, optionally followed by a :<type> annotation, e.g.: ":id:int"
+  private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":(" + RE_VAR_NAME + ")(?::(" + RE_VAR_NAME + "))?");
+
+  // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id:int" only matches integers.
+  // A second token that is not a known type is parsed as another parameter, like any other ":<token name>" in the path
+  private static final Map<String, String> TYPE_PATTERNS = new HashMap<>();
+
+  static {
+    TYPE_PATTERNS.put("int", "-?\\d+");
+    TYPE_PATTERNS.put("number", "-?\\d+(?:\\.\\d+)?");
+    TYPE_PATTERNS.put("bool", "true|false");
+    TYPE_PATTERNS.put("uuid", "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+  }
+
   // Pattern for (?<token name>) in path
   private static final Pattern RE_TOKEN_NAME_SEARCH = Pattern.compile("\\(\\?<(" + RE_VAR_NAME + ")>");
 
@@ -351,16 +363,22 @@ public class RouteImpl implements Route {
     Matcher m = RE_TOKEN_SEARCH.matcher(path);
     StringBuffer sb = new StringBuffer();
     List<String> groups = new ArrayList<>();
-    int index = 0;
+    int colons = 0;
     while (m.find()) {
-      String param = "p" + index;
-      String group = m.group().substring(1);
-      if (groups.contains(group)) {
-        throw new IllegalArgumentException("Cannot use identifier " + group + " more than once in pattern string");
+      String name = m.group(1);
+      String type = m.group(2);
+      StringBuilder replacement = new StringBuilder();
+      if (type == null || TYPE_PATTERNS.containsKey(type)) {
+        // a single param, optionally restricted to a known type, e.g.: ":id:int"
+        appendNamedGroup(replacement, groups, name, type == null ? "[^/]+" : TYPE_PATTERNS.get(type));
+        colons += type == null ? 1 : 2;
+      } else {
+        // the second token is not a known type, parse it as another param, e.g.: ":from:to"
+        appendNamedGroup(replacement, groups, name, "[^/]+");
+        appendNamedGroup(replacement, groups, type, "[^/]+");
+        colons += 2;
       }
-      m.appendReplacement(sb, "(?<" + param + ">[^/]+)");
-      groups.add(group);
-      index++;
+      m.appendReplacement(sb, Matcher.quoteReplacement(replacement.toString()));
     }
     m.appendTail(sb);
     if (state.isExactPath() && !state.isPathEndsWithSlash()) {
@@ -370,7 +388,15 @@ public class RouteImpl implements Route {
 
     state = state.setGroups(groups);
     state = state.setPattern(Pattern.compile(path));
-    return index;
+    return colons;
+  }
+
+  private static void appendNamedGroup(StringBuilder sb, List<String> groups, String name, String pattern) {
+    if (groups.contains(name)) {
+      throw new IllegalArgumentException("Cannot use identifier " + name + " more than once in pattern string");
+    }
+    sb.append("(?<p").append(groups.size()).append('>').append(pattern).append(')');
+    groups.add(name);
   }
 
   private void checkPath(String path) {
@@ -418,11 +444,15 @@ public class RouteImpl implements Route {
       Matcher m = RE_TOKEN_SEARCH.matcher(combinedPath);
       Set<String> groups = new HashSet<>();
       while (m.find()) {
-        String group = m.group();
-        if (groups.contains(group)) {
-          throw new IllegalStateException("Cannot use identifier " + group + " more than once in pattern string");
+        String name = m.group(1);
+        String type = m.group(2);
+        if (!groups.add(name)) {
+          throw new IllegalStateException("Cannot use identifier :" + name + " more than once in pattern string");
         }
-        groups.add(group);
+        // a second token that is not a known type is another parameter
+        if (type != null && !TYPE_PATTERNS.containsKey(type) && !groups.add(type)) {
+          throw new IllegalStateException("Cannot use identifier :" + type + " more than once in pattern string");
+        }
       }
     }
   }

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouteImpl.java
@@ -328,15 +328,15 @@ public class RouteImpl implements Route {
     "[A-Za-z_$][A-Za-z0-9_$-]*" :
     "[A-Za-z0-9_]+";
 
-  // Pattern for :<token name> in path, optionally followed by a :<type> annotation, e.g.: ":id:int"
+  // Pattern for :<token name> in path, optionally followed by a :<type> annotation, e.g.: ":id:integer"
   private static final Pattern RE_TOKEN_SEARCH = Pattern.compile(":(" + RE_VAR_NAME + ")(?::(" + RE_VAR_NAME + "))?");
 
-  // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id:int" only matches integers.
+  // Known path parameter types, mapped to the regex a path value must match, e.g.: ":id:integer" only matches integers.
   // A second token that is not a known type is parsed as another parameter, like any other ":<token name>" in the path
   private static final Map<String, String> TYPE_PATTERNS = Map.of(
-    "int", "-?\\d+",
+    "integer", "-?\\d+",
     "number", "-?\\d+(?:\\.\\d+)?",
-    "bool", "true|false",
+    "boolean", "true|false",
     "uuid", "\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}");
 
   // Pattern for (?<token name>) in path
@@ -366,7 +366,7 @@ public class RouteImpl implements Route {
       String type = m.group(2);
       StringBuilder replacement = new StringBuilder();
       if (type == null || TYPE_PATTERNS.containsKey(type)) {
-        // a single param, optionally restricted to a known type, e.g.: ":id:int"
+        // a single param, optionally restricted to a known type, e.g.: ":id:integer"
         appendNamedGroup(replacement, groups, name, type == null ? "[^/]+" : TYPE_PATTERNS.get(type));
         colons += type == null ? 1 : 2;
       } else {

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -975,6 +975,77 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testTypedParamInt() throws Exception {
+    router.route("/blah/:id:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
+    testPattern("/blah/123", "123");
+    testRequest(HttpMethod.GET, "/blah/-5", 200, "-5");
+    testRequest(HttpMethod.GET, "/blah/abc", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/blah/12abc", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/blah/1.5", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamNumber() throws Exception {
+    router.route("/blah/:val:number").handler(rc -> rc.response().setStatusMessage(rc.pathParam("val")).end());
+    testRequest(HttpMethod.GET, "/blah/3.14", 200, "3.14");
+    testRequest(HttpMethod.GET, "/blah/10", 200, "10");
+    testRequest(HttpMethod.GET, "/blah/-2.5", 200, "-2.5");
+    testRequest(HttpMethod.GET, "/blah/3.", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/blah/abc", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamBool() throws Exception {
+    router.route("/flag/:enabled:bool").handler(rc -> rc.response().setStatusMessage(rc.pathParam("enabled")).end());
+    testRequest(HttpMethod.GET, "/flag/true", 200, "true");
+    testRequest(HttpMethod.GET, "/flag/false", 200, "false");
+    testRequest(HttpMethod.GET, "/flag/TRUE", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/flag/yes", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamUUID() throws Exception {
+    router.route("/blah/:id:uuid").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
+    testRequest(HttpMethod.GET, "/blah/123e4567-e89b-12d3-a456-426614174000", 200, "123e4567-e89b-12d3-a456-426614174000");
+    testRequest(HttpMethod.GET, "/blah/123E4567-E89B-12D3-A456-426614174000", 200, "123E4567-E89B-12D3-A456-426614174000");
+    testRequest(HttpMethod.GET, "/blah/123e4567-e89b-12d3-a456", 404, "Not Found");
+    testRequest(HttpMethod.GET, "/blah/zzze4567-e89b-12d3-a456-426614174000", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamMixedWithUntypedParams() throws Exception {
+    router.route("/cat/:type/:id:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("type") + "|" + rc.pathParam("id")).end());
+    testRequest(HttpMethod.GET, "/cat/tools/42", 200, "tools|42");
+    testRequest(HttpMethod.GET, "/cat/tools/drill", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamWithWildcard() throws Exception {
+    router.route("/blah/:id:int/*").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id") + "|" + rc.pathParam("*")).end());
+    testRequest(HttpMethod.GET, "/blah/42/sub/path", 200, "42|sub/path");
+    testRequest(HttpMethod.GET, "/blah/abc/sub", 404, "Not Found");
+  }
+
+  @Test
+  public void testTypedParamUnknownTypeIsAnotherParam() throws Exception {
+    // ":foo" is not a known type, so it is parsed as a second adjacent param, as it always was
+    router.route("/blah/:a:foo").handler(rc -> rc.response().setStatusMessage(rc.pathParam("a") + "|" + rc.pathParam("foo")).end());
+    testRequest(HttpMethod.GET, "/blah/xy", 200, "x|y");
+  }
+
+  @Test
+  public void testTypedParamNameClash() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id:int/:id"));
+  }
+
+  @Test
+  public void testParamNamedLikeType() throws Exception {
+    // a param simply named "int" is still a regular untyped param
+    router.route("/blah/:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("int")).end());
+    testRequest(HttpMethod.GET, "/blah/abc", 200, "abc");
+  }
+
+  @Test
   public void testRegex1() throws Exception {
     router.routeWithRegex("\\/([^\\/]+)\\/([^\\/]+)").handler(rc -> {
       MultiMap params = rc.request().params();

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -976,7 +976,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamInt() throws Exception {
-    router.route("/blah/:id:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
+    router.route("/blah/:id:integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
     testPattern("/blah/123", "123");
     testRequest(HttpMethod.GET, "/blah/-5", 200, "-5");
     testRequest(HttpMethod.GET, "/blah/abc", 404, "Not Found");
@@ -996,7 +996,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamBool() throws Exception {
-    router.route("/flag/:enabled:bool").handler(rc -> rc.response().setStatusMessage(rc.pathParam("enabled")).end());
+    router.route("/flag/:enabled:boolean").handler(rc -> rc.response().setStatusMessage(rc.pathParam("enabled")).end());
     testRequest(HttpMethod.GET, "/flag/true", 200, "true");
     testRequest(HttpMethod.GET, "/flag/false", 200, "false");
     testRequest(HttpMethod.GET, "/flag/TRUE", 404, "Not Found");
@@ -1014,14 +1014,14 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamMixedWithUntypedParams() throws Exception {
-    router.route("/cat/:type/:id:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("type") + "|" + rc.pathParam("id")).end());
+    router.route("/cat/:type/:id:integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("type") + "|" + rc.pathParam("id")).end());
     testRequest(HttpMethod.GET, "/cat/tools/42", 200, "tools|42");
     testRequest(HttpMethod.GET, "/cat/tools/drill", 404, "Not Found");
   }
 
   @Test
   public void testTypedParamWithWildcard() throws Exception {
-    router.route("/blah/:id:int/*").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id") + "|" + rc.pathParam("*")).end());
+    router.route("/blah/:id:integer/*").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id") + "|" + rc.pathParam("*")).end());
     testRequest(HttpMethod.GET, "/blah/42/sub/path", 200, "42|sub/path");
     testRequest(HttpMethod.GET, "/blah/abc/sub", 404, "Not Found");
   }
@@ -1043,13 +1043,13 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamNameClash() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id:int/:id"));
+    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id:integer/:id"));
   }
 
   @Test
   public void testParamNamedLikeType() throws Exception {
-    // a param simply named "int" is still a regular untyped param
-    router.route("/blah/:int").handler(rc -> rc.response().setStatusMessage(rc.pathParam("int")).end());
+    // a param simply named "integer" is still a regular untyped param
+    router.route("/blah/:integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("integer")).end());
     testRequest(HttpMethod.GET, "/blah/abc", 200, "abc");
   }
 

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -976,7 +976,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamInt() throws Exception {
-    router.route("/blah/:id:integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
+    router.route("/blah/:id::integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
     testPattern("/blah/123", "123");
     testRequest(HttpMethod.GET, "/blah/-5", 200, "-5");
     testRequest(HttpMethod.GET, "/blah/abc", 404, "Not Found");
@@ -986,7 +986,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamNumber() throws Exception {
-    router.route("/blah/:val:number").handler(rc -> rc.response().setStatusMessage(rc.pathParam("val")).end());
+    router.route("/blah/:val::number").handler(rc -> rc.response().setStatusMessage(rc.pathParam("val")).end());
     testRequest(HttpMethod.GET, "/blah/3.14", 200, "3.14");
     testRequest(HttpMethod.GET, "/blah/10", 200, "10");
     testRequest(HttpMethod.GET, "/blah/-2.5", 200, "-2.5");
@@ -996,7 +996,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamBool() throws Exception {
-    router.route("/flag/:enabled:boolean").handler(rc -> rc.response().setStatusMessage(rc.pathParam("enabled")).end());
+    router.route("/flag/:enabled::boolean").handler(rc -> rc.response().setStatusMessage(rc.pathParam("enabled")).end());
     testRequest(HttpMethod.GET, "/flag/true", 200, "true");
     testRequest(HttpMethod.GET, "/flag/false", 200, "false");
     testRequest(HttpMethod.GET, "/flag/TRUE", 404, "Not Found");
@@ -1005,7 +1005,7 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamUUID() throws Exception {
-    router.route("/blah/:id:uuid").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
+    router.route("/blah/:id::uuid").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id")).end());
     testRequest(HttpMethod.GET, "/blah/123e4567-e89b-12d3-a456-426614174000", 200, "123e4567-e89b-12d3-a456-426614174000");
     testRequest(HttpMethod.GET, "/blah/123E4567-E89B-12D3-A456-426614174000", 200, "123E4567-E89B-12D3-A456-426614174000");
     testRequest(HttpMethod.GET, "/blah/123e4567-e89b-12d3-a456", 404, "Not Found");
@@ -1014,21 +1014,21 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamMixedWithUntypedParams() throws Exception {
-    router.route("/cat/:type/:id:integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("type") + "|" + rc.pathParam("id")).end());
+    router.route("/cat/:type/:id::integer").handler(rc -> rc.response().setStatusMessage(rc.pathParam("type") + "|" + rc.pathParam("id")).end());
     testRequest(HttpMethod.GET, "/cat/tools/42", 200, "tools|42");
     testRequest(HttpMethod.GET, "/cat/tools/drill", 404, "Not Found");
   }
 
   @Test
   public void testTypedParamWithWildcard() throws Exception {
-    router.route("/blah/:id:integer/*").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id") + "|" + rc.pathParam("*")).end());
+    router.route("/blah/:id::integer/*").handler(rc -> rc.response().setStatusMessage(rc.pathParam("id") + "|" + rc.pathParam("*")).end());
     testRequest(HttpMethod.GET, "/blah/42/sub/path", 200, "42|sub/path");
     testRequest(HttpMethod.GET, "/blah/abc/sub", 404, "Not Found");
   }
 
   @Test
   public void testTypedParamUnknownTypeIsAnotherParam() throws Exception {
-    // ":foo" is not a known type, so it is parsed as a second adjacent param, as it always was
+    // ":foo" after a single colon is a separate adjacent param, not a type annotation (which requires "::")
     router.route("/blah/:a:foo").handler(rc -> rc.response().setStatusMessage(rc.pathParam("a") + "|" + rc.pathParam("foo")).end());
     testRequest(HttpMethod.GET, "/blah/xy", 200, "x|y");
   }
@@ -1043,7 +1043,12 @@ public class RouterTest extends WebTestBase {
 
   @Test
   public void testTypedParamNameClash() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id:integer/:id"));
+    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id::integer/:id"));
+  }
+
+  @Test
+  public void testTypedParamUnknownTypeThrows() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id::foo"));
   }
 
   @Test

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -1034,6 +1034,14 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testInvalidTypeAfterLiteralIsAParam() throws Exception {
+    // ":foo" is not a known type, it is a regular param following the literal prefix "id"
+    router.route("/id:foo").handler(rc -> rc.response().setStatusMessage(rc.pathParam("foo")).end());
+    testRequest(HttpMethod.GET, "/idbar", 200, "bar");
+    testRequest(HttpMethod.GET, "/id", 404, "Not Found");
+  }
+
+  @Test
   public void testTypedParamNameClash() throws Exception {
     assertThrows(IllegalArgumentException.class, () -> router.route("/blah/:id:int/:id"));
   }


### PR DESCRIPTION
Motivation:

Closes #2860

This PR adds the syntax proposed in the issue:

```java
router.get("/users/:id:int").handler(ctx -> {
  int id = Integer.parseInt(ctx.pathParam("id")); // guaranteed to be an integer
});