### PR TITLE
Upgrade to Handlebars 4.5.3

### DIFF
--- a/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
+++ b/vertx-template-engines/vertx-web-templ-handlebars/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -44,5 +44,54 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- Java 11 => use Maven Toolchain to compile this module with JDK 25
+       The config file .m2/toolchains.xml is needed with this content
+
+       <toolchains>
+         <toolchain>
+           <type>jdk</type>
+           <provides>
+             <id>Java25</id>
+             <version>25</version>
+           </provides>
+           <configuration>
+             <jdkHome>/PATH/TO/JDK/25</jdkHome>
+           </configuration>
+         </toolchain>
+       </toolchains>
+  -->
+  <profiles>
+    <profile>
+      <id>Java11</id>
+      <activation>
+        <jdk>[11,17)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <version>1.0</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>toolchain</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>25</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/module-info.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module io.vertx.web.template.handlebars {
   requires io.netty.common;
   requires io.vertx.core;
   requires io.vertx.web.common;
-  requires handlebars; // Automatic module
+  requires com.github.jknack.handlebars;
 
   exports io.vertx.ext.web.templ.handlebars;
 }

--- a/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/module-info.java
+++ b/vertx-template-engines/vertx-web-templ-handlebars/src/test/java/module-info.java
@@ -18,6 +18,6 @@ open module io.vertx.web.template.handlebars.tests {
   requires io.vertx.core;
   requires io.vertx.web.common;
   requires io.vertx.web.template.handlebars;
-  requires handlebars;
+  requires com.github.jknack.handlebars;
   requires org.junit.jupiter.api;
 }


### PR DESCRIPTION
Resolves security issues

Handlebars 4.4+ requires Java 17 or higher and Handlebars 4.3 is no longer maintained.

Besides, the library now has a proper module name instead of an automatic one.