### PR TITLE
Fix additional intermittent SockJS test failures

### DIFF
--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSHandlerTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSHandlerTest.java
@@ -17,7 +17,6 @@
 package io.vertx.ext.web.tests.handler.sockjs;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
@@ -306,22 +305,17 @@ public class SockJSHandlerTest extends WebTestBase {
   private WebSocket setupSockJsClient(String serverPath, List<Buffer> receivedMessagesCollector, Runnable onClose) {
     String requestURI = serverPath + "/000/000/websocket";
 
-    Promise<WebSocket> promise = Promise.promise();
-    wsClient.connect(requestURI).onComplete(TestUtils.onSuccess(ws -> {
-      ws.handler(replyBuffer -> {
-        log.debug("Client received " + replyBuffer);
-        String textReply = replyBuffer.toString();
-        if ("o".equals(textReply)) {
-          promise.complete(ws);
-        } else {
-          receivedMessagesCollector.add(replyBuffer);
-        }
-      });
-      ws.endHandler(v -> onClose.run());
-      ws.exceptionHandler(err -> fail(err.getMessage()));
-    }));
-
-    return promise.future().await();
+    WebSocket ws = wsClient.connect(requestURI).await();
+    ws.handler(replyBuffer -> {
+      log.debug("Client received " + replyBuffer);
+      String textReply = replyBuffer.toString();
+      if (!"o".equals(textReply)) {
+        receivedMessagesCollector.add(replyBuffer);
+      }
+    });
+    ws.endHandler(v -> onClose.run());
+    ws.exceptionHandler(err -> fail(err.getMessage()));
+    return ws;
   }
 
   /**

--- a/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSRawTransportTest.java
+++ b/vertx-web/src/test/java/io/vertx/ext/web/tests/handler/sockjs/SockJSRawTransportTest.java
@@ -46,28 +46,30 @@ public class SockJSRawTransportTest extends SockJSTestBase {
   public void disableHost(Checkpoint checkpoint) throws Exception {
     String expected = TestUtils.randomAlphaString(64);
     socketHandler = () -> socket -> {
-      socket.write(expected);
+      socket.handler(msg -> {
+        socket.write(expected);
+      });
       socket.endHandler(v -> {
         checkpoint.flag();
       });
     };
     startServers(new SockJSHandlerOptions());
-    wsClient.connect(
+    WebSocket ws = wsClient.connect(
       new WebSocketConnectOptions()
         .setHost("localhost")
         .setPort(8080)
         .setURI("/test/websocket")
-        .setAllowOriginHeader(false)).onComplete(TestUtils.onSuccess(ws -> {
-        ws.frameHandler(frame -> {
-          if (frame.isClose()) {
-            //
-          } else {
-            assertTrue(frame.isText());
-            assertEquals(expected, frame.textData());
-            ws.end();
-          }
-        });
-      }));
+        .setAllowOriginHeader(false)).await();
+    ws.frameHandler(frame -> {
+      if (frame.isClose()) {
+        //
+      } else {
+        assertTrue(frame.isText());
+        assertEquals(expected, frame.textData());
+        ws.end();
+      }
+    });
+    ws.writeTextMessage("ready");
   }
 
   @Test
@@ -92,23 +94,25 @@ public class SockJSRawTransportTest extends SockJSTestBase {
   public void goodOrigin(Checkpoint checkpoint) throws Exception {
     String expected = TestUtils.randomAlphaString(64);
     socketHandler = () -> socket -> {
-      socket.write(expected);
+      socket.handler(msg -> {
+        socket.write(expected);
+      });
       socket.endHandler(v -> {
         checkpoint.flag();
       });
     };
     startServers(new SockJSHandlerOptions().setOrigin("http://localhost:8080"));
-    wsClient.connect("/test/websocket").onComplete(TestUtils.onSuccess(ws -> {
-      ws.frameHandler(frame -> {
-        if (frame.isClose()) {
-          //
-        } else {
-          assertTrue(frame.isText());
-          assertEquals(expected, frame.textData());
-          ws.end();
-        }
-      });
-    }));
+    WebSocket ws = wsClient.connect("/test/websocket").await();
+    ws.frameHandler(frame -> {
+      if (frame.isClose()) {
+        //
+      } else {
+        assertTrue(frame.isText());
+        assertEquals(expected, frame.textData());
+        ws.end();
+      }
+    });
+    ws.writeTextMessage("ready");
   }
 
   @Test


### PR DESCRIPTION
In `SockJSHandlerTest`, `setupSockJsClient` blocked on receiving the SockJS "o" frame via a `Promise`. If the frame was lost, the test hung. Remove the dependency on receiving the "o" frame since it is not needed for the tests to function correctly.

In `SockJSRawTransportTest`, `disableHost` and `goodOrigin` wrote data immediately in the socket handler. Use the same ready-message protocol as `testWriteText` so the server waits for the client to signal readiness.