### PR TITLE
Add RFC 10008 (QUERY Method) support

### DIFF
--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/HttpContext.java
@@ -406,6 +406,7 @@ public class HttpContext<T> {
   }
 
   private void handleDispatchResponse() {
+    body = null;
     promise.tryComplete(response);
   }
 
@@ -540,9 +541,9 @@ public class HttpContext<T> {
 
   private void doSendRequest(HttpClientRequest request) {
     Object bodyToSend = body;
-    if (bodyToSend != null) {
-      body = null;
+    if (bodyToSend != null && requestOptions.getMethod() != HttpMethod.GET && requestOptions.getMethod() != HttpMethod.HEAD) {
       if (bodyToSend instanceof Pipe) {
+        body = null;
         Pipe<Buffer> pipe = (Pipe<Buffer>) bodyToSend;
         if (this.request.headers == null || !this.request.headers.contains(HttpHeaders.CONTENT_LENGTH)) {
           request.setChunked(true);

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheInterceptor.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheInterceptor.java
@@ -26,6 +26,8 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.impl.HttpContext;
 import io.vertx.ext.web.client.spi.CacheStore;
+import io.netty.util.internal.StringUtil;
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -84,6 +86,10 @@ public class CacheInterceptor implements Handler<HttpContext<?>> {
 
   private void handleCreateRequest(HttpContext<Buffer> context) {
     RequestOptions request = context.requestOptions();
+    if (options.getCachedMethods().contains(request.getMethod())) {
+      context.set("cache.body_fingerprint", getBodyFingerprint(context.body()));
+    }
+
     Vary variation;
 
     if (!options.getCachedMethods().contains(request.getMethod()) || (variation = selectVariation(request)) == null) {
@@ -92,7 +98,7 @@ public class CacheInterceptor implements Handler<HttpContext<?>> {
     }
 
     Promise<CachedHttpResponse> promise = Promise.promise();
-    CacheKey key = new CacheKey(request, variation);
+    CacheKey key = new CacheKey(request, variation, context.get("cache.body_fingerprint"));
 
     if (context.privateCacheStore() != null) {
       // Check the local private store first
@@ -238,7 +244,8 @@ public class CacheInterceptor implements Handler<HttpContext<?>> {
     Vary variation = new Vary(request.headers(), response.headers());
     registerVariation(variationsKey, variation);
 
-    CacheKey key = new CacheKey(context.requestOptions(), variation);
+    String bodyFingerprint = context.get("cache.body_fingerprint");
+    CacheKey key = new CacheKey(context.requestOptions(), variation, bodyFingerprint != null ? bodyFingerprint : "");
     CachedHttpResponse cachedResponse = CachedHttpResponse.wrap(response, cacheControl);
 
     if (cacheControl.isPrivate()) {
@@ -254,5 +261,21 @@ public class CacheInterceptor implements Handler<HttpContext<?>> {
 
     updated.add(variation);
     variationsRegistry.put(variationsKey, updated);
+  }
+
+  private static String getBodyFingerprint(Object body) {
+    if (body == null) {
+      return "";
+    }
+    if (body instanceof Buffer) {
+      try {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(((Buffer) body).getBytes());
+        return StringUtil.toHexString(hash);
+      } catch (Exception e) {
+        return body.toString();
+      }
+    }
+    return body.toString();
   }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheKey.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheKey.java
@@ -32,10 +32,16 @@ import java.util.Objects;
 public class CacheKey extends CacheVariationsKey {
 
   private final String variations;
+  private final String bodyFingerprint;
 
   public CacheKey(RequestOptions request, Vary vary) {
+    this(request, vary, null);
+  }
+
+  public CacheKey(RequestOptions request, Vary vary, String bodyFingerprint) {
     super(request);
     this.variations = vary.toString();
+    this.bodyFingerprint = bodyFingerprint != null ? bodyFingerprint : "";
   }
 
   @Override
@@ -44,10 +50,13 @@ public class CacheKey extends CacheVariationsKey {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
       digest.update(super.toString().getBytes(StandardCharsets.UTF_8));
       digest.update(variations.getBytes(StandardCharsets.UTF_8));
+      if (!bodyFingerprint.isEmpty()) {
+        digest.update(bodyFingerprint.getBytes(StandardCharsets.UTF_8));
+      }
       byte[] hashed = digest.digest();
       return StringUtil.toHexString(hashed);
     } catch (Exception e) {
-      return super.toString() + "|" + variations;
+      return String.join("|", super.toString(), variations, bodyFingerprint);
     }
   }
 
@@ -61,14 +70,16 @@ public class CacheKey extends CacheVariationsKey {
     }
     CacheKey cacheKey = (CacheKey) o;
     return port == cacheKey.port
+      && method == cacheKey.method
       && host.equals(cacheKey.host)
       && path.equals(cacheKey.path)
       && queryString.equals(cacheKey.queryString)
-      && variations.equals(cacheKey.variations);
+      && variations.equals(cacheKey.variations)
+      && bodyFingerprint.equals(cacheKey.bodyFingerprint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port, path, queryString, variations);
+    return Objects.hash(method, host, port, path, queryString, variations, bodyFingerprint);
   }
 }

--- a/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKey.java
+++ b/vertx-web-client/src/main/java/io/vertx/ext/web/client/impl/cache/CacheVariationsKey.java
@@ -17,6 +17,7 @@ package io.vertx.ext.web.client.impl.cache;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
  */
 class CacheVariationsKey {
 
+  protected final HttpMethod method;
   protected final String host;
   protected final int port;
   protected final String path;
@@ -37,6 +39,7 @@ class CacheVariationsKey {
   CacheVariationsKey(RequestOptions request) {
     String requestURI = request.getURI();
     QueryStringDecoder dec = new QueryStringDecoder(requestURI);
+    this.method = request.getMethod();
     this.host = request.getHost();
     this.port = request.getPort();
     this.path = dec.path();
@@ -45,7 +48,7 @@ class CacheVariationsKey {
 
   @Override
   public String toString() {
-    return host + ":" + port + path + "?" + queryString;
+    return method + "|" + host + ":" + port + path + "?" + queryString;
   }
 
   @Override
@@ -58,6 +61,7 @@ class CacheVariationsKey {
     }
     CacheVariationsKey that = (CacheVariationsKey) o;
     return port == that.port
+      && method == that.method
       && host.equals(that.host)
       && path.equals(that.path)
       && queryString.equals(that.queryString);
@@ -65,7 +69,7 @@ class CacheVariationsKey {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port, path, queryString);
+    return Objects.hash(method, host, port, path, queryString);
   }
 
   private String queryString(Map<String, List<String>> queryParams) {

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/CachingWebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/CachingWebClientTest.java
@@ -154,6 +154,42 @@ public class CachingWebClientTest {
     assertNotCached(defaultClient);
   }
 
+  @Test
+  public void testQueryCaching() throws Exception {
+    CachingWebClientOptions cacheOpts = new CachingWebClientOptions()
+      .addCachedMethod(HttpMethod.QUERY);
+    WebClient queryClient = CachingWebClient.create(buildBaseWebClient(), new TestCacheStore(), cacheOpts);
+
+    server.requestHandler(req -> {
+      req.response().headers().set("Cache-Control", "public, max-age=60");
+      req.bodyHandler(body -> {
+        req.response().end(body.toString() + "|" + UUID.randomUUID().toString());
+      });
+    });
+    server.listen().await();
+
+    Buffer body1 = Buffer.buffer("q=apples");
+    Buffer body2 = Buffer.buffer("q=pears");
+
+    // First request with body1 -> stores cache
+    HttpResponse<Buffer> res1_1 = queryClient.request(HttpMethod.QUERY, "/contacts").sendBuffer(body1).await();
+    // Second request with body1 -> should hit cache (same body, same response)
+    HttpResponse<Buffer> res1_2 = queryClient.request(HttpMethod.QUERY, "/contacts").sendBuffer(body1).await();
+
+    assertEquals(res1_1.bodyAsString(), res1_2.bodyAsString());
+    assertNotNull(res1_2.headers().get(HttpHeaders.AGE));
+
+    // Request with body2 -> should NOT hit cache of body1, should call server and get new response
+    HttpResponse<Buffer> res2_1 = queryClient.request(HttpMethod.QUERY, "/contacts").sendBuffer(body2).await();
+    assertNotEquals(res1_1.bodyAsString(), res2_1.bodyAsString());
+    assertNull(res2_1.headers().get(HttpHeaders.AGE));
+
+    // Second request with body2 -> should hit cache of body2
+    HttpResponse<Buffer> res2_2 = queryClient.request(HttpMethod.QUERY, "/contacts").sendBuffer(body2).await();
+    assertEquals(res2_1.bodyAsString(), res2_2.bodyAsString());
+    assertNotNull(res2_2.headers().get(HttpHeaders.AGE));
+  }
+
   // Non-GET methods that we shouldn't cache
 
   @Test

--- a/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
+++ b/vertx-web-client/src/test/java/io/vertx/ext/web/client/tests/WebClientTest.java
@@ -2523,6 +2523,72 @@ public class WebClientTest extends WebClientTestBase {
     }
   }
 
+  @Nested
+  class QueryRedirectTest extends SendTestBase {
+
+    private static final String location = "http://" + DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT + "/ok";
+
+    @Override
+    void requestEnd(HttpServerRequest req, Buffer body) {
+      if (req.path().equals("/redirect")) {
+        assertEquals("q=apples", body.toString());
+        req.response().setStatusCode(301).putHeader("Location", location).end();
+      } else {
+        assertEquals(HttpMethod.QUERY, req.method());
+        assertEquals("q=apples", body.toString());
+        req.response().end(req.path());
+      }
+    }
+
+    @Override
+    Future<? extends HttpResponse<?>> send(WebClient client) {
+      return client.request(HttpMethod.QUERY, "/redirect")
+        .followRedirects(true)
+        .sendBuffer(Buffer.buffer("q=apples"));
+    }
+
+    @Override
+    void assertResponse(HttpResponse<?> response) {
+      assertEquals(200, response.statusCode());
+      assertEquals("/ok", response.body().toString());
+      assertEquals(1, response.followedRedirects().size());
+      assertEquals(location, response.followedRedirects().get(0));
+    }
+  }
+
+  @Nested
+  class Query303RedirectTest extends SendTestBase {
+
+    private static final String location = "http://" + DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT + "/ok";
+
+    @Override
+    void requestEnd(HttpServerRequest req, Buffer body) {
+      if (req.path().equals("/redirect")) {
+        assertEquals("q=apples", body.toString());
+        req.response().setStatusCode(303).putHeader("Location", location).end();
+      } else {
+        assertEquals(HttpMethod.GET, req.method());
+        assertEquals(0, body.length());
+        req.response().end(req.path());
+      }
+    }
+
+    @Override
+    Future<? extends HttpResponse<?>> send(WebClient client) {
+      return client.request(HttpMethod.QUERY, "/redirect")
+        .followRedirects(true)
+        .sendBuffer(Buffer.buffer("q=apples"));
+    }
+
+    @Override
+    void assertResponse(HttpResponse<?> response) {
+      assertEquals(200, response.statusCode());
+      assertEquals("/ok", response.body().toString());
+      assertEquals(1, response.followedRedirects().size());
+      assertEquals(location, response.followedRedirects().get(0));
+    }
+  }
+
   private abstract static class WriteStreamBase implements WriteStream<Buffer> {
 
     protected Handler<Throwable> exceptionHandler;

--- a/vertx-web/src/main/java/io/vertx/ext/web/Router.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/Router.java
@@ -247,6 +247,31 @@ public interface Router extends Handler<HttpServerRequest> {
   Route postWithRegex(String regex);
 
   /**
+   * Add a route that matches any HTTP QUERY request
+   *
+   * @return the route
+   */
+  Route query();
+
+  /**
+   * Add a route that matches a HTTP QUERY request and the specified path
+   *
+   * @param path  URI paths that begin with this path will match
+   *
+   * @return the route
+   */
+  Route query(String path);
+
+  /**
+   * Add a route that matches a HTTP QUERY request and the specified path regex
+   *
+   * @param regex  URI paths that begin with a match for this regex will match
+   *
+   * @return the route
+   */
+  Route queryWithRegex(String regex);
+
+  /**
    * Add a route that matches any HTTP DELETE request
    *
    * @return the route

--- a/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
+++ b/vertx-web/src/main/java/io/vertx/ext/web/impl/RouterImpl.java
@@ -175,6 +175,21 @@ public class RouterImpl implements Router {
   }
 
   @Override
+  public Route query() {
+    return route().method(HttpMethod.QUERY);
+  }
+
+  @Override
+  public Route query(String path) {
+    return route(HttpMethod.QUERY, path);
+  }
+
+  @Override
+  public Route queryWithRegex(String path) {
+    return route().method(HttpMethod.QUERY).pathRegex(path);
+  }
+
+  @Override
   public Route delete() {
     return route().method(HttpMethod.DELETE);
   }

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/RouterTest.java
@@ -85,6 +85,21 @@ public class RouterTest extends WebTestBase {
   }
 
   @Test
+  public void testQueryRoute() throws Exception {
+    router.query("/contacts").handler(rc -> {
+      String contentType = rc.request().getHeader(HttpHeaders.CONTENT_TYPE);
+      assertEquals("application/x-www-form-urlencoded", contentType);
+      rc.response().setStatusCode(200).end("Query Success");
+    });
+
+    testRequest(
+      webClient.request(HttpMethod.QUERY, "/contacts")
+        .putHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded"),
+      200, "OK", "Query Success"
+    );
+  }
+
+  @Test
   public void testSimpleFunction() throws Exception {
     router.route()
       .respond(rc -> vertx.fileSystem().readFile(rc.queryParams().get("file")));


### PR DESCRIPTION
Fixes #2917

Motivation:

This change adds support for RFC 10008, relying on the changes done on https://github.com/eclipse-vertx/vert.x/pull/6212
I cheated a bit by passing around the body hash (called it body fingerprint) so it doesn't need to be recalculated. 

Changes:

- Added support for defining routes matching the new QUERY method using the standard vert.x core HttpMethod.QUERY type
- Modified the CacheVariationsKey to incorporate the HTTP method, so that cached QUERY requests do not conflict with GET requests on the same URL path
- Modified CacheKey to accept and incorporate a body fingerprint calculated as a SHA-256 hash (or fallback toString()) of the request body
- Stored the computed body fingerprint in the HTTP context attributes during the initial request phase inside the CacheInterceptor (CacheInterceptor.java). That way even if the request body is nullified during actual network dispatch for garbage collection optimization, it stays fully available for generating the cache key when storing the response.
- Fixed request body handling during redirection inside HttpContext. The request body is now preserved during redirect execution for repeatable bodies (like Buffer or ClientForm)
- Ensured that the request body is correctly dropped when a redirect changes the HTTP method to GET or HEAD (such as in a status 303 response)

Conformance:

- [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md 

- [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
